### PR TITLE
Fixed locale handling

### DIFF
--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -1012,9 +1012,8 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 				local accountLocale = service.LocalizationService.RobloxLocaleId
 				return if accountLocale ~= "en-us" and accountLocale ~= "en" then accountLocale
 							else service.LocalizationService.SystemLocaleId
-			else
-				return "en-us"
 			end
+			return "en-us"
 		end,
 
 		GetTime = os.time;

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -1007,28 +1007,27 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 			})
 		end;
 
+		GetCurrentLocale = function()
+			if service.RunService:IsClient() then
+				local accountLocale = service.LocalizationService.RobloxLocaleId
+				return (accountLocale ~= "en-us" and accountLocale ~= "en") and accountLocale or service.LocalizationService.SystemLocaleId
+			else
+				return "en-us"
+			end
+		end,
+
 		GetTime = os.time;
 
 		FormatTime = function(optTime, options)
-			if options == true then options = {WithDate = true} end
-			if not options then options = {} end
-
+			options = (options == true) and {WithDate = true} or options or {}
 			local formatString = options.FormatString
 			if not formatString then
 				formatString = options.WithWrittenDate and "LL HH:mm:ss" or (options.WithDate and "L HH:mm:ss" or "HH:mm:ss")
 			end
 
-			local tim = DateTime.fromUnixTimestamp(optTime or service.GetTime())
-
-			if service.RunService:IsServer() then
-				return tim:FormatUniversalTime(formatString, "en-us")
-			else
-				local locale = service.Players.LocalPlayer.LocaleId
-				local success, str = pcall(function()
-					return tim:FormatLocalTime(formatString, locale) -- Show in player's local timezone and format
-				end)
-				return success and str or tim:FormatLocalTime(formatString, "en-us") -- Fallback if locale is not supported by DateTime
-			end
+			local timeObj = DateTime.fromUnixTimestamp(optTime or service.GetTime())
+			local success, value = pcall(timeObj.FormatLocalTime, timeObj, formatString, service.GetCurrentLocale())
+			return success and value or timeObj:ToIsoDate()
 		end;
 
 		FormatPlayer = function(plr, withUserId)

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -1010,7 +1010,8 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		GetCurrentLocale = function()
 			if service.RunService:IsClient() then
 				local accountLocale = service.LocalizationService.RobloxLocaleId
-				return (accountLocale ~= "en-us" and accountLocale ~= "en") and accountLocale or service.LocalizationService.SystemLocaleId
+				return if accountLocale ~= "en-us" and accountLocale ~= "en" then accountLocale
+							else service.LocalizationService.SystemLocaleId
 			else
 				return "en-us"
 			end
@@ -1019,7 +1020,8 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		GetTime = os.time;
 
 		FormatTime = function(optTime, options)
-			options = (options == true) and {WithDate = true} or options or {}
+			options = if options == true then {WithDate = true} else options or {}
+
 			local formatString = options.FormatString
 			if not formatString then
 				formatString = options.WithWrittenDate and "LL HH:mm:ss" or (options.WithDate and "L HH:mm:ss" or "HH:mm:ss")
@@ -1027,7 +1029,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 
 			local timeObj = DateTime.fromUnixTimestamp(optTime or service.GetTime())
 			local success, value = pcall(timeObj.FormatLocalTime, timeObj, formatString, service.GetCurrentLocale())
-			return success and value or timeObj:ToIsoDate()
+			return if success then value else timeObj:ToIsoDate()
 		end;
 
 		FormatPlayer = function(plr, withUserId)


### PR DESCRIPTION
- By default the users account locale is `en-us` even if they don't have it on their device which will cause timestampts to be shown in US time. This fixes it by making it so that if the users account locale is default then system locale is used instead.
- Also fixed a bug where the failsafe could fail too. This makes it use `ToIsoDate` which will never fail. Also unsupported locales would not generate an error because they are overritten internally so ISO dates only appear if there is an internal error in Roblox.