### PR TITLE
Add myself to credits

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -529,6 +529,7 @@ return function(Vargs)
 					if
 						not string.find(string.lower(Message), "failed to load", 1, true) and
 						not string.find(string.lower(Message), "meshcontentprovider failed to process", 1, true) and
+						not string.find(string.lower(Message), string.lower("GetCollisionGroups is deprecated, please use GetRegisteredCollisionGroups instead."))
 						(string.match(string.lower(Message), string.lower(v)) or string.match(Message, v))
 					then
 						return true

--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -529,7 +529,6 @@ return function(Vargs)
 					if
 						not string.find(string.lower(Message), "failed to load", 1, true) and
 						not string.find(string.lower(Message), "meshcontentprovider failed to process", 1, true) and
-						not string.find(string.lower(Message), string.lower("GetCollisionGroups is deprecated, please use GetRegisteredCollisionGroups instead."))
 						(string.match(string.lower(Message), string.lower(v)) or string.match(Message, v))
 					then
 						return true

--- a/MainModule/Server/Shared/Credits.lua
+++ b/MainModule/Server/Shared/Credits.lua
@@ -68,6 +68,7 @@ return {
 		{Text = "@GitHub WideManHost",		Desc = "GitHub Contributor"};
 		{Text = "@GitHub autodoorsdev",		Desc = "GitHub Contributor"};
 		{Text = "@GitHub Lethalitics",		Desc = "GitHub Contributor"};
+		{Text = "@GitHub Deniernal354",		Desc = "GitHub Contributor"};
 		{Text = "@GitHub RoyallyFlushed",	Desc = "GitHub Contributor"};
 		{Text = "@GitHub supercoolspy",		Desc = "GitHub Contributor"};
 		{Text = "@GitHub AlexanderDarmody",	Desc = "GitHub Contributor"};


### PR DESCRIPTION
This fixes the anti cheat crashing players if their console gets a deprecated collision group method warning. It was falsely triggered by matching `getreg` from `GetRegisteredCollisionGroups` in the warning message.