### PR TITLE
Fix some potential false flags

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -471,8 +471,8 @@ return function(Vargs)
 				"getmenv";
 				"gettenv"; -- script-ware specific
 				"identifyexecutor";
-				"getreg";
-				"getgc";
+				--"getreg";
+				--"getgc";
 				"getnilinstances";
 				"getconnections";
 				"getloadedmodules";


### PR DESCRIPTION
Also fixes for
```
GetCollisionGroups is deprecated, please use GetRegisteredCollisionGroups instead. More info: https://devforum.roblox.com/t/updates-to-collision-groups/1990215
```