### PR TITLE
Fix for ":noclip" command & the Noclip script (Clipper) along with readability improvements

### DIFF
--- a/MainModule/Server/Dependencies/Assets/Clipper.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Clipper.client.lua
@@ -1,14 +1,11 @@
-local hum = script.Parent
-local char = hum.Parent
-local torso = char:FindFirstChild("HumanoidRootPart")
-local origY = torso.Position.Y
+local Humanoid = script.Parent
+local Character = Humanoid.Parent
+
 game:GetService("RunService").Stepped:Connect(function()
-	for _,v in pairs(char:GetDescendants()) do
-		if v:IsA("BasePart") then
-			v.CanCollide = false
+	for _, Object in pairs(Character:GetDescendants()) do
+		if Object:IsA("BasePart") and Object.CanCollide then
+			Object.CanCollide = false
 		end
 	end
-	local cf = torso.CFrame
-	torso.CFrame = (cf - cf.Position) + Vector3.new(cf.X, origY, cf.Z)
-	hum:ChangeState(11)
+	Humanoid:ChangeState(11)	--| Enum.HumanoidStateType.StrafingNoPhysics (semi-depricated but still working and fixes the colliding if in water).
 end)


### PR DESCRIPTION
Idk why changing the root part cframe.. it was causing the character to repeatly go up and down lol.