### PR TITLE
Update Fly.client.lua - Remove the breaking Vector3 transformation function

### DIFF
--- a/MainModule/Server/Dependencies/Assets/Fly.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Fly.client.lua
@@ -42,10 +42,6 @@ function Check()
 	end
 end
 
-function tranVec(num)
-	return Vector3.new(num, num, num)
-end
-
 function getCF(part, isFor)
 	local cframe = part.CFrame
 	local noRot = CFrame.new(cframe.p)
@@ -67,10 +63,10 @@ function Start()
 	end)
 
 	bPos.Position = part.Position
-	bPos.MaxForce = tranVec(math.huge)
+	bPos.MaxForce = math.huge
 
 	bGyro.CFrame = part.CFrame
-	bGyro.MaxTorque = tranVec(9e9)
+	bGyro.MaxTorque = 9e9
 
 	antiLoop = antiReLoop
 
@@ -150,11 +146,11 @@ function Stop()
 	human.PlatformStand = false
 
 	if bPos then
-		bPos.MaxForce = tranVec(0)
+		bPos.MaxForce = 0
 	end
 
 	if bGyro then
-		bGyro.MaxTorque = tranVec(0)
+		bGyro.MaxTorque = 0
 	end
 
 	if conn then


### PR DESCRIPTION
The commit will reverse commit f0cb4d:
https://github.com/Epix-Incorporated/Adonis/commit/f0cb4ddd50f8fc6f1d51475bf2faa64fe374a4e9

Mentioned commit breaks the fly command and will keep moving you to the void. Caused by feeding Vector3 values into the new AlignPosition and AlignOrientation, causing the values to stay at zero aka nil. The person behind this commit might be using an older or unofficial version of Adonis, or even being misled by the "bGyro" variable name while it's actually AlignOrientation behind the scenes, since only the legacy BodyMover objects request Vector3 for MaxTorque and MaxForce, the newer ones take number values instead. To fix this I removed the tranVec() function that convert numbers to Vector3 values and thus reverting the commit.
Some proofs can be seen that the new Align objects doesn't take Vector3 for MaxForce and MaxTorque but take numbers instead, and Adonis doesn't use BodyMovers for fly anymore.
![image](https://github.com/Epix-Incorporated/Adonis/assets/54766538/584b8170-415b-4590-a894-07e0c981446a)
![image](https://github.com/Epix-Incorporated/Adonis/assets/54766538/7b5d1f01-e2f9-47b3-874f-c008717fed08)
![image](https://github.com/Epix-Incorporated/Adonis/assets/54766538/4c8bf9c8-b3ac-46ab-8ed9-444bd274d16c)
