### PR TITLE
Made chatservice handlers wait for 5 minutes. Fixes bugs in games with many chatsystems

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -114,7 +114,7 @@ return function(Vargs, GetEnv)
 
 			--// Support for legacy Lua chat system
 			--// ChatService mute handler (credit to Coasterteam)
-			local chatService = Functions.GetChatService()
+			local chatService = Functions.GetChatService(300)
 			if chatService then
 				chatService:RegisterProcessCommandsFunction("ADONIS_CMD", function(speakerName, message)
 					local speaker = chatService:GetSpeaker(speakerName)

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -114,6 +114,7 @@ return function(Vargs, GetEnv)
 
 			--// Support for legacy Lua chat system
 			--// ChatService mute handler (credit to Coasterteam)
+			AddLog("Script", "Starting loading of legacy chatservice handler")
 			local chatService = Functions.GetChatService(300)
 			if chatService then
 				chatService:RegisterProcessCommandsFunction("ADONIS_CMD", function(speakerName, message)

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -451,10 +451,10 @@ return function(Vargs, GetEnv)
 			return fakePlayer
 		end;
 
-		GetChatService = function()
+		GetChatService = function(waitTime)
 			local isTextChat = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService
-			local chatHandler = service.ServerScriptService:WaitForChild("ChatServiceRunner", isTextChat and 0.2 or 120)
-			local chatMod = chatHandler and chatHandler:WaitForChild("ChatService", isTextChat and 0.2 or 120)
+			local chatHandler = service.ServerScriptService:WaitForChild("ChatServiceRunner", waitTime or isTextChat and 0.2 or 145)
+			local chatMod = chatHandler and chatHandler:WaitForChild("ChatService", waitTime or isTextChat and 0.2 or 145)
 
 			if chatMod then
 				return require(chatMod)


### PR DESCRIPTION
This makes the legacy chatservice wait for 5 minutes to check if there is a chatservice even if textchatservice is enabled.

This fixes *most* bugs in games where there are multiple chat systems. 5 minutes is probably long enough for most usecases. I could have made it wait for even longer but this seems to suffice.