### PR TITLE
Add a healthlist command

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6844,9 +6844,9 @@ return function(Vargs, env)
 					if a[4] == b[4] then
 						if a[3] == b[3] then
 							if a[1] == b[1] then
-								return(a[2] > b[2])
+								return(a[2] < b[2])
 							else
-								return(a[1] > b[1])
+								return(a[1] < b[1])
 							end
 						else
 							return(a[3] > b[3])

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6828,5 +6828,81 @@ return function(Vargs, env)
 			end
 		};
 
+		HealthList = {
+			Prefix = Settings.Prefix;
+			Commands = {"healthlist", "healthlogs", "healths", "hlist","hlogs"};
+			Args = {"autoupdate? (default: true)"};
+			Description = "Shows a list of all players' current and max healths.";
+			AdminLevel = "Moderators";
+			ListUpdater = function(plr: Player, args: {string})
+				local RawTable = {}
+				for _, v in Functions.GetPlayers(plr, "all") do
+					table.insert(RawTable, {v.DisplayName, v.Name, v.Character.Humanoid.Health, v.Character.Humanoid.MaxHealth})
+				end
+				
+				table.sort(RawTable, function(a,b)
+					if a[4] == b[4] then
+						return a[3] > b[3]
+					else
+						return(a[4] > b[4])
+					end
+				end)
+				
+				local GoddedCheck = false
+				local GodTable = {}
+				local NormalCheck = false
+				local NormalTable = {}
+				for _, v in RawTable do
+					if tostring(v[4]) == "inf" then
+						table.insert(GodTable, v)
+						GoddedCheck = true
+					else
+						table.insert(NormalTable, v)
+						NormalCheck = true
+					end
+				end
+				
+				local LogTable = {}
+				
+				if GoddedCheck == true then
+					table.insert(LogTable, "<b><u>Godded Players: </u></b>")
+				end
+				
+				for _, v in GodTable do
+					local Color = "100,175,255"
+					table.insert(LogTable, v[1] .. ' (@' .. v[2] .. ') :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[3]) .. '/' .. math.round(v[4]) .. ']</font>')
+				end
+				
+				if NormalCheck == true then
+					table.insert(LogTable, "<b><u>Normal Players: </u></b>")
+				end
+				
+				for _, v in NormalTable do
+					local Color
+					if v[3]/v[4] >= .5 then
+						Color =  math.round(100 + (155 * ((v[3]/v[4]) * -2 + 2))) .."," .. 255 ..  "," .. 100
+					else
+						Color =  255 .."," .. math.round(100 + 155 * (v[3]/v[4]) * 2) ..  "," .. 100
+					end
+					table.insert(LogTable, v[1] .. ' (@' .. v[2] .. ') :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[3]) .. '/' .. math.round(v[4]) .. ']</font>')
+				end
+				
+				return LogTable
+			end;
+			
+			Function = function(plr: Player, args: {string})
+				Functions.Hint("Fetching player healths.", {plr})
+				Remote.MakeGui(plr, "List", {
+					Title = "Player Healths";
+					Tab = Logs.ListUpdaters.HealthList(plr);
+					Dots = true;
+					Update = "HealthList";
+					AutoUpdate = if args[1] and (args[1]:lower() == "false" or args[1]:lower() == "no") then nil else 1;
+					Sanitize = false;
+					Stacking = true;
+					RichText = true;
+				})
+			end
+		};
 	}
 end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6842,7 +6842,15 @@ return function(Vargs, env)
 				
 				table.sort(RawTable, function(a,b)
 					if a[4] == b[4] then
-						return a[3] > b[3]
+						if a[3] == b[3] then
+							if a[1] == b[1] then
+								return(a[2] > b[2])
+							else
+								return(a[1] > b[1])
+							end
+						else
+							return(a[3] > b[3])
+						end
 					else
 						return(a[4] > b[4])
 					end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6846,10 +6846,10 @@ return function(Vargs, env)
 				
 				table.sort(RawTable, function(a,b)
 					if a[3] == b[3] then
-						if a[1] == b[1] then
-							return(a[2] < b[2])
-						else
+						if a[2] == b[2] then
 							return(a[1] < b[1])
+						else
+							return(a[2] > b[2])
 						end
 					else
 						return(a[3] > b[3])

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6835,16 +6835,16 @@ return function(Vargs, env)
 			Description = "Shows a list of all players' current and max healths.";
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player, args: {string})
-				local RawTable = {}
+				local rawTable = {}
 				for _, v in Functions.GetPlayers(plr, "all") do
 					if v.Character and v.Character:FindFirstChildOfClass("Humanoid") then
-						table.insert(RawTable, {service.FormatPlayer(v), v.Character:FindFirstChildOfClass("Humanoid").Health, v.Character:FindFirstChildOfClass("Humanoid").MaxHealth})
+						table.insert(rawTable, {service.FormatPlayer(v), v.Character:FindFirstChildOfClass("Humanoid").Health, v.Character:FindFirstChildOfClass("Humanoid").MaxHealth})
 					else
-						table.insert(RawTable, {service.FormatPlayer(v), 0, 0})
+						table.insert(rawTable, {service.FormatPlayer(v), 0, 0})
 					end
 				end
 				
-				table.sort(RawTable, function(a,b)
+				table.sort(rawTable, function(a,b)
 					if a[3] == b[3] then
 						if a[2] == b[2] then
 							return(a[1] < b[1])
@@ -6856,55 +6856,55 @@ return function(Vargs, env)
 					end
 				end)
 				
-				local GoddedCheck = false
-				local NormalCheck = false
-				local GodTable = {}
-				local ZeroTable = {}
-				local NormalTable = {}
+				local goddedCheck = false
+				local normalCheck = false
+				local godTable = {}
+				local zeroTable = {}
+				local normalTable = {}
 				
-				for _, v in RawTable do
+				for _, v in rawTable do
 					if tostring(v[3]) == "inf" then
-						table.insert(GodTable, v)
-						GoddedCheck = true
+						table.insert(godTable, v)
+						goddedCheck = true
 					else
 						if v[3] <= 0 then
-							table.insert(ZeroTable, v)
-							NormalCheck = true
+							table.insert(zeroTable, v)
+							normalCheck = true
 						else
-							table.insert(NormalTable, v)
-							NormalCheck = true
+							table.insert(normalTable, v)
+							normalCheck = true
 						end
 					end
 				end
 				
 				local LogTable = {}
 				
-				if GoddedCheck == true then
+				if goddedCheck == true then
 					table.insert(LogTable, "<b><u>Godded Players: </u></b>")
 				end
 				
-				for _, v in GodTable do
-					local Color = "100, 175, 255"
-					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
+				for _, v in godTable do
+					local color = "100, 175, 255"
+					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
 				end
 				
-				if NormalCheck == true then
+				if normalCheck == true then
 					table.insert(LogTable, "<b><u>Normal Players: </u></b>")
 				end
 				
-				for _, v in NormalTable do
-					local Color
+				for _, v in normalTable do
+					local color
 					if v[2]/v[3] >= .5 then
-						Color =  math.round(100 + 155 * (v[2]/v[3] * -2 + 2)) .. ", 255, 100"
+						color =  math.round(100 + 155 * (v[2]/v[3] * -2 + 2)) .. ", 255, 100"
 					else
-						Color =  "255, " .. math.round(100 + 155 * v[2]/v[3] * 2) ..  ", 100"
+						color =  "255, " .. math.round(100 + 155 * v[2]/v[3] * 2) ..  ", 100"
 					end
-					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
+					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
 				end
 				
-				for _, v in ZeroTable do
-					local Color = "255, 100, 100"
-					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. Color .. ')">[N/A]</font>')
+				for _, v in zeroTable do
+					local color = "255, 100, 100"
+					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[N/A]</font>')
 				end
 				
 				return LogTable
@@ -6925,5 +6925,4 @@ return function(Vargs, env)
 			end
 		};
 	}
