### PR TITLE
Remove Ender

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -908,8 +908,8 @@ return function(Vargs, GetEnv)
 			local fps = tonumber(fps)
 			if fps then
 				service.StartLoop("SetFPS",0.1,function()
-					local ender = time()+1/fps
-					repeat until time()>=ender
+					local fpslockint = time() +1 /fps
+					repeat until time()>=fpslockint
 				end)
 			end
 		end;


### PR DESCRIPTION
Why is ender in the fps lock code