### PR TITLE
Made `SavePlayerData` only save data for valid players

### DIFF
--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -634,7 +634,7 @@ return function(Vargs, GetEnv)
 
 				Core.PlayerData[key] = PlayerData
 
-				if Core.DataStore then
+				if Core.DataStore and p.UserId > 0 then
 					local data = Core.GetData(key)
 					if type(data) == "table" then
 						data.AdminNotes = if data.AdminNotes then Functions.DSKeyNormalize(data.AdminNotes, true) else {}

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -664,7 +664,7 @@ return function(Vargs, GetEnv)
 			local pData = customData or Core.PlayerData[key]
 
 			if Core.DataStore then
-				if pData then
+				if pData and p.UserId > 0 then
 					local data = service.CloneTable(pData)
 
 					--// Temporary junk that will be removed on save.


### PR DESCRIPTION
Users with a negative userid are temporary accounts for which data shouldn't be saved. Currently used by Studio fake players and was used previously by Guests.