### PR TITLE
Fix error with fly

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2528,8 +2528,14 @@ return function(Vargs, env)
 			Description = "Flying noclip";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
+				local newArgs = {
+					"me",
+					args[2] or "2",
+					"true"
+				}
+
 				for i, p in service.GetPlayers(plr, args[1]) do
-					Commands.Fly.Function(p, args, nil, true)
+					Commands.Fly.Function(p, newArgs)
 				end
 			end
 		};
@@ -5706,10 +5712,10 @@ return function(Vargs, env)
 		Fly = {
 			Prefix = Settings.Prefix;
 			Commands = {"fly", "flight"};
-			Args = {"player", "speed"};
+			Args = {"player", "speed", "noclip"};
 			Description = "Lets the target player(s) fly";
 			AdminLevel = "Moderators";
-			Function = function(plr: Player, args: {string}, _: any?, noclip: boolean?)
+			Function = function(plr: Player, args: {string})
 				local speed = tonumber(args[2]) or 2
 				local scr = Deps.Assets.Fly:Clone()
 				local sVal = service.New("NumberValue", {
@@ -5719,7 +5725,7 @@ return function(Vargs, env)
 				})
 				local NoclipVal = service.New("BoolValue", {
 					Name = "Noclip";
-					Value = noclip or false;
+					Value = args[3] and (string.lower(args[3]) == "true" or string.lower(args[3]) == "yes") or args[3] == nil and false;
 					Parent = scr;
 				})
 				

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2528,11 +2528,7 @@ return function(Vargs, env)
 			Description = "Flying noclip";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				local newArgs = {
-					"me",
-					args[2] or "2",
-					"true"
-				}
+				local newArgs = { "me", args[2] or "2", "true" }
 
 				for i, p in service.GetPlayers(plr, args[1]) do
 					Commands.Fly.Function(p, newArgs)

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2529,7 +2529,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for i, p in service.GetPlayers(plr, args[1]) do
-					Commands.Fly.Function(p, args, true)
+					Commands.Fly.Function(p, args, nil, true)
 				end
 			end
 		};
@@ -5709,7 +5709,7 @@ return function(Vargs, env)
 			Args = {"player", "speed"};
 			Description = "Lets the target player(s) fly";
 			AdminLevel = "Moderators";
-			Function = function(plr: Player, args: {string}, noclip: boolean?)
+			Function = function(plr: Player, args: {string}, _: any?, noclip: boolean?)
 				local speed = tonumber(args[2]) or 2
 				local scr = Deps.Assets.Fly:Clone()
 				local sVal = service.New("NumberValue", {

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -5708,7 +5708,7 @@ return function(Vargs, env)
 		Fly = {
 			Prefix = Settings.Prefix;
 			Commands = {"fly", "flight"};
-			Args = {"player", "speed", "noclip"};
+			Args = {"player", "speed", "noclip? (default: true)"};
 			Description = "Lets the target player(s) fly";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
@@ -5721,7 +5721,7 @@ return function(Vargs, env)
 				})
 				local NoclipVal = service.New("BoolValue", {
 					Name = "Noclip";
-					Value = args[3] and (string.lower(args[3]) == "true" or string.lower(args[3]) == "yes") or args[3] == nil and false;
+					Value = args[3] and (string.lower(args[3]) == "true" or string.lower(args[3]) == "yes");
 					Parent = scr;
 				})
 				


### PR DESCRIPTION
## What this pull request does

**This pull request fixes:**

- Invalid usage of the third function argument (stops conflicting with global function arguments,  stops undocumented instance property behavior)
- `:flynoclip` invalidly using the args table resulting in undesired behavior and lag (if ran on multiple people)

**Fixed by:**

- Function argument bug fixed by using command arguments instead of function arguments
- `:flynoclip` bug fixed by using a custom args table

---------

## Explanation of why bug occurs

The fly function invalidly reads the third argument of the command function as a boolean. This works fine if said command is ran via the `flynoclip`

If the :fly command is ran via normal means this is what the `noclip` argument of the function will be a table, it won't be a boolean. The argument `noclip` will be normally this table:
```lua
{
	["Options"] =  ▼  {
		["Chat"] = true
	},
	["PlayerData"] =  ▼  {
		["Level"] = 900,
		["Player"] = "Player1",
		["isDonor"] = true
	}
}
```

This is invalid behavior, and adonis sets the `.Value` of the `BoolValue` to that table, which results in undocumented behavior (currently it sets to true, but if an update comes to Rbx then it would have a different result, or totally break).

Another issue is that the `:flynoclip` command sends it's full args to the `:fly` commands function, meaing if you do `:flynoclip` all, each player will then run `:fly all` which causes a lot of lag.

Also using a pre-defined function argument instead of a command argument conflicts with current (and potentially future)