### PR TITLE
Fix(?) softshutdown looping

### DIFF
--- a/MainModule/Server/Plugins/Server-SoftShutdown.lua
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.lua
@@ -21,7 +21,7 @@ return function(Vargs, GetEnv)
 	if game.PrivateServerId ~= "" and game.PrivateServerOwnerId == 0  then
 		--// This is a reserved server
 
-		local waitTime = 5
+		local waitTime = 15
 		local function teleport(player)
 			local joindata = player:GetJoinData()
 			local data = type(joindata) == "table" and joindata.TeleportData


### PR DESCRIPTION
Increased the wait time in the reserved server to hopefully allow ROBLOX to shutdown the empty server quick enough