### PR TITLE
Fix mystery error with hint

### DIFF
--- a/MainModule/Client/UI/Default/Hint.rbxmx
+++ b/MainModule/Client/UI/Default/Hint.rbxmx
@@ -193,7 +193,7 @@
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="TextScaled">true</bool>
+					<bool name="TextScaled">false</bool>
 					<float name="TextSize">18</float>
 					<Color3 name="TextStrokeColor3">
 						<R>0</R>

--- a/MainModule/Client/UI/Default/Hint.rbxmx
+++ b/MainModule/Client/UI/Default/Hint.rbxmx
@@ -193,7 +193,7 @@
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="TextScaled">false</bool>
+					<bool name="TextScaled">true</bool>
 					<float name="TextSize">18</float>
 					<Color3 name="TextStrokeColor3">
 						<R>0</R>

--- a/MainModule/Client/UI/Default/Hint.rbxmx
+++ b/MainModule/Client/UI/Default/Hint.rbxmx
@@ -147,12 +147,7 @@
 					<int name="BorderSizePixel">1</int>
 					<bool name="ClipsDescendants">false</bool>
 					<bool name="Draggable">false</bool>
-					<Font name="FontFace">
-						<Family><url>rbxasset://fonts/families/SourceSansPro.json</url></Family>
-						<Weight>400</Weight>
-						<Style>Normal</Style>
-						<CachedFaceId><url>rbxasset://fonts/SourceSansPro-Regular.ttf</url></CachedFaceId>
-					</Font>
+					<token name="Font">3</token>
 					<int name="LayoutOrder">0</int>
 					<float name="LineHeight">1</float>
 					<int name="MaxVisibleGraphemes">-1</int>


### PR DESCRIPTION
Hint for some reason became bigger without good reason? This seems to pretty much fix it. Although there is a slight font difference

Edit: Apparently it's because Scelratis updated the hint and somehow Roblox makes it weird