### PR TITLE
Fix :size causing small players to slide around

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3790,7 +3790,7 @@ return function(Vargs, env)
 					elseif ResizedCharValue and ResizedCharValue*num < sizeLimit then
 						char:SetAttribute("ResizedCharValue", ResizedCharValue * num)
 					else
-						Functions.Hint(`Cannot resize {service.FormatPlayer(v)}'s character by {tonumber(args[2] or 1)}: size limit exceeded.`, {plr})
+						Functions.Hint(string.format("Cannot resize %s's character by %f%%: size limit exceeded.", service.FormatPlayer(v), num), {plr})
 						continue
 					end
 

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3765,12 +3765,12 @@ return function(Vargs, env)
 				end
 
 				local function fixDensity(char)
-					for _, charpart in char:GetChildren() do
-						if charpart:IsA("MeshPart") or charpart:IsA("Part") then
-							local defaultprops = PhysicalProperties.new(charpart.Material)
-							local density = defaultprops.Density / char:GetAttribute("ResizedCharValue") ^ 3
+					for _, charPart in char:GetChildren() do
+						if charPart:IsA("MeshPart") or charPart:IsA("Part") then
+							local defaultprops = PhysicalProperties.new(charPart.Material)
+							local density = defaultprops.Density / char:GetAttribute("Adonis_Resize") ^ 3
 
-							charpart.CustomPhysicalProperties = PhysicalProperties.new(density, defaultprops.Friction, defaultprops.Elasticity)
+							charPart.CustomPhysicalProperties = PhysicalProperties.new(density, defaultprops.Friction, defaultprops.Elasticity)
 						end
 					end
 				end

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3769,7 +3769,6 @@ return function(Vargs, env)
 						if charpart:IsA("MeshPart") or charpart:IsA("Part") then
 							local defaultprops = PhysicalProperties.new(charpart.Material)
 							local density = defaultprops.Density / char:GetAttribute("ResizedCharValue")^3
-							print(`DENSITY = {density}`)
 							
 							charpart.CustomPhysicalProperties = PhysicalProperties.new(density, defaultprops.Friction, defaultprops.Elasticity)
 						end

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3756,25 +3756,25 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local sizeLimit = Settings.SizeLimit or 20
 				local num = math.clamp(tonumber(args[2]) or 1, 0.001, sizeLimit) -- Size limit exceeding over 20 would be unnecessary and may potientially create massive lag !!
-				
+
 				if not args[2] or not tonumber(args[2]) then
 					num = 1
 					Functions.Hint("Size changed to 1 [Argument #2 (size multiplier) wasn't supplied correctly.]", {plr})
 				elseif tonumber(args[2]) and tonumber(args[2]) > sizeLimit then
 					Functions.Hint(`Size changed to the maximum {num} [Argument #2 (size multiplier) went over the size limit]`, {plr})
 				end
-				
+
 				local function fixDensity(char)
 					for _, charpart in char:GetChildren() do
 						if charpart:IsA("MeshPart") or charpart:IsA("Part") then
 							local defaultprops = PhysicalProperties.new(charpart.Material)
-							local density = defaultprops.Density / char:GetAttribute("ResizedCharValue")^3
-							
+							local density = defaultprops.Density / char:GetAttribute("ResizedCharValue") ^ 3
+
 							charpart.CustomPhysicalProperties = PhysicalProperties.new(density, defaultprops.Friction, defaultprops.Elasticity)
 						end
 					end
 				end
-				
+
 				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local human = char and char:FindFirstChildOfClass("Humanoid")
@@ -3784,11 +3784,11 @@ return function(Vargs, env)
 						continue
 					end
 					
-					local ResizedCharValue = char:GetAttribute("ResizedCharValue")
-					if not ResizedCharValue then
-						char:SetAttribute("ResizedCharValue", num)
-					elseif ResizedCharValue and ResizedCharValue*num < sizeLimit then
-						char:SetAttribute("ResizedCharValue", ResizedCharValue * num)
+					local resizeAttributeValue = char:GetAttribute("Adonis_Resize")
+					if not resizeAttributeValue then
+						char:SetAttribute("Adonis_Resize", num)
+					elseif resizeAttributeValue * num < sizeLimit then
+						char:SetAttribute("Adonis_Resize", resizeAttributeValue * num)
 					else
 						Functions.Hint(string.format("Cannot resize %s's character by %g%%: size limit exceeded.", service.FormatPlayer(v), num*100), {plr})
 						continue

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3790,7 +3790,7 @@ return function(Vargs, env)
 					elseif ResizedCharValue and ResizedCharValue*num < sizeLimit then
 						char:SetAttribute("ResizedCharValue", ResizedCharValue * num)
 					else
