### PR TITLE
Update Anti_Cheat.lua - Add StarterPack for CoreGui check

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -295,6 +295,7 @@ return function(Vargs)
 						local coreUrls = {}
 						local backpack = Player:FindFirstChildOfClass("Backpack")
 						local character = Player.Character
+						local startergear = service.StarterPack
 						local screenshotHud = service.GuiService:FindFirstChildOfClass("ScreenshotHud")
 
 						if character then
@@ -313,6 +314,14 @@ return function(Vargs)
 							end
 						end
 
+						if startergear then
+							for _, v in ipairs(startergear:GetChildren()) do
+								if v:IsA("BackpackItem") and service.Trim(v.TextureId) ~= "" then
+									table.insert(coreUrls, service.Trim(v.TextureId))
+								end
+							end
+						end
+								
 						if screenshotHud and service.Trim(screenshotHud.CameraButtonIcon) ~= "" then
 							table.insert(coreUrls, service.Trim(screenshotHud.CameraButtonIcon))
 						end

--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -295,7 +295,7 @@ return function(Vargs)
 						local coreUrls = {}
 						local backpack = Player:FindFirstChildOfClass("Backpack")
 						local character = Player.Character
-						local startergear = service.StarterPack
+						local starterPack = service.StarterPack
 						local screenshotHud = service.GuiService:FindFirstChildOfClass("ScreenshotHud")
 
 						if character then
@@ -314,8 +314,8 @@ return function(Vargs)
 							end
 						end
 
-						if startergear then
-							for _, v in ipairs(startergear:GetChildren()) do
+						if starterPack then
+							for _, v in ipairs(starterPack:GetChildren()) do
 								if v:IsA("BackpackItem") and service.Trim(v.TextureId) ~= "" then
 									table.insert(coreUrls, service.Trim(v.TextureId))
 								end


### PR DESCRIPTION
This is because recently in my exploit logs systems which is connected to Adonis someone was kicked because of Disallowed content URL in CoreGui but the URL it gets was from one of the gears in StarterPack.