### PR TITLE
Made createpart have correct values

### DIFF
--- a/MainModule/Server/Dependencies/Assets/F3X Deps.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/F3X Deps.rbxmx
@@ -32017,14 +32017,20 @@ function CreatePart(PartType)
 	elseif PartType == 'Seat' then
 		NewPart = Instance.new('Seat')
 		NewPart.Size = Vector3.new(4, 1, 2)
+		NewPart.BrickColor = BrickColor.Black()
 
 	elseif PartType == 'Vehicle Seat' then
 		NewPart = Instance.new('VehicleSeat')
 		NewPart.Size = Vector3.new(4, 1, 2)
+		NewPart.BrickColor = BrickColor.Black()
 
 	elseif PartType == 'Spawn' then
 		NewPart = Instance.new('SpawnLocation')
-		NewPart.Size = Vector3.new(4, 1, 2)
+		NewPart.Size = Vector3.new(6, 1, 6)
+		local SpawnDecal = Instance.new('Decal')
+		SpawnDecal.Face = Enum.NormalId.Top
+		SpawnDecal.Texture = 'rbxasset://textures/SpawnLocation.png'
+		SpawnDecal.Parent = NewPart
 	end
 
 	-- Make part surfaces smooth


### PR DESCRIPTION
Currently creating `Seat`s, `VehicleSeat`s and `SpawnLocation`s has bad UX because they have incorrect default values making them hard to distinguish from other parts.
This makes them have the same defaults as studio making them easily differenciable from other parts.

I have created a pull for this in the upstream F3X repository 2 years ago but the repo is inactive so I'm going to add this here as well.