### PR TITLE
Update the trello related commands

### DIFF
--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1360,7 +1360,12 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string}, data: {any})
 				local trello = HTTP.Trello.API
-				if not Settings.Trello_Enabled or trello == nil then return Functions.Hint('Trello has not been configured in settings', {plr}) end
+				if not Settings.Trello_Enabled or trello == nil then return 
+					Remote.MakeGui(plr, "Notification", {
+						Title = "Trelloban";
+						Message = "Trello has not been configured.";
+					})
+				end
 
 				local lists = trello.getLists(Settings.Trello_Primary)
 				local list = trello.getListObj(lists, {"Banlist", "Ban List", "Bans"})

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1211,11 +1211,11 @@ return function(Vargs, env)
 			end
 		};
 
-		ShowSBL = {
+		ShowTrelloBansList = {
 			Prefix = Settings.Prefix;
-			Commands = {"sbl", "syncedbanlist", "globalbanlist", "trellobans", "trellobanlist"};
+			Commands = {"SyncedTrelloBans", "TrelloBans", "TrelloBanList", "ShowTrelloBans"};
 			Args = {};
-			Description = "Shows Trello bans";
+			Description = "Shows bans synced from Trello.";
 			TrelloRequired = true;
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player)
@@ -1231,12 +1231,20 @@ return function(Vargs, env)
 				return tab
 			end;
 			Function = function(plr: Player, args: {string})
-				Remote.MakeGui(plr, "List", {
-					Title = "Synced Ban List";
-					Icon = server.MatIcons.Gavel;
-					Tab = Logs.ListUpdaters.ShowSBL(plr);
-					Update = "ShowSBL";
-				})
+				local trello = HTTP.Trello.API
+				if not Settings.Trello_Enabled or trello == nil then
+					Remote.MakeGui(plr, "Notification", {
+						Title = "Trello Synced Ban List";
+						Message = "Trello has not been enabled.";
+					})
+				else				
+					Remote.MakeGui(plr, "List", {
+						Title = "Trello Synced Bans List";
+						Icon = server.MatIcons.Gavel;
+						Tab = Logs.ListUpdaters.ShowTrelloBansList(plr);
+						Update = "ShowTrelloBansList";
+					})
+				end
 			end;
 		};
 


### PR DESCRIPTION
Updated the command that shows the synced trello bans.
Changed above command to show a notification instead of creating the list if trello is not configured/enabled.
Changed the trelloban command to make a notification instead of a hint if trello is not configured/enabled.