### PR TITLE
Update !playerinfo command - Mail & Phone/ID Verified Status

### DIFF
--- a/MainModule/Client/UI/Default/Profile.lua
+++ b/MainModule/Client/UI/Default/Profile.lua
@@ -109,6 +109,8 @@ return function(data, env)
 			{"Membership", player.MembershipType.Name, "The player's Roblox membership type (Premium)"},
 			{"Can Chat", data.CanChatGet[1] and boolToStr(data.CanChatGet[2]) or "[Error]", "Does the player's account settings allow them to chat?"},
 			{"Safe Chat Enabled", data.SafeChat, "[Admins Only] Does the player have safe chat applied?"},
+			{"Mail Verified", data.MailVerified, "[Admins Only] Does the player have verified their mail?"},
+			{"Phone/ID Verified", data.IDVerified, "[Admins Only] Does the player have verified their non-VoIP phone / ID?"},
 			}) do
 			generaltab:Add("TextLabel", {
 				Text = `  {v[1]}: `;

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -900,12 +900,24 @@ return function(Vargs, env)
 						local hasSafeChat = if policyInfo then
 							type(policyInfo) == "string" and policyInfo or table.find(policyInfo.AllowedExternalLinkReferences, "Discord") and "No" or "Yes"
 							else "[Redacted]"
+						
+						local mailVerif = select(2, xpcall(service.MarketplaceService.PlayerOwnsAsset, function() return "[Error]" end, service.MarketplaceService, v, 102611803))
+						local hasVerifiedMail = if elevated then
+							type(mailVerif) == "string" and mailVerif or mailVerif and "Yes" or "No"
+							else "[Redacted]"
+						
+						local idVerif = select(2, xpcall(v.IsVerified, function() return "[Error]" end, v))
+						local hasVerifiedId = if elevated then
+							type(idVerif) == "string" and idVerif or idVerif and "Yes" or "No"
+							else "[Redacted]"
 
 						Remote.RemoveGui(plr, `Profile_{v.UserId}`)
 						Remote.MakeGui(plr, "Profile", {
 							Target = v;
 							SafeChat = hasSafeChat;
 							CanChatGet = table.pack(pcall(service.Chat.CanUserChatAsync, service.Chat, v.UserId));
+							MailVerified = hasVerifiedMail;
+							IDVerified = hasVerifiedId;
 							IsDonor = Admin.CheckDonor(v);
 							GameData = gameData;
 							IsServerOwner = v.UserId == game.PrivateServerOwnerId;


### PR DESCRIPTION
This is to adapt with the new Roblox feature, Player:IsVerified(), which was released just 3 days ago, despite of the title still saying Beta, and some games like Arsenal already uses this feature for it's "Premium Servers" feature.
https://devforum.roblox.com/t/isverified-api-beta/2432501

This also includes a way for checking Mail Verified, using the MarketplaceService:PlayerOwnsAsset() to check if the Verified Bonafide hat is owned by the player. (https://www.roblox.com/catalog/102611803)

The code in the backend is a bit inspired from the SafeChat check (xpcall, conditional variable) so the code shouldn't be too messy although if there's still something wrong in the code, feel free to comment the faulty code and suggest a potential fix.

This PR have been tested across one account (my main) with Chat enabled, No SafeChat, and both of Mail & ID Verified, and also with another account with Chat also enabled, but with SafeChat enabled, Mail Verified but not ID Verified:
![RobloxPlayerBeta_JD9vk2MMmM](https://github.com/Epix-Incorporated/Adonis/assets/54766538/1406f2b3-4210-4afb-82d4-d6a998f9b67f)
Another view from the alternative account, which have no Adonis permissions at all, is also confirmed to be working correctly (3 of them says [REDACTED]):
![i_view64_U5n3mO22R4](https://github.com/Epix-Incorporated/Adonis/assets/54766538/247631de-de5f-48d1-8a59-cbf2593c3f51)
