### PR TITLE
Made FiOne use an empty env instead of the fenv for performance and future compatibility

### DIFF
--- a/MainModule/Server/Shared/FiOne.lua
+++ b/MainModule/Server/Shared/FiOne.lua
@@ -1068,5 +1068,5 @@ function wrap_lua_func(state, env, upvals)
 end
 
 return function(BCode, Env)
-	return wrap_lua_func(stm_lua_bytecode(BCode), Env or getfenv(0))
+	return wrap_lua_func(stm_lua_bytecode(BCode), Env or {})
 end


### PR DESCRIPTION
If we wan't to use a virtual env ever then FiOne calling fenv would negate any of it's benefits.