### PR TITLE
Made player and donor commands not save in oldlogs

### DIFF
--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -121,15 +121,19 @@ return function(Vargs, GetEnv)
 				local temp = {}
 
 				for _, m in logsToSave do
-					local newTab = type(m) == "table" and service.CloneTable(m) or m
-					if type(m) == "table" and newTab.Player then
-						local p = newTab.Player
-						newTab.Player = {
-							Name = p.Name;
-							UserId = p.UserId;
-						}
+					local isTable = (type(m) == "table")
+					local newTab = isTable and service.CloneTable(m) or m
+
+					if isTable and not newTab.NoSave or not isTable then
+						if isTable and newTab.Player then
+							local p = newTab.Player
+							newTab.Player = {
+								Name = p.Name;
+								UserId = p.UserId;
+							}
+						end
+						table.insert(temp, newTab)--{Time = m.Time; Text = `{m.Text}: {m.Desc}`; Desc = m.Desc})
 					end
-					table.insert(temp, newTab)--{Time = m.Time; Text = `{m.Text}: {m.Desc}`; Desc = m.Desc})
 				end
 
 				if oldLogs then

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -121,10 +121,10 @@ return function(Vargs, GetEnv)
 				local temp = {}
 
 				for _, m in logsToSave do
-					local isTable = (type(m) == "table")
-					local newTab = isTable and service.CloneTable(m) or m
+					local isTable = type(m) == "table"
+					local newTab = if isTable then service.CloneTable(m) else m
 
-					if isTable and not newTab.NoSave or not isTable then
+					if (isTable and not newTab.NoSave) or not isTable then
 						if isTable and newTab.Player then
 							local p = newTab.Player
 							newTab.Player = {

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -462,10 +462,12 @@ return function(Vargs, GetEnv)
 				end
 
 				if opts.CrossServer or (not isSystem and not opts.DontLog) then
+					local noSave = command.AdminLevel == "Player" or command.Donors or command.AdminLevel == 0
 					AddLog("Commands", {
 						Text = `{((opts.CrossServer and "[CRS_SERVER] ") or "")}{p.Name}`;
 						Desc = `{matched}{Settings.SplitKey}{table.concat(args, Settings.SplitKey)}`;
 						Player = p;
+						NoSave = noSave;
 					})
 
 					if Settings.ConfirmCommands then


### PR DESCRIPTION
This eases datastore usage.
It also fixes a problem where important logs can be cleared out by unimportant ones.