### PR TITLE
A very good addition to commands, quotation support

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1329,6 +1329,33 @@ return function(Vargs, GetEnv)
 			return ret
 		end;
 
+		ExtractArgs = function(text, numArgs)
+			local arguments = {}
+
+			local lastArgs = {}
+
+			for argument in 
+				('""'..text:gsub("\\?.", {['\\"']="\\\6ADONIS]\6"}))
+				:gsub('"(.-)"([^"]*)', function(q,n) return "\\\2ADONIS]"..q..n:gsub("%s+", "\0") end)
+				:sub(10) -- matches lenght of first temporary replace
+				:gmatch"%Z+" 
+			do
+				argument = argument:gsub("\\\6ADONIS]\6", '"'):gsub("\\\2ADONIS]", ""):gsub("\\(.)", "%1")
+
+				if not (numArgs <= (#arguments + 1) ) then
+					arguments[#arguments+1] = argument
+				else
+					table.insert(lastArgs, argument)
+				end
+			end
+
+			if (lastArgs and next(lastArgs)) then
+				arguments[#arguments + 1] = table.concat(lastArgs, " ")
+			end
+
+			return arguments
+		end;
+
 		CountTable = function(tab)
 			local num = 0
 			for i in tab do

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -443,7 +443,14 @@ return function(Vargs, GetEnv)
 
 				local cmdArgs = command.Args or command.Arguments
 				local argString = string.match(msg, `^.-{Settings.SplitKey}(.+)`) or ""
-				local args = (opts.Args or opts.Arguments) or (#cmdArgs > 0 and Functions.Split(argString, Settings.SplitKey, #cmdArgs)) or {}
+				local args
+				if (command.NoFilter) or (#cmdArgs == 1) then
+					-- Default
+					args = (opts.Args or opts.Arguments) or (#cmdArgs > 0 and Functions.Split(argString, Settings.SplitKey, #cmdArgs)) or {}
+				else
+					-- Quotation Support
+					args = (opts.Args or opts.Arguments) or (#cmdArgs > 0 and Functions.ExtractArgs(argString, #cmdArgs)) or {}
+				end
 
 				local taskName = string.format("Command :: %s : (%s)", p.Name, msg)
 


### PR DESCRIPTION
This change is a change that Adonis needs. It's a change that will revolutionize any other admin system, because they do not have this.

They do not have that what Garry's Mod has, which I even think is implemented by the Source SDK in the Console. It's quotation support.

Being able to turn this ``"%Team 1"`` into one argument ``%Team 1``.

Previously it would do something like this ``%Team`` and the rest would be for the second argument.

&nbsp;

If you want to select a specific Team for the ``:team`` command.
![image](https://github.com/Epix-Incorporated/Adonis/assets/12023782/0c91d762-84e6-4e55-b2d1-a52fadf71c77)

You'd be unable to select any specific Team because the first argument of ``:team`` gets split after a space.

What this addition does. Is that If you have it wrapped inside a quotation. e.g.

``:team "%Team 1" Team 2``

this would put everyone in "Team 1" inside Team 2.

Notice how I didn't use quotation for the second argument.

&nbsp;

&nbsp;

This is how it works.

```lua
local args
if (command.NoFilter) or (#cmdArgs == 1) then
	-- Default
	args = (opts.Args or opts.Arguments) or (#cmdArgs > 0 and Functions.Split(argString, Settings.SplitKey, #cmdArgs)) or {}
else
	-- Quotation Support
	args = (opts.Args or opts.Arguments) or (#cmdArgs > 0 and Functions.ExtractArgs(argString, #cmdArgs)) or {}
end
```

**Commands** that have **``NoFilter``** set to true, will not be affected. As well as commands that only have one total argument to pass. As example, server messages.

``NoFilter`` existed already, and I didn't see it being used in any way. But it was set on commands like ``s`` for scripts, which would break if it would use the quotation parser.

This will affect ``"``. The function ``ExtractArgs`` allows even quotation within quotations, aslong they're escaped like so ``\"``

However, ``:pm`` will require people to do

``:pm random \"Hello\"``
if they wanted to send ``"Hello"`` to someone random **with the quotations**

Theoretically, we could let the client choose which "parser" to use, but...

Right now it isn't straight forward to users, that there's a quotation support implementation. The reply box for PMs works normal though. This only affects commands.

Maybe in the future, this can somehow be changed. I tried to keep track of the "string position", but since this gsub from ``ExtractArgs`` is removing spaces and etc.

So let's say a command needs 3 arguments.
It will do quotation operations on 2 arguments, but the last one will be treated like it used to work before, but just that it will still remove quotations.

And what I wanted, was to split the text into a different splitter, keeping the "raw input string". But this is a very small issue.

Maybe with the Old version that I had, maybe there it would work. I'd ask Sceletaris for this. But for now, this works.

It's a question on which is faster and more efficient.

&nbsp;

However, for the ``:pm`` command.

This can easily be fixed, by giving the ``:pm`` command the value ``NoFilter = true`` though.

&nbsp;

``ExtractArgs`` will respect the ``#cmdArgs``. This means if there are only 3 arguments. It won't return more than 3 arguments. So the rest of the arguments will get space splitted. But still do "quotation operations".

&nbsp;

``ExtractArgs`` has some things like

``\\\6ADONIS]\6`` and ``\\\2ADONIS]``

The reason they're set-up like this. Is because if someone would be trying to send these through a command, ``ExtractArgs`` would get confused.

It uses these "character sets" to temporarily replace Quotations and stuff.

``:sub(10)`` I used to erase these.

---

I used to have an older version for this.

<details><summary>Code</summary>
<pre>
OldExtractArgs = function(text,splitKey)
	local skip = 0
	local arguments = {}
	local curString = ""

	for i = 1, text:len() do
		if (i <= skip) then continue end

		local c = text:sub(i, i)

		if (c == "\\") and (text:sub(i+1, i+1) == "\"") then
			continue
		end

		if (c == "\"") and (text:sub(i-1, i-1) ~= "\\") then
			local match = text:sub(i):match("%b\"\"")

			if (match) then
				curString = ""
				skip = i + match:len()
				arguments[#arguments + 1] = match:sub(2, -2)
			else
				curString = curString..c
			end
		elseif (c == splitKey and curString ~= "") then
			arguments[#arguments + 1] = curString
			curString = ""
		else
			if (c == splitKey and curString == "") then
				continue
			end

			curString = curString..c
		end
	end

	if (curString ~= "") then
		arguments[#arguments + 1] = curString
	end

	return arguments
end;
</pre>
</details>

But then I found a better one.


Though both seem okay. The one I added is this one
<details><summary>Code</summary>
<pre>
ExtractArgs = function(text, numArgs)
	local arguments = {}

	local lastArgs = {}

	for argument in 
		('""'..text:gsub("\\?.", {['\\"']="\\\6ADONIS]\6"}))
		:gsub('"(.-)"([^"]*)', function(q,n) return "\\\2ADONIS]"..q..n:gsub("%s+", "\0") end)
		:sub(10) -- matches lenght of first temporary replace
		:gmatch"%Z+" 
	do
		argument = argument:gsub("\\\6ADONIS]\6", '"'):gsub("\\\2ADONIS]", ""):gsub("\\(.)", "%1")

		if not (numArgs <= (#arguments + 1) ) then
			arguments[#arguments+1] = argument
		else
			table.insert(lastArgs, argument)
		end
	end

	if (lastArgs and next(lastArgs)) then
		arguments[#arguments + 1] = table.concat(lastArgs, " ")
	end

	return arguments
end;
</pre>
</details>

&nbsp;

I had this prepared for a longer time, I just never continued on it to release it.