### PR TITLE
Added a better and much faster base64 implementation

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -311,62 +311,140 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
-		Base64Encode = function(data)
-			local sub = string.sub
-			local byte = string.byte
-			local gsub = string.gsub
+		-- Thanks to Tiffany352 for this base64 implementation!
 
-			return (gsub(gsub(data, '.', function(x)
-				local r, b = "", byte(x)
-				for i = 8, 1, -1 do
-					r ..= (b % 2 ^ i - b % 2 ^ (i - 1) > 0 and '1' or '0')
-				end
-				return r;
-			end) .. '0000', '%d%d%d?%d?%d?%d?', function(x)
-				if #(x) < 6 then
-					return ''
-				end
-				local c = 0
-				for i = 1, 6 do
-					c += (sub(x, i, i) == '1' and 2 ^ (6 - i) or 0)
-				end
-				return sub('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/', c + 1, c + 1)
-			end)..({
-				'',
-				'==',
-				'='
-			})[#(data) % 3 + 1])
+		Base64Encode = function(str)
+			local floor = math.floor
+			local char = string.char
+			local nOut = 0
+			local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+			local strLen = #str
+			local out = table.create(math.ceil(strLen / 0.75))
+
+			-- 3 octets become 4 hextets
+			for i = 1, strLen - 2, 3 do
+				local b1, b2, b3 = str:byte(i, i + 3)
+				local word = b3 + b2 * 256 + b1 * 256 * 256
+
+				local h4 = word % 64 + 1
+				word = floor(word / 64)
+				local h3 = word % 64 + 1
+				word = floor(word / 64)
+				local h2 = word % 64 + 1
+				word = floor(word / 64)
+				local h1 = word % 64 + 1
+
+				out[nOut + 1] = alphabet:sub(h1, h1)
+				out[nOut + 2] = alphabet:sub(h2, h2)
+				out[nOut + 3] = alphabet:sub(h3, h3)
+				out[nOut + 4] = alphabet:sub(h4, h4)
+				nOut = nOut + 4
+			end
+
+			local remainder = strLen % 3
+
+			if remainder == 2 then
+				-- 16 input bits -> 3 hextets (2 full, 1 partial)
+				local b1, b2 = str:byte(-2, -1)
+				-- partial is 4 bits long, leaving 2 bits of zero padding ->
+				-- offset = 4
+				local word = b2 * 4 + b1 * 4 * 256
+
+				local h3 = word % 64 + 1
+				word = floor(word / 64)
+				local h2 = word % 64 + 1
+				word = floor(word / 64)
+				local h1 = word % 64 + 1
+
+				out[nOut + 1] = alphabet:sub(h1, h1)
+				out[nOut + 2] = alphabet:sub(h2, h2)
+				out[nOut + 3] = alphabet:sub(h3, h3)
+				out[nOut + 4] = "="
+			elseif remainder == 1 then
+				-- 8 input bits -> 2 hextets (2 full, 1 partial)
+				local b1 = str:byte(-1, -1)
+				-- partial is 2 bits long, leaving 4 bits of zero padding ->
+				-- offset = 16
+				local word = b1 * 16
+
+				local h2 = word % 64 + 1
+				word = floor(word / 64)
+				local h1 = word % 64 + 1
+
+				out[nOut + 1] = alphabet:sub(h1, h1)
+				out[nOut + 2] = alphabet:sub(h2, h2)
+				out[nOut + 3] = "="
+				out[nOut + 4] = "="
+			end
+			-- if the remainder is 0, then no work is needed
+
+			return table.concat(out, "")
 		end;
 
-		Base64Decode = function(data)
-			local sub = string.sub
-			local gsub = string.gsub
-			local find = string.find
+		Base64Decode = function(str)
+			local floor = math.floor
 			local char = string.char
+			local nOut = 0
+			local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+			local strLen = #str
+			local out = table.create(math.ceil(strLen * 0.75))
+			local acc = 0
+			local nAcc = 0
 
-			local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+			local alphabetLut = {}
+			for i = 1, #alphabet do
+				alphabetLut[alphabet:sub(i, i)] = i - 1
+			end
 
-			data = gsub(data, `[^{b}=]`, '')
+			-- 4 hextets become 3 octets
+			for i = 1, strLen do
+				local ch = str:sub(i, i)
+				local byte = alphabetLut[ch]
+				if byte then
+					acc = acc * 64 + byte
+					nAcc += 1
+				end
 
-			return (gsub(gsub(data, '.', function(x)
-				if x == '=' then
-					return ''
+				if nAcc == 4 then
+					local b3 = acc % 256
+					acc = floor(acc / 256)
+					local b2 = acc % 256
+					acc = floor(acc / 256)
+					local b1 = acc % 256
+
+					out[nOut + 1] = char(b1)
+					out[nOut + 2] = char(b2)
+					out[nOut + 3] = char(b3)
+					nOut += 3
+					nAcc = 0
+					acc = 0
 				end
-				local r, f = '', (find(b, x) - 1)
-				for i = 6, 1, -1 do
-					r ..= (f % 2 ^ i - f % 2 ^ (i - 1) > 0 and '1' or '0')
-				end
-				return r;
-			end), '%d%d%d?%d?%d?%d?%d?%d?', function(x)
-				if #x ~= 8 then
-					return ''
-				end
-				local c = 0
-				for i = 1, 8 do
-					c += (sub(x, i, i) == '1' and 2 ^ (8 - i) or 0)
-				end
-				return char(c)
-			end))
+			end
+
+			if nAcc == 3 then
+				-- 3 hextets -> 16 bit output
+				acc *= 64
+				acc = floor(acc / 256)
+				local b2 = acc % 256
+				acc = floor(acc / 256)
+				local b1 = acc % 256
+
+				out[nOut + 1] = char(b1)
+				out[nOut + 2] = char(b2)
+			elseif nAcc == 2 then
+				-- 2 hextets -> 8 bit output
+				acc *= 64
+				acc = floor(acc / 256)
+				acc *= 64
+				acc = floor(acc / 256)
+				local b1 = acc % 256
+
+				out[nOut + 1] = char(b1)
+			elseif nAcc == 1 then
+				error("Base64 has invalid length")
+			end
+
+			return table.concat(out, "")
 		end;
 
 		GetGuiData = function(args)

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -854,61 +854,140 @@ return function(Vargs, GetEnv)
 		end;
 		--
 
-		Base64Encode = function(data)
-			local sub = string.sub
-			local byte = string.byte
-			local gsub = string.gsub
+		-- Thanks to Tiffany352 for this base64 implementation!
 
-			return (gsub(gsub(data, '.', function(x)
-				local r, b = "", byte(x)
-				for i = 8, 1, -1 do
-					r ..= (b % 2 ^ i - b % 2 ^ (i - 1) > 0 and '1' or '0')
-				end
-				return r;
-			end) .. '0000', '%d%d%d?%d?%d?%d?', function(x)
-				if #(x) < 6 then
-					return ''
-				end
-				local c = 0
-				for i = 1, 6 do
-					c += (sub(x, i, i) == '1' and 2 ^ (6 - i) or 0)
-				end
-				return sub('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/', c + 1, c + 1)
-			end)..({
-				'',
-				'==',
-				'='
-			})[#(data) % 3 + 1])
+		Base64Encode = function(str)
+			local floor = math.floor
+			local char = string.char
+			local nOut = 0
+			local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+			local strLen = #str
+			local out = table.create(math.ceil(strLen / 0.75))
+
+			-- 3 octets become 4 hextets
+			for i = 1, strLen - 2, 3 do
+				local b1, b2, b3 = str:byte(i, i + 3)
+				local word = b3 + b2 * 256 + b1 * 256 * 256
+
+				local h4 = word % 64 + 1
+				word = floor(word / 64)
+				local h3 = word % 64 + 1
+				word = floor(word / 64)
+				local h2 = word % 64 + 1
+				word = floor(word / 64)
+				local h1 = word % 64 + 1
+
+				out[nOut + 1] = alphabet:sub(h1, h1)
+				out[nOut + 2] = alphabet:sub(h2, h2)
+				out[nOut + 3] = alphabet:sub(h3, h3)
+				out[nOut + 4] = alphabet:sub(h4, h4)
+				nOut = nOut + 4
+			end
+
+			local remainder = strLen % 3
+
+			if remainder == 2 then
+				-- 16 input bits -> 3 hextets (2 full, 1 partial)
+				local b1, b2 = str:byte(-2, -1)
+				-- partial is 4 bits long, leaving 2 bits of zero padding ->
+				-- offset = 4
+				local word = b2 * 4 + b1 * 4 * 256
+
+				local h3 = word % 64 + 1
+				word = floor(word / 64)
+				local h2 = word % 64 + 1
+				word = floor(word / 64)
+				local h1 = word % 64 + 1
+
+				out[nOut + 1] = alphabet:sub(h1, h1)
+				out[nOut + 2] = alphabet:sub(h2, h2)
+				out[nOut + 3] = alphabet:sub(h3, h3)
+				out[nOut + 4] = "="
+			elseif remainder == 1 then
+				-- 8 input bits -> 2 hextets (2 full, 1 partial)
+				local b1 = str:byte(-1, -1)
+				-- partial is 2 bits long, leaving 4 bits of zero padding ->
+				-- offset = 16
+				local word = b1 * 16
+
+				local h2 = word % 64 + 1
+				word = floor(word / 64)
+				local h1 = word % 64 + 1
+
+				out[nOut + 1] = alphabet:sub(h1, h1)
+				out[nOut + 2] = alphabet:sub(h2, h2)
+				out[nOut + 3] = "="
+				out[nOut + 4] = "="
+			end
+			-- if the remainder is 0, then no work is needed
+
+			return table.concat(out, "")
 		end;
 
-		Base64Decode = function(data)
-			local sub = string.sub
-			local gsub = string.gsub
-			local find = string.find
+		Base64Decode = function(str)
+			local floor = math.floor
 			local char = string.char
+			local nOut = 0
+			local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+			local strLen = #str
+			local out = table.create(math.ceil(strLen * 0.75))
+			local acc = 0
+			local nAcc = 0
 
-			local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+			local alphabetLut = {}
+			for i = 1, #alphabet do
+				alphabetLut[alphabet:sub(i, i)] = i - 1
+			end
 
-			data = gsub(data, `[^{b}=]`, '')
-			return (gsub(gsub(data, '.', function(x)
-				if x == '=' then
-					return ''
+			-- 4 hextets become 3 octets
+			for i = 1, strLen do
+				local ch = str:sub(i, i)
+				local byte = alphabetLut[ch]
+				if byte then
+					acc = acc * 64 + byte
+					nAcc += 1
 				end
-				local r, f = '', (find(b, x) - 1)
-				for i = 6, 1, -1 do
-					r ..= (f % 2 ^ i - f % 2 ^ (i - 1) > 0 and '1' or '0')
+
+				if nAcc == 4 then
+					local b3 = acc % 256
+					acc = floor(acc / 256)
+					local b2 = acc % 256
+					acc = floor(acc / 256)
+					local b1 = acc % 256
+
+					out[nOut + 1] = char(b1)
+					out[nOut + 2] = char(b2)
+					out[nOut + 3] = char(b3)
+					nOut += 3
+					nAcc = 0
+					acc = 0
 				end
-				return r;
-			end), '%d%d%d?%d?%d?%d?%d?%d?', function(x)
-				if #x ~= 8 then
-					return ''
-				end
-				local c = 0
-				for i = 1, 8 do
-					c += (sub(x, i, i) == '1' and 2 ^ (8 - i) or 0)
-				end
-				return char(c)
-			end))
+			end
+
+			if nAcc == 3 then
+				-- 3 hextets -> 16 bit output
+				acc *= 64
+				acc = floor(acc / 256)
+				local b2 = acc % 256
+				acc = floor(acc / 256)
+				local b1 = acc % 256
+
+				out[nOut + 1] = char(b1)
+				out[nOut + 2] = char(b2)
+			elseif nAcc == 2 then
+				-- 2 hextets -> 8 bit output
+				acc *= 64
+				acc = floor(acc / 256)
+				acc *= 64
+				acc = floor(acc / 256)
+				local b1 = acc % 256
+
+				out[nOut + 1] = char(b1)
+			elseif nAcc == 1 then
+				error("Base64 has invalid length")
+			end
+
+			return table.concat(out, "")
 		end;
 
 		Hint = function(message, players, duration)

--- a/MainModule/Server/Shared/Credits.lua
+++ b/MainModule/Server/Shared/Credits.lua
@@ -69,7 +69,7 @@ return {
 		{Text = "@GitHub supercoolspy",		Desc = "GitHub Contributor"};
 	};
 	Misc = {
-		{Text = "Kein-Hong Man",		Desc = "Creator of the Yueliang (Lua bytecode compiler in loadstring module). Also created LuLu VM, the first Lua bytecode interpreter used in Adonis (no longer used)"};
+		{Text = "Kein-Hong Man",			Desc = "Creator of the Yueliang (Lua bytecode compiler in loadstring module). Also created LuLu VM, the first Lua bytecode interpreter used in Adonis (no longer used)"};
 		{Text = "Stravant/JustAPerson",		Desc = "Wrote LBI (no longer used)"};
 		{Text = "darkelementallord",		Desc = "Updated some guis"};
 		{Text = "TheFurryFish",				Desc = "Gave me some dank ideas like local particles and some loading related things; and helped debug"};
@@ -83,7 +83,8 @@ return {
 		{Text = "Bubby4j",					Desc = "Used their \"Refresh Icon\" image (default theme)"};
 		{Text = "meafers",					Desc = "Suggested some stuff"};
 		{Text = "Osyris",					Desc = "Wrote 't', an open-source typechecking library"};
-		{Text = "buildthomas",					Desc = "Wrote 'MockDataStoreService', an open-source mock DataStoreService replacement library"};
+		{Text = "buildthomas",				Desc = "Wrote 'MockDataStoreService', an open-source mock DataStoreService replacement library"};
+		{Text = "Tiffany352",				Desc = "Made a faster base64 implementation"};
 		{Text = "",							Desc = ""};
 		{Text = "~ :) ~",					Desc = ""};
 		{Text = "Donors",					Desc = "Donors keep the wheels turning ;)"};


### PR DESCRIPTION
This base64 implementation is much faster than the current one.

Benchmark for both with Luau optimisations. \\/
Old: 160.56607509899186 seconds
New: 9.714655200194102 seconds

This one added to Adonis doesn't have all Luau optimisation because Adonis uses fenv. But if anyone wants a Luau optimised one then here it is \\/
```lua
-- Thanks to Tiffany352 for this base64 implementation!

local function base64Encode(str)
	local nOut = 0
	local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
	local strLen = string.len(str)
	local out = table.create(math.ceil(strLen / 0.75))

	-- 3 octets become 4 hextets
	for i = 1, strLen - 2, 3 do
		local b1, b2, b3 = string.byte(str, i, i + 3)
		local word = b3 + b2 * 256 + b1 * 256 * 256

		local h4 = word % 64 + 1
		word = math.floor(word / 64)
		local h3 = word % 64 + 1
		word = math.floor(word / 64)
		local h2 = word % 64 + 1
		word = math.floor(word / 64)
		local h1 = word % 64 + 1

		out[nOut + 1] = string.sub(alphabet, h1, h1)
		out[nOut + 2] = string.sub(alphabet, h2, h2)
		out[nOut + 3] = string.sub(alphabet, h3, h3)
		out[nOut + 4] = string.sub(alphabet, h4, h4)
		nOut += 4
	end

	local remainder = strLen % 3

	if remainder == 2 then
		-- 16 input bits -> 3 hextets (2 full, 1 partial)
		local b1, b2 = string.byte(str, -2, -1)
		-- partial is 4 bits long, leaving 2 bits of zero padding ->
		-- offset = 4
		local word = b2 * 4 + b1 * 4 * 256

		local h3 = word % 64 + 1
		word = math.floor(word / 64)
		local h2 = word % 64 + 1
		word = math.floor(word / 64)
		local h1 = word % 64 + 1

		out[nOut + 1] = string.sub(alphabet, h1, h1)
		out[nOut + 2] = string.sub(alphabet, h2, h2)
		out[nOut + 3] = string.sub(alphabet, h3, h3)
		out[nOut + 4] = "="
	elseif remainder == 1 then
		-- 8 input bits -> 2 hextets (2 full, 1 partial)
		local b1 = string.byte(str, -1, -1)
		-- partial is 2 bits long, leaving 4 bits of zero padding ->
		-- offset = 16
		local word = b1 * 16

		local h2 = word % 64 + 1
		word = math.floor(word / 64)
		local h1 = word % 64 + 1

		out[nOut + 1] = string.sub(alphabet, h1, h1)
		out[nOut + 2] = string.sub(alphabet, h2, h2)
		out[nOut + 3] = "="
		out[nOut + 4] = "="
	end
	-- if the remainder is 0, then no work is needed

	return table.concat(out, "")
end

local function base64Decode(str)
	local nOut = 0
	local alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
	local strLen = string.len(str)
	local out = table.create(math.ceil(strLen * 0.75))
	local acc = 0
	local nAcc = 0

	local alphabetLut = {}
	for i = 1, string.len(alphabet) do
		alphabetLut[string.sub(alphabet, i, i)] = i - 1
	end

	-- 4 hextets become 3 octets
	for i = 1, strLen do
		local ch = string.sub(str, i, i)
		local byte = alphabetLut[ch]
		if byte then
			acc = acc * 64 + byte
			nAcc += 1
		end

		if nAcc == 4 then
			local b3 = acc % 256
			acc = math.floor(acc / 256)
			local b2 = acc % 256
			acc = math.floor(acc / 256)
			local b1 = acc % 256

			out[nOut + 1] = string.char(b1)
			out[nOut + 2] = string.char(b2)
			out[nOut + 3] = string.char(b3)
			nOut += 3
			nAcc = 0
			acc = 0
		end
	end

	if nAcc == 3 then
		-- 3 hextets -> 16 bit output
		acc *= 64
		acc = math.floor(acc / 256)
		local b2 = acc % 256
		acc = math.floor(acc / 256)
		local b1 = acc % 256

		out[nOut + 1] = string.char(b1)
		out[nOut + 2] = string.char(b2)
	elseif nAcc == 2 then
		-- 2 hextets -> 8 bit output
		acc *= 64
		acc = math.floor(acc / 256)
		acc *= 64
		acc = math.floor(acc / 256)
		local b1 = acc % 256

		out[nOut + 1] = string.char(b1)
	elseif nAcc == 1 then
		error("Base64 has invalid length")
	end

	return table.concat(out, "")
end
```

Adapted from: <https://gist.github.com/tiffany352/c9850885c8be5b1dfcd79becaf47a3f6>