-end
 end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6877,19 +6877,19 @@ return function(Vargs, env)
 					end
 				end
 				
-				local LogTable = {}
+				local logTable = {}
 				
 				if goddedCheck == true then
-					table.insert(LogTable, "<b><u>Godded Players: </u></b>")
+					table.insert(logTable, "<b><u>Godded Players: </u></b>")
 				end
 				
 				for _, v in godTable do
 					local color = "100, 175, 255"
-					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
+					table.insert(logTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
 				end
 				
 				if normalCheck == true then
-					table.insert(LogTable, "<b><u>Normal Players: </u></b>")
+					table.insert(logTable, "<b><u>Normal Players: </u></b>")
 				end
 				
 				for _, v in normalTable do
@@ -6899,15 +6899,15 @@ return function(Vargs, env)
 					else
 						color =  "255, " .. math.round(100 + 155 * v[2]/v[3] * 2) ..  ", 100"
 					end
-					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
+					table.insert(logTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
 				end
 				
 				for _, v in zeroTable do
 					local color = "255, 100, 100"
-					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[N/A]</font>')
+					table.insert(logTable, v[1] .. ' :: <font color = "rgb(' .. color .. ')">[N/A]</font>')
 				end
 				
-				return LogTable
+				return logTable
 			end;
 			
 			Function = function(plr: Player, args: {string})

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6837,36 +6837,43 @@ return function(Vargs, env)
 			ListUpdater = function(plr: Player, args: {string})
 				local RawTable = {}
 				for _, v in Functions.GetPlayers(plr, "all") do
-					table.insert(RawTable, {v.DisplayName, v.Name, v.Character.Humanoid.Health, v.Character.Humanoid.MaxHealth})
+					if v.Character and v.Character:FindFirstChildOfClass("Humanoid") then
+						table.insert(RawTable, {service.FormatPlayer(v), v.Character:FindFirstChildOfClass("Humanoid").Health, v.Character:FindFirstChildOfClass("Humanoid").MaxHealth})
+					else
+						table.insert(RawTable, {service.FormatPlayer(v), 0, 0})
+					end
 				end
 				
 				table.sort(RawTable, function(a,b)
-					if a[4] == b[4] then
-						if a[3] == b[3] then
-							if a[1] == b[1] then
-								return(a[2] < b[2])
-							else
-								return(a[1] < b[1])
-							end
+					if a[3] == b[3] then
+						if a[1] == b[1] then
+							return(a[2] < b[2])
 						else
-							return(a[3] > b[3])
+							return(a[1] < b[1])
 						end
 					else
-						return(a[4] > b[4])
+						return(a[3] > b[3])
 					end
 				end)
 				
 				local GoddedCheck = false
-				local GodTable = {}
 				local NormalCheck = false
+				local GodTable = {}
+				local ZeroTable = {}
 				local NormalTable = {}
+				
 				for _, v in RawTable do
-					if tostring(v[4]) == "inf" then
+					if tostring(v[3]) == "inf" then
 						table.insert(GodTable, v)
 						GoddedCheck = true
 					else
-						table.insert(NormalTable, v)
-						NormalCheck = true
+						if v[3] <= 0 then
+							table.insert(ZeroTable, v)
+							NormalCheck = true
+						else
+							table.insert(NormalTable, v)
+							NormalCheck = true
+						end
 					end
 				end
 				
@@ -6877,8 +6884,8 @@ return function(Vargs, env)
 				end
 				
 				for _, v in GodTable do
-					local Color = "100,175,255"
-					table.insert(LogTable, v[1] .. ' (@' .. v[2] .. ') :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[3]) .. '/' .. math.round(v[4]) .. ']</font>')
+					local Color = "100, 175, 255"
+					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
 				end
 				
 				if NormalCheck == true then
@@ -6887,12 +6894,17 @@ return function(Vargs, env)
 				
 				for _, v in NormalTable do
 					local Color
-					if v[3]/v[4] >= .5 then
-						Color =  math.round(100 + (155 * ((v[3]/v[4]) * -2 + 2))) .."," .. 255 ..  "," .. 100
+					if v[2]/v[3] >= .5 then
+						Color =  math.round(100 + 155 * (v[2]/v[3] * -2 + 2)) .. ", 255, 100"
 					else
-						Color =  255 .."," .. math.round(100 + 155 * (v[3]/v[4]) * 2) ..  "," .. 100
+						Color =  "255, " .. math.round(100 + 155 * v[2]/v[3] * 2) ..  ", 100"
 					end
-					table.insert(LogTable, v[1] .. ' (@' .. v[2] .. ') :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[3]) .. '/' .. math.round(v[4]) .. ']</font>')
+					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. Color .. ')">[' .. math.round(v[2]) .. '/' .. math.round(v[3]) .. ']</font>')
+				end
+				
+				for _, v in ZeroTable do
+					local Color = "255, 100, 100"
+					table.insert(LogTable, v[1] .. ' :: <font color = "rgb(' .. Color .. ')">[N/A]</font>')
 				end
 				
 				return LogTable
@@ -6913,4 +6925,5 @@ return function(Vargs, env)
 			end
 		};
 	}
+end
 end


### PR DESCRIPTION
It is currently difficult to tell which players are godded, have altered health, etc. This command makes an automatically updating list of all players and their respective healths. Players are ordered first by max health, then current health, then display name, then username.