### PR TITLE
Fix support for https://devforum.roblox.com/t/disconnect-player-on-removal-from-datamodel/2061753

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -230,7 +230,7 @@ return function(Vargs, GetEnv)
 					local workspace = service.UnWrap(workspace)
 					local nilPlayers = setmetatable({}, {__mode = "v"})
 
-					service.UnWrap(Players).ChildRemoved:Connect(function(child)
+					service.UnWrap(service.Players).ChildRemoved:Connect(function(child)
 						if child:IsA("Player") then
 							table.insert(nilPlayers, child)
 						end

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -228,6 +228,13 @@ return function(Vargs, GetEnv)
 				coroutine.wrap(function()
 					local LocalPlayer = service.UnWrap(Player)
 					local workspace = service.UnWrap(workspace)
+					local nilPlayers = setmetatable({}, {__mode = "v"})
+
+					service.UnWrap(Players).ChildRemoved:Connect(function(child)
+						if child:IsA("Player") then
+							table.insert(nilPlayers, child)
+						end
+					end)
 
 					local success, err = pcall(function()
 						LocalPlayer.Kick(workspace, "If this appears, you have a glitch. Method 1")
@@ -250,7 +257,7 @@ return function(Vargs, GetEnv)
 						for _, v in service.Players:GetPlayers() do
 							local otherPlayer = service.UnWrap(v)
 
-							if otherPlayer and otherPlayer.Parent == unwrappedPlayers and otherPlayer ~= LocalPlayer then
+							if otherPlayer and not table.find(nilPlayers, otherPlayer) and otherPlayer.Parent == unwrappedPlayers and otherPlayer ~= LocalPlayer then
 								local success, err = pcall(LocalPlayer.Kick, otherPlayer, "If this message appears, report it to Adonis maintainers. #2")
 								local success2, err2 = pcall(function()
 									otherPlayer:Kick("If this message appears, report it to Adonis maintainers. #3")

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -245,10 +245,12 @@ return function(Vargs, GetEnv)
 					end
 
 					if #service.Players:GetPlayers() > 1 then
+						local unwrappedPlayers = service.Players
+
 						for _, v in service.Players:GetPlayers() do
 							local otherPlayer = service.UnWrap(v)
 
-							if otherPlayer and otherPlayer.Parent and otherPlayer ~= LocalPlayer then
+							if otherPlayer and otherPlayer.Parent == unwrappedPlayers and otherPlayer ~= LocalPlayer then
 								local success, err = pcall(LocalPlayer.Kick, otherPlayer, "If this message appears, report it to Adonis maintainers. #2")
 								local success2, err2 = pcall(function()
 									otherPlayer:Kick("If this message appears, report it to Adonis maintainers. #3")


### PR DESCRIPTION
A new feature disconnects all player events when a player is parented to nil, which breaks `:unincognito`

This fixes the difference issues caused by: https://devforum.roblox.com/t/disconnect-player-on-removal-from-datamodel/2061753