### PR TITLE
Add ":starterscript" command

### DIFF
--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1070,23 +1070,25 @@ return function(Vargs, env)
 
 		CreateStarterScript = {
 			Prefix = Settings.Prefix;
-			Commands = {"starterscript","starters"};
+			Commands = {"starterscript", "clientstarterscript", "starterclientscript"};
 			Args = {"code"};
-			Description = "Executes the given code on the client when each player respawns";
+			Description = "Executes the given code on everyone's client upon respawn";
 			AdminLevel = "Admins";
 			NoFilter = true;
 			Function = function(plr: Player, args: {string})
+				assert(args[2], "Missing LocalScript code (argument #1)")
+
 				local bytecode = Core.Bytecode(args[1])
 				assert(string.find(bytecode, "\27Lua"), `LocalScript unable to be created; {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
 
 				local new = Core.NewScript("LocalScript", args[1], true)
-				new.Name = "AdonisStarterScript"
+				new.Name = "[Adonis] StarterScript"
+				new.Parent = service.StarterGui
 				new.Disabled = false
-				new.Parent = game:GetService("StarterGui")
-				Functions.Hint(`Created starter script`, {plr})
+				Functions.Hint("Created starter script", {plr})
 			end
 		};
-		
+
 		Note = {
 			Prefix = Settings.Prefix;
 			Commands = {"note", "writenote", "makenote"};

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1076,7 +1076,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			NoFilter = true;
 			Function = function(plr: Player, args: {string})
-				assert(args[2], "Missing LocalScript code (argument #1)")
+				assert(args[1], "Missing LocalScript code (argument #1)")
 
 				local bytecode = Core.Bytecode(args[1])
 				assert(string.find(bytecode, "\27Lua"), `LocalScript unable to be created; {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1068,6 +1068,25 @@ return function(Vargs, env)
 			end
 		};
 
+		CreateStarterScript = {
+			Prefix = Settings.Prefix;
+			Commands = {"starterscript","starters"};
+			Args = {"code"};
+			Description = "Executes the given code on the client when each player respawns";
+			AdminLevel = "Admins";
+			NoFilter = true;
+			Function = function(plr: Player, args: {string})
+				local bytecode = Core.Bytecode(args[1])
+				assert(string.find(bytecode, "\27Lua"), `LocalScript unable to be created; {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
+
+				local new = Core.NewScript("LocalScript", args[1], true)
+				new.Name = "AdonisStarterScript"
+				new.Disabled = false
+				new.Parent = game:GetService("StarterGui")
+				Functions.Hint(`Created starter script`, {plr})
+			end
+		};
+		
 		Note = {
 			Prefix = Settings.Prefix;
 			Commands = {"note", "writenote", "makenote"};


### PR DESCRIPTION
The ":cs" command is useful for a variety of reasons. If I need to display a dependent message during an in-game event, I can use the command to do this easily. It is restricted in the way that I need to rerun this command each time a player joins, and I've had to create some workarounds due to this limitation. While large scripts are not usually ran with :cs, I believe adding a :starterscript command would make things much easier.