### PR TITLE
Server-Dex: Fix can't parse JSON

### DIFF
--- a/MainModule/Server/Plugins/Server-Dex.rbxmx
+++ b/MainModule/Server/Plugins/Server-Dex.rbxmx
@@ -102322,7 +102322,7 @@ end]]></ProtectedString>
 	}
 	],
 	"Version": 1
-}}}]==]
+}]==]
 ]]></ProtectedString>
 							<int64 name="SourceAssetId">-1</int64>
 							<BinaryString name="Tags"></BinaryString>


### PR DESCRIPTION
The RawApiJson had two ``}`` extra brackets at the end.

So I removed them.