### PR TITLE
Fix for :bunnyhop not executing more than once

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -2441,11 +2441,11 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local bunnyScript = Deps.Assets.BunnyHop
-				bunnyScript.Name = "HippityHopitus"
 				local hat = service.Insert(110891941)
 				for i, v in service.GetPlayers(plr, args[1]) do
 					hat:Clone().Parent = v.Character
 					local clone = bunnyScript:Clone()
+					clone.Name = "HippityHopitus"
 					clone.Parent = v.Character
 					clone.Disabled = false
 				end


### PR DESCRIPTION
The bunnyScript was supposed to be renamed **after** the clone, however in this current case it's actually renamed **before** the script gets cloned, thus editing the first script's name causing the further executions to fail. This commit should fix this issue to it's intended function.