### PR TITLE
Fix `HTTP.HttpEnabled`

### DIFF
--- a/MainModule/Server/Core/HTTP.lua
+++ b/MainModule/Server/Core/HTTP.lua
@@ -41,7 +41,7 @@ return function(Vargs, GetEnv)
 	server.HTTP = {
 		Init = Init;
 		HttpEnabled = (function()
-			local success, res = pcall(service.HttpService.GetAsync, service.HttpService, "https://google.com/robots.txt")
+			local success, res = pcall(service.HttpService.GetAsync, service.HttpService, "https://www.google.com/robots.txt")
 			if not success and res:find("Http requests are not enabled.") then
 				return false
 			end


### PR DESCRIPTION
If it doesn't have `www.` it becomes a 301 redirect instead of a success