### PR TITLE
Fixed DoCheck failing on nonwrapped players

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -505,8 +505,8 @@ return function(Vargs, GetEnv)
 		end;
 
 		DoCheck = function(pObj, check, banCheck)
-			local pType = typeof(pObj)
-			local cType = typeof(check)
+			local pType = type(pObj)
+			local cType = type(check)
 
 			local pUnWrapped = service.UnWrap(pObj)
 


### PR DESCRIPTION
If the player is nonwrapped it doesn't return userdata with `typeof`