### PR TITLE
Make `:avataritem` be accessible without Donor

### DIFF
--- a/MainModule/Server/Commands/Donors.lua
+++ b/MainModule/Server/Commands/Donors.lua
@@ -311,7 +311,7 @@ return function(Vargs, env)
 			Args = {"ID"};
 			Description = "Gives yourself the avatar item that belongs to <ID>";
 			Donors = true;
-			AdminLevel = "Donors";
+			AdminLevel = "Players";
 			Function = function(plr: Player, args: {[number]:string}, data: {})
 				return Commands.AvatarItem.Function(plr, {`@{plr.Name}`, args[1]}, data)
 			end


### PR DESCRIPTION
Before the commit https://github.com/Epix-Incorporated/Adonis/commit/6f052c4860cb41d0b6d284983f34d98af9cf3206 was made you could use `:avataritem` without having donor.

This reverts the commits behavior to achieve the same effect.