-						Functions.Hint(string.format("Cannot resize %s's character by %f%%: size limit exceeded.", service.FormatPlayer(v), num), {plr})
+						Functions.Hint(string.format("Cannot resize %s's character by %g%%: size limit exceeded.", service.FormatPlayer(v), num*100), {plr})
 						continue
 					end
 

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3756,14 +3756,26 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local sizeLimit = Settings.SizeLimit or 20
 				local num = math.clamp(tonumber(args[2]) or 1, 0.001, sizeLimit) -- Size limit exceeding over 20 would be unnecessary and may potientially create massive lag !!
-
+				
 				if not args[2] or not tonumber(args[2]) then
 					num = 1
 					Functions.Hint("Size changed to 1 [Argument #2 (size multiplier) wasn't supplied correctly.]", {plr})
 				elseif tonumber(args[2]) and tonumber(args[2]) > sizeLimit then
 					Functions.Hint(`Size changed to the maximum {num} [Argument #2 (size multiplier) went over the size limit]`, {plr})
 				end
-
+				
+				local function fixDensity(char)
+					for _, charpart in char:GetChildren() do
+						if charpart:IsA("MeshPart") or charpart:IsA("Part") then
+							local defaultprops = PhysicalProperties.new(charpart.Material)
+							local density = defaultprops.Density / char:GetAttribute("ResizedCharValue")^3
+							print(`DENSITY = {density}`)
+							
+							charpart.CustomPhysicalProperties = PhysicalProperties.new(density, defaultprops.Friction, defaultprops.Elasticity)
+						end
+					end
+				end
+				
 				for _, v in service.GetPlayers(plr, args[1]) do
 					local char = v.Character
 					local human = char and char:FindFirstChildOfClass("Humanoid")
@@ -3772,13 +3784,14 @@ return function(Vargs, env)
 						Functions.Hint(`Cannot resize {service.FormatPlayer(v)}'s character: humanoid and/or character doesn't exist!`, {plr})
 						continue
 					end
-
-					if not Variables.SizedCharacters[char] then
-						Variables.SizedCharacters[char] = num
-					elseif Variables.SizedCharacters[char] and Variables.SizedCharacters[char]*num < sizeLimit then
-						Variables.SizedCharacters[char] = Variables.SizedCharacters[char]*num
+					
+					local ResizedCharValue = char:GetAttribute("ResizedCharValue")
+					if not ResizedCharValue then
+						char:SetAttribute("ResizedCharValue", num)
+					elseif ResizedCharValue and ResizedCharValue*num < sizeLimit then
+						char:SetAttribute("ResizedCharValue", ResizedCharValue * num)
 					else
-						Functions.Hint(string.format("Cannot resize %s's character by %f%%: size limit exceeded.", service.FormatPlayer(v), num*100), {plr})
+						Functions.Hint(`Cannot resize {service.FormatPlayer(v)}'s character by {tonumber(args[2] or 1)}: size limit exceeded.`, {plr})
 						continue
 					end
 
@@ -3788,6 +3801,7 @@ return function(Vargs, env)
 								val.Value *= num
 							end
 						end
+						fixDensity(char)
 					elseif human and human.RigType == Enum.HumanoidRigType.R6 then
 						local motors = {}
 						table.insert(motors, char.HumanoidRootPart:FindFirstChild("RootJoint"))
@@ -3814,6 +3828,7 @@ return function(Vargs, env)
 								v.Scale *= num
 							end
 						end
+						fixDensity(char)
 					end
 				end
 			end

--- a/MainModule/Server/Core/Variables.lua
+++ b/MainModule/Server/Core/Variables.lua
@@ -115,8 +115,6 @@ return function(Vargs, GetEnv)
 
 		LocalEffects = {};
 
-		SizedCharacters = {};
-
 		BundleCache = {};
 
 		TrackingTable = {};


### PR DESCRIPTION
- Added code to adjust character density based on size to avoid sliding around while small (due to roblox clamping density to 100, if you go below 10% of normal character size you can start to slide. But hey, at least it's better)
- Replaced `Variables.SizedCharacters` with an attribute on the character so it clears when that character is destroyed