### PR TITLE
Rename 'Admin Logs' to 'Command Logs'

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6408,7 +6408,7 @@ return function(Vargs, env)
 			end;
 			Function = function(plr: Player, args: {string})
 				Remote.MakeGui(plr, "List", {
-					Title = "Admin Logs";
+					Title = "Command Logs";
 					Table = Logs.ListUpdaters.Logs(plr);
 					Dots = true;
 					Update = "Logs";


### PR DESCRIPTION
why? because of the J