### PR TITLE
Fix %team being able to select everyone

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -190,7 +190,7 @@ return function(Vargs, GetEnv)
 					local lower = string.lower
 					local sub = string.sub
 
-					if matched then
+					if matched and #matched > 0 then
 						for _,v in service.Teams:GetChildren() do
 							if sub(lower(v.Name), 1, #matched) == lower(matched) then
 								for _,m in parent:GetChildren() do


### PR DESCRIPTION
This change fixes a bug where if "%" is used as the selector on a command, everyone gets selected. For example, currently ":bring %" is the same as ":bring all".