### PR TITLE
Don't save groups

### DIFF
--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -679,7 +679,7 @@ return function(Vargs, GetEnv)
 					local data = service.DeepCopy(pData)
 
 					--// Temporary junk that will be removed on save.
-					for _, blacklistedData in ipairs({"LastChat", "AdminRank", "AdminLevel", "LastLevelUpdate", "LastDataSave"}) do
+					for _, blacklistedData in ipairs({"Groups", "LastChat", "AdminRank", "AdminLevel", "LastLevelUpdate", "LastDataSave"}) do
 						data[blacklistedData] = nil
 					end
 					


### PR DESCRIPTION
Groups saving in datastore is the worst feature ever. It makes datastores very bloated

![image](https://user-images.githubusercontent.com/68124053/230638512-868faf8c-7671-4e16-903d-409eb4db272d.png)

Biggest bruh moment feature