### PR TITLE
Misc copyright/trademark stuff

### DIFF
--- a/MainModule/Server/Shared/MatIcons.lua
+++ b/MainModule/Server/Shared/MatIcons.lua
@@ -1,8 +1,9 @@
 --[[
 	════════════════════════════════════════════
-	Material Icons Collection for ROBLOX
+	Material Icons Collection for Roblox
 		Uploaded painstakingly by @Expertcoderz
-		Sourced from:
+		Images are licensed under Apache 2.0 license
+		Sourced from Google LLC:
 			https://fonts.google.com/icons
 			('Sharp' style, white colored)
 	════════════════════════════════════════════


### PR DESCRIPTION
- Made `ROBLOX` to `Roblox`. FIrst letter capitalised ir proper trademark. First is improper use
- Credited `Google LLC` for material icons