### PR TITLE
Fix rainbowify replication

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -666,7 +666,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				local scr = Core.NewScript("LocalScript",[[
+				local scr = Core.NewScript("Script",[[
 					repeat
 						task.wait(0.1)
 						local char = script.Parent.Parent


### PR DESCRIPTION
Rainbowify clones a localscript to whoever the command is used on, but it doesn't replicate. Changing "LocalScript" to "Script" should fix this.