### PR TITLE
Update BunnyHop.client.lua - use GetPropertyChangedSignal

### DIFF
--- a/MainModule/Server/Dependencies/Assets/BunnyHop.client.lua
+++ b/MainModule/Server/Dependencies/Assets/BunnyHop.client.lua
@@ -1,6 +1,7 @@
 local hum = script.Parent:FindFirstChildOfClass("Humanoid")
 
-while true do
+hum.Jump = true
+hum:GetPropertyChangedSignal("Jump"):Connect(function()
 	hum.Jump = true
-	task.wait()
-end
+end)
+hum.Jump = not hum.Jump -- in some unreliable cases this line might be needed to make GetPropertyChangedSignal trigger immediately


### PR DESCRIPTION
Almost locking hum.Jump using while loops is unreliable, and sometimes the humanoid doesn't even jump because Roblox engine will sometimes get confused whether the character should jump or not.