### PR TITLE
Improve !audioplayer global audio permissions system

### DIFF
--- a/MainModule/Client/UI/Default/Music.rbxmx
+++ b/MainModule/Client/UI/Default/Music.rbxmx
@@ -42,7 +42,7 @@ return function(data, env)
 	local audioLib = nil
 	local controlPositionSlider = nil
 	local progressupdatewait = 0.05
-
+	local canUseGlobal = data.GlobalPerms
 
 	-- The audio visulaiser at the top of the menu.
 
@@ -250,65 +250,68 @@ return function(data, env)
 		end
 	})
 
-	local globalButton = window:AddTitleButton({
-		Text = "";
-		OnClick = function()
-			audioLib("UpdateSound", {
-				Playing = false;
-				TimePosition = 0;
-			})
-			if isGlobal then
-				gImg.Image = "rbxassetid://8318256297"
-				isGlobal = false
-				task.spawn(client.UI.Make, "Notification",{
-					Title = "Global Audio";
-					Icon = "rbxassetid://7541916144";
-					Message = "Only you can hear your music";
-					Time = 3;
-				})
+	local globalButton = nil
 
-				audioLib = localAudioLibFunction
+	if canUseGlobal then
+		globalButton = window:AddTitleButton({
+			Text = "";
+			OnClick = function()
 				audioLib("UpdateSound", {
 					Playing = false;
 					TimePosition = 0;
 				})
-				visualiser:LinkToSound(audioLib("GetSound"))
-				progressupdatewait = 0.05
+				if isGlobal then
+					gImg.Image = "rbxassetid://8318256297"
+					isGlobal = false
+					task.spawn(client.UI.Make, "Notification",{
+						Title = "Global Audio";
+						Icon = "rbxassetid://7541916144";
+						Message = "Only you can hear your music";
+						Time = 3;
+					})
 
-			else
-				--updateAudio({Global = true})
-				gImg.Image = "rbxassetid://8318257291";
-				isGlobal = true
-				task.spawn(client.UI.Make, "Notification",{
-					Title = "Global Audio";
-					Icon = "rbxassetid://7541916144";
-					Message = "Everyone can hear your music";
-					Time = 3;
-				})
-				audioLib = function(func, args)
-					return client.Remote.Get("AudioLib", {func, args})
+					audioLib = localAudioLibFunction
+					audioLib("UpdateSound", {
+						Playing = false;
+						TimePosition = 0;
+					})
+					visualiser:LinkToSound(audioLib("GetSound"))
+					progressupdatewait = 0.05
+
+				else
+					--updateAudio({Global = true})
+					gImg.Image = "rbxassetid://8318257291";
+					isGlobal = true
+					task.spawn(client.UI.Make, "Notification",{
+						Title = "Global Audio";
+						Icon = "rbxassetid://7541916144";
+						Message = "Everyone can hear your music";
+						Time = 3;
+					})
+					audioLib = function(func, args)
+						return client.Remote.Get("AudioLib", {func, args})
+					end
+					audioLib("UpdateSound", {
+						Playing = false;
+						TimePosition = 0;
+					})
+					visualiser:LinkToSound(audioLib("GetSound"))
+					progressupdatewait = 2
 				end
-				audioLib("UpdateSound", {
-					Playing = false;
-					TimePosition = 0;
-				})
-				visualiser:LinkToSound(audioLib("GetSound"))
-				progressupdatewait = 2
 			end
-		end
-	})
+		})
+		gImg = globalButton:Add("ImageLabel", {
+			Size = UDim2.new(1, 0, 1 ,0);
+			Position = UDim2.new(0, 0, 0, 0);
+			Image = "rbxassetid://8318256297";
+			BackgroundTransparency = 1;
+		})
+	end
 
 	sImg = muteButton:Add("ImageLabel", {
 		Size = UDim2.new(1, 0, 1 ,0);
 		Position = UDim2.new(0, 0, 0, 0);
 		Image = "rbxassetid://1638551696";
-		BackgroundTransparency = 1;
-	})
-
-	gImg = globalButton:Add("ImageLabel", {
-		Size = UDim2.new(1, 0, 1 ,0);
-		Position = UDim2.new(0, 0, 0, 0);
-		Image = "rbxassetid://8318256297";
 		BackgroundTransparency = 1;
 	})
 

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -1077,8 +1077,25 @@ return function(Vargs, env)
 			Description = "Opens the audio player";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
+				local canUseGlobalBroadcast
+				local cmd, ind
+				for i, v in Admin.SearchCommands(plr, "all") do
+					for _, p in ipairs(v.Commands) do
+						if (v.Prefix or "")..string.lower(p) == (v.Prefix or "")..string.lower("music") then
+							cmd, ind = v, i
+							break
+						end
+					end
+					if ind then break end
+				end
+				if cmd then
+					canUseGlobalBroadcast = true
+				else
+					canUseGlobalBroadcast = false
+				end
 				Remote.MakeGui(plr, "Music", {
-					Song = args[1]
+					Song = args[1],
+					GlobalPerms = canUseGlobalBroadcast
 				})
 			end
 		};

--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -465,7 +465,23 @@ return function(Vargs, GetEnv)
 			end;
 
 			AudioLib = function(p,args)
-				if Admin.GetLevel(p) >= Settings.Ranks.Moderators.Level then
+				local canUseGlobalBroadcast
+				local cmd, ind
+				for i, v in Admin.SearchCommands(p, "all") do
+					for _, c in ipairs(v.Commands) do
+						if (v.Prefix or "")..string.lower(c) == (v.Prefix or "")..string.lower("music") then
+							cmd, ind = v, i
+							break
+						end
+					end
+					if ind then break end
+				end
+				if cmd then
+					canUseGlobalBroadcast = true
+				else
+					canUseGlobalBroadcast = false
+				end
+				if canUseGlobalBroadcast then
 					if not server.Functions.AudioLib then
 						local audioLibFolder = workspace:FindFirstChild("ADONIS_AUDIOLIB")
 						if not audioLibFolder then
@@ -477,13 +493,6 @@ return function(Vargs, GetEnv)
 					end
 
 					return server.Functions.AudioLib[args[1][1]](server.Functions.AudioLib, args[1][2])
-				else
-					task.spawn(Remote.MakeGui,p,"Notification",{
-						Title = "Global Audio";
-						Message = "Only Moderators or above may broadcast audio!";
-						Icon = server.Shared.MatIcons.Language;
-						Time = 3;
-					})
 				end
 			end;
 		};


### PR DESCRIPTION
The permissions of !audioplayer global audio now rely on the player's permission to use the :music command, meaning if the player is not allowed to use :music, the player cannot broadcast global audio (to prevent players being able to play music for the entire server even if they can't use :music, which functions the same as global audio in the audio player)

In addition, if a player is not allowed to broadcast global audio, the global audio toggle on their end won't be visible at all. (and the server check is still there and updated for the permission changes)
