### PR TITLE
Add more TextChatService functionality

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -966,6 +966,22 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
+		DisplaySystemMessageInTextChat = function(channel: TextChannel?, message, meta)
+			if service.TextChatService then
+				if not channel then
+					--// we wanna get the default channel because the new ChatSystem sucks
+					--// Please fix it Roblox
+					--// we need less strict ways to filter & receive messages
+					if service.TextChatService:FindFirstChild("TextChannels") and service.TextChatService.TextChannels:FindFirstChild("RBXGeneral") then
+						channel = service.TextChatService.TextChannels.RBXGeneral
+					end
+				end
+				if channel then
+					channel:DisplaySystemMessage(message, meta)
+				end
+			end
+		end;
+
 		SetCamProperty = function(prop,value)
 			local cam = workspace.CurrentCamera
 			if cam[prop] then

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -333,9 +333,21 @@ return function(Vargs, env)
 			Filter = true;
 			Description = "Makes a message in the chat window";
 			AdminLevel = "Admins";
-			Function = function(plr: Player, args: {string})
+			Function = function(plr: Player, args: {string}, data: {any})
 				for _, v in service.GetPlayers() do
-					Remote.Send(v, "Function", "ChatMessage", string.format("[%s] %s", Settings.SystemTitle, service.Filter(args[1], plr, v)), Color3.fromRGB(255,64,77))
+					--Remote.Send(v, "Function", "ChatMessage", string.format("[%s] %s", Settings.SystemTitle, service.Filter(args[1], plr, v)), Color3.fromRGB(255,64,77))
+					if service.TextChatService and service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService then
+						local TextToUse = args[1]
+						if data.Options.Chat ~= true then
+							TextToUse = server.Functions.EscapeRichTextTags(args[1] or "Hello world!")
+						end 
+						Remote.Send(
+							v, "Function", "DisplaySystemMessageInTextChat", nil, `{
+							string.format(`<font color="rgb(255, 64, 77)"><b>[%s]</b></font> <font color="rgb(235, 99, 108)">%s</font>`, Settings.SystemTitle, service.Filter(TextToUse), plr, v)
+							}`)
+					else 
+						Remote.Send(v, "Function", "ChatMessage", string.format("[%s] %s", Settings.SystemTitle, service.Filter(args[1], plr, v)), Color3.fromRGB(255,64,77))
+					end
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6657,6 +6657,10 @@ return function(Vargs, env)
 
 						if check then
 							table.insert(Settings.Muted, `{v.Name}:{v.UserId}`)
+							service.Events.PlayerMuted:Fire({
+								Target = v.UserId;
+								Moderator = plr.UserId;
+							})
 						end
 					end
 				end
@@ -6677,6 +6681,10 @@ return function(Vargs, env)
 							--Remote.LoadCode(v,[[if not client.Variables.CustomChat then service.StarterGui:SetCoreGuiEnabled("Chat", true) client.Variables.ChatEnabled = false end client.Variables.Muted = true]])
 						end
 					end
+					service.Events.PlayerUnMuted:Fire({
+						Target = v.UserId;
+						Moderator = plr.UserId;
+					})
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -595,9 +595,21 @@ return function(Vargs, env)
 			Filter = true;
 			Description = "Makes a message in the target player(s)'s chat window";
 			AdminLevel = "Moderators";
-			Function = function(plr: Player, args: {string})
+			Function = function(plr: Player, args: {string}, data: {any})
 				for _, v in service.GetPlayers(plr, args[1]) do
-					Remote.Send(v, "Function", "ChatMessage", service.Filter(args[2], plr, v), Color3.fromRGB(255, 64, 77))
+					if service.TextChatService and service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService then
+						local TextToUse = args[2]
+						if data.Options.Chat ~= true then
+							TextToUse = server.Functions.EscapeRichTextTags(args[2] or "Hello world!")
+						end 
+						Remote.Send(
+							v, "Function", "DisplaySystemMessageInTextChat", nil, `<font color="rgb(255, 64, 77)">{
+							service.Filter(TextToUse, plr, v)
+							}</font>`)
+					else 
+						Remote.Send(v, "Function", "ChatMessage", service.Filter(args[2], plr, v), Color3.fromRGB(255, 64, 77))
+					end
+					
 				end
 			end
 		};

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -42,7 +42,7 @@ return function(Vargs, GetEnv)
 				local function onNewTextchannel(textchannel: TextChannel)
 					AddLog("Script", `Connected to TextChannel: {textchannel.Name}`)
 					
-					if Settings.OverrideChatCallbacks then 
+					if Settings.OverrideChatCallbacks ~= false then --// Default to "on" this for all games
 						AddLog("Script", "Overriding ShouldDeliverCallback for " .. textchannel.Name)
 						textchannel.ShouldDeliverCallback = function(chatMessage, textSource)
 							if

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -38,69 +38,163 @@ return function(Vargs, GetEnv)
 		TrackTask("Thread: ChatServiceHandler", function()
 
 			--// Support for modern TextChatService
-			if service.TextChatService and service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and Settings.OverrideChatCallbacks then
-				local function onNewTextchannel(textchannel)
-					AddLog("Script", "Connected to textchannel: "..textchannel.Name)
+			if service.TextChatService and service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService then
+				local function onNewTextchannel(textchannel: TextChannel)
+					AddLog("Script", `Connected to TextChannel: {textchannel.Name}`)
+					
+					if Settings.OverrideChatCallbacks then 
+						AddLog("Script", "Overriding ShouldDeliverCallback for " .. textchannel.Name)
+						textchannel.ShouldDeliverCallback = function(chatMessage, textSource)
+							if
+								chatMessage.Status == Enum.TextChatMessageStatus.Success
+								or chatMessage.Status == Enum.TextChatMessageStatus.Sending
+							then
+								local player = service.Players:GetPlayerByUserId(textSource.UserId)
+								local slowCache = Admin.SlowCache
 
-					textchannel.ShouldDeliverCallback = function(chatMessage, textSource)
-						if
-							chatMessage.Status == Enum.TextChatMessageStatus.Success
-							or chatMessage.Status == Enum.TextChatMessageStatus.Sending
-						then
-							local player = service.Players:GetPlayerByUserId(textSource.UserId)
-							local slowCache = Admin.SlowCache
+								if not player then
+									return true
+								elseif Admin.DoHideChatCmd(player, chatMessage.Text) then -- // Hide chat commands?
+									return false
+								elseif Admin.IsMuted(player) then -- // Mute handler
+									Remote.MakeGui(player, "Notification", {
+										Title = "You are muted!";
+										Message = "You are muted and cannot talk in the chat right now.";
+										Time = 10;
+									})
 
-							if not player then
-								return true
-							elseif Admin.DoHideChatCmd(player, chatMessage.Text) then -- // Hide chat commands?
-								return false
-							elseif Admin.IsMuted(player) then -- // Mute handler
-								Remote.MakeGui(player, "Notification", {
-									Title = "You are muted!";
-									Message = "You are muted and cannot talk in the chat right now.";
-									Time = 10;
-								})
+									return false
+								elseif Admin.SlowMode and not Admin.CheckAdmin(player) and slowCache[player] and os.time() - slowCache[player] < Admin.SlowMode then
+									Remote.MakeGui(player, "Notification", {
+										Title = "You are chatting too fast!";
+										Message = string.format("[Adonis] :: Slow mode enabled! (%g second(s) remaining)", Admin.SlowMode - (os.time() - slowCache[player]));
+										Time = 10;
+									})
 
-								return false
-							elseif Admin.SlowMode and not Admin.CheckAdmin(player) and slowCache[player] and os.time() - slowCache[player] < Admin.SlowMode then
-								Remote.MakeGui(player, "Notification", {
-									Title = "You are chatting too fast!";
-									Message = string.format("[Adonis] :: Slow mode enabled! (%g second(s) remaining)", Admin.SlowMode - (os.time() - slowCache[player]));
-									Time = 10;
-								})
+									return false
+								end
 
-								return false
+								if Variables.DisguiseBindings[textSource.UserId] then -- // Disguise command handler
+									chatMessage.PrefixText = Variables.DisguiseBindings[textSource.UserId].TargetUsername..":"
+								end
+
+								if Admin.SlowMode then
+									slowCache[player] = os.time()
+								end
 							end
 
-							if Variables.DisguiseBindings[textSource.UserId] then -- // Disguise command handler
-								chatMessage.PrefixText = Variables.DisguiseBindings[textSource.UserId].TargetUsername..":"
-							end
-
-							if Admin.SlowMode then
-								slowCache[player] = os.time()
+							return true
+						end
+					else 
+						AddLog("Script", `Using the \`CanSend\` method of handling chat connectivity in channel {textchannel.Name}`)
+						server.Variables.TextChatSpeakers = {}
+						local function AddUserToTextChatSpeakers(player: Player, speaker: TextSource)
+							if not server.Variables.TextChatSpeakers[player] then
+								server.Variables.TextChatSpeakers[player] = {}
+							end 
+							table.insert(server.Variables.TextChatSpeakers[player], speaker)
+							--// Check if the player is muted or not
+							speaker:SetAttribute("OriginalCanSend", speaker.CanSend)
+							if server.Admin.IsMuted(player) then
+								speaker.CanSend = false
 							end
 						end
-
-						return true
+						local function SpeakerAdded(speaker: TextSource) 
+							if speaker.UserId and speaker.UserId > 0 then
+								local Player = service.Players:GetPlayerByUserId(speaker.UserId)
+								if Player then
+									AddUserToTextChatSpeakers(Player, speaker)
+								end
+							end
+						end
+						local function SpeakerRemoved(speaker: TextSource)
+							if speaker.UserId and speaker.UserId > 0 then
+								local Player = service.Players:GetPlayerByUserId(speaker.UserId)
+								local Tab = server.Variables.TextChatSpeakers[Player]
+								if Tab then
+									local index = table.find(Tab, speaker)
+									while index do
+										table.remove(Tab, index)
+										index = table.find(Tab, speaker)
+									end
+									task.defer(function()
+										if #Tab == 0 then
+											server.Variables.TextChatSpeakers[Player] = nil
+										end
+									end)
+								end
+							end
+						end
+						
+						textchannel.ChildAdded:Connect(function(textSource)
+							if textSource:IsA("TextSource") then
+								SpeakerAdded(textSource)
+							end
+						end)
+						
+						textchannel.ChildRemoved:Connect(function(textSource)
+							if textSource:IsA("TextSource") then
+								SpeakerRemoved(textSource)
+							end
+						end)
+						
+						for _,inst in textchannel:GetChildren() do 
+							if inst:IsA("TextSource") then
+								SpeakerAdded(inst)
+							end
+						end
+						
 					end
 				end
+				
+				--// Only set this up once
+				--// This is for commands to tell us when a player should be muted
+				if not Settings.OverrideChatCallbacks then 
+					service.Events.PlayerMuted:Connect(function(data)
+						local PlayerId = data.Target;
+						local ModId = data.Moderator;
+
+						local Player = service.Players:GetPlayerByUserId(PlayerId)
+						--// Loop through CanSend of a speaker
+						for _,speakers : TextSource in if Player then server.Variables.TextChatSpeakers[Player] or {} else {} do 
+							speakers.CanSend = false
+						end
+						if Player then
+							AddLog("Script", `Muted player {Player.Name}:{Player.UserId} using CanSend method`)
+						end
+					end)
+					service.Events.PlayerUnMuted:Connect(function(data)
+						local PlayerId = data.Target;
+						local ModId = data.Moderator;
+
+						local Player = service.Players:GetPlayerByUserId(PlayerId)
+						--// Loop through CanSend of a speaker
+						for _,speakers : TextSource in if Player then server.Variables.TextChatSpeakers[Player] or {} else {} do 
+							local original = speakers:GetAttribute("OriginalCanSend")
+							speakers.CanSend = if original ~= nil then original else true
+						end
+						if Player then
+							AddLog("Script", `UnMuted player {Player.Name}:{Player.UserId} via CanSend method`)
+						end
+					end)
+					service.Events.MutedPlayerChat_UnFiltered:Connect(function(p, ...)
+						server.Remote.Send(p, "Function", "DisplaySystemMessageInTextChat", nil, `<font color="rgb(130, 100, 130)">[Adonis Chat]: </font><b>You are muted!</b> Other players cannot see your messages.`)
+					end)
+				end
+					
 
 				local function onTextChannelsAdded(textChannels)
-					for _, v in textChannels:GetChildren() do
-						if v:IsA("TextChannel") then
-							task.spawn(onNewTextchannel, v)
-						end
-					end
-
 					textChannels.ChildAdded:Connect(function(child)
 						if child:IsA("TextChannel") then
 							task.spawn(onNewTextchannel, child)
 						end
 					end)
-				end
-
-				if service.TextChatService:FindFirstChild("TextChannels") then
-					task.spawn(pcall, onTextChannelsAdded, service.TextChatService:FindFirstChild("TextChannels"))
+				
+					for _, v in textChannels:GetChildren() do
+						if v:IsA("TextChannel") then
+							task.spawn(onNewTextchannel, v)
+						end
+					end
 				end
 
 				service.TextChatService.ChildAdded:Connect(function(child)
@@ -108,6 +202,10 @@ return function(Vargs, GetEnv)
 						task.spawn(onTextChannelsAdded, child)
 					end
 				end)
+				
+				if service.TextChatService:FindFirstChild("TextChannels") then
+					task.spawn(pcall, onTextChannelsAdded, service.TextChatService:FindFirstChild("TextChannels"))
+				end
 
 				AddLog("Script", "TextChatService Handler Loaded")
 			end

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -451,6 +451,20 @@ return function(Vargs, GetEnv)
 			return fakePlayer
 		end;
 
+		EscapeRichTextTags = function(text)
+			local EscapedText = {
+				["<"] = "&lt;";
+				[">"] = "&gt;";
+				['"'] = "&quot;";
+				["'"] =  "&apos;";
+				["%&"] = "&amp;";
+			}
+			for strToReplace,replacementStr in EscapedText do 
+				text = text:gsub(strToReplace, replacementStr)
+			end
+			return text
+		end;
+
 		GetChatService = function(waitTime)
 			local isTextChat = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService
 			local chatHandler = service.ServerScriptService:WaitForChild("ChatServiceRunner", waitTime or isTextChat and 0.2 or 145)

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -640,12 +640,14 @@ return function(Vargs, GetEnv)
 					end
 				elseif isMuted then
 					local msg = string.sub(msg, 1, Process.MsgStringLimit);
+					service.Events.MutedPlayerChat_UnFiltered:Fire(p, msg)
 					local filtered = service.LaxFilter(msg, p)
 					AddLog(Logs.Chats, {
 						Text = `[MUTED] {p.Name}: {filtered}`;
 						Desc = tostring(filtered);
 						Player = p;
 					})
+					service.Events.MutedPlayerChat_Filtered:Fire(p, filtered)
 				end
 			elseif not didPassRate and RateLimit(p, "RateLog") then
 				Anti.Detected(p, "Log", string.format("Chatting too quickly (>Rate: %s/sec)", curRate))

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -277,7 +277,7 @@ ChatCommands = true;			-- If false you will not be able to run commands via the 
 CreatorPowers = true;			-- Gives me creator-level admin; This is strictly used for debugging; I can't debug without full access to the script
 CodeExecution = false;			-- Enables the use of code execution in Adonis; Scripting related (such as :s) and a few other commands require this
 SilentCommandDenials = false;	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
-OverrideChatCallbacks = true;		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for muting
+OverrideChatCallbacks = true;		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
 
 BanMessage = "Banned";				-- Message shown to banned users upon kick
 LockMessage = "Not Whitelisted";	-- Message shown to people when they are kicked while the game is :slocked
@@ -446,7 +446,7 @@ CommandFeedback = [[ Should players be notified when commands with non-obvious e
 CrossServerCommands = [[ Are commands which affect more than one server enabled? ]];
 ChatCommands = [[ If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands ]];
 SilentCommandDenials = [[ If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command ]];
-OverrideChatCallbacks = [[ If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for muting ]];
+OverrideChatCallbacks = [[ If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false. ]];
 
 BanMessage = [[ Message shown to banned users ]];
 LockMessage = [[ Message shown to people when they are kicked while the game is :slocked ]];


### PR DESCRIPTION
Adds support for:
- CanSend mutes (doesn't need to use the ShouldDeliverCallback in TCS)
- :chatnotify works with TextChatService
- :broadcast works with TextChatService
- Both broadcast/chatnotify escape text as well