### PR TITLE
Remove Anti32bit

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -374,7 +374,6 @@ settings.AntiSpeed = false 				-- (Default: false)	(Client-Sided) Attempts to de
 settings.AntiBuildingTools = false		-- (Default: false)	(Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client.
 settings.AntiAntiIdle = false 			-- (Default: false)	(Client-Sided) Kick the player if they are using an anti-idle exploit. Highly useful for grinding/farming games.
 settings.ExploitGuiDetection = false 	-- (Default: false)	(Client-Sided) If any exploit GUIs are found in the CoreGui the exploiter gets kicked (If you use StarterGui:SetCore("SendNotification") with an image this will kick you).
-settings.Anti32bit = false				-- (Default: false)	(Client-Sided) Prevent anybody using the Microsoft Store version (UWP/32-bit) of Roblox which is primarily being used for exploiting.
 
 ---------------------
 -- END OF SETTINGS --
@@ -524,7 +523,6 @@ descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
 descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
 descs.AntiAntiIdle = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit. Highly useful for grinding/farming games ]]
 descs.ExploitGuiDetection = [[ (Client-Sided) If any exploit GUIs are found in the CoreGui the exploiter gets kicked (If you use StarterGui:SetCore("SendNotification") with an image this will kick you) ]]
-descs.Anti32bit = [[ (Client-Sided) Prevent anybody using the Microsoft Store version (UWP/32-bit) of Roblox which is primarily being used for exploiting. ]];
 
 order = {
 	"HideScript";
@@ -635,7 +633,6 @@ order = {
 	"AntiBuildingTools";
 	"AntiAntiIdle";
 	"ExploitGuiDetection";
-	"Anti32bit";
 }
 
 return {Settings = settings, Descriptions = descs, Order = order}

--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -151,15 +151,6 @@ return function(Vargs)
 	end
 
 	local Detectors = {
-		Anti32bit = function()
-			if service.UserInputService.TouchEnabled and not service.UserInputService.KeyboardEnabled and not service.UserInputService.MouseEnabled or service.GuiService:IsTenFootInterface() then return end -- Do not detect on mobile
-			local tableAddress = tonumber(string.sub(tostring{}, 8))
-			if #tostring(tableAddress) <= 10 then -- If the memory address for the table is less than 512 bits then it's a 32-bit memory address
-				Detected("kick", "32-bit Roblox client detected. Please ensure you are using the Roblox Player downloaded from the website and not from the Microsoft Store. 0xDEADBEEF")
-				return
-			end
-		end;
-
 		Speed = function(data)
 			service.StartLoop("AntiSpeed", 1, function()
 				if workspace:GetRealPhysicsFPS() > tonumber(data.Speed) then

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -893,9 +893,6 @@ return function(Vargs, GetEnv)
 						Enabled = (Settings.AntiAntiIdle ~= false or Settings.AntiClientIdle ~= false)
 					})
 
-					if Settings.Anti32bit then
-						Remote.Send(p, "LaunchAnti", "Anti32bit")
-					end
 					if Settings.ExploitGuiDetection then
 						Remote.Send(p, "LaunchAnti", "AntiCoreGui")
 					end

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -374,7 +374,6 @@ settings.AntiSpeed = false 				-- (Default: false)	(Client-Sided) Attempts to de
 settings.AntiBuildingTools = false		-- (Default: false)	(Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client.
 settings.AntiAntiIdle = false 			-- (Default: false)	(Client-Sided) Kick the player if they are using an anti-idle exploit. Highly useful for grinding/farming games.
 settings.ExploitGuiDetection = false 	-- (Default: false)	(Client-Sided) If any exploit GUIs are found in the CoreGui the exploiter gets kicked (If you use StarterGui:SetCore("SendNotification") with an image this will kick you).
-settings.Anti32bit = false				-- (Default: false)	(Client-Sided) Prevent anybody using the Microsoft Store version (UWP/32-bit) of Roblox which is primarily being used for exploiting.
 
 ---------------------
 -- END OF SETTINGS --
@@ -524,7 +523,6 @@ descs.AntiSpeed = [[ (Client-Sided) Attempts to detect speed exploits ]]
 descs.AntiBuildingTools = [[ (Client-Sided) Attempts to detect any HopperBin(s)/Building Tools added to the client ]]
 descs.AntiAntiIdle = [[ (Client-Sided) Kick the player if they are using an anti-idle exploit. Highly useful for grinding/farming games ]]
 descs.ExploitGuiDetection = [[ (Client-Sided) If any exploit GUIs are found in the CoreGui the exploiter gets kicked (If you use StarterGui:SetCore("SendNotification") with an image this will kick you) ]]
-descs.Anti32bit = [[ (Client-Sided) Prevent anybody using the Microsoft Store version (UWP/32-bit) of Roblox which is primarily being used for exploiting. ]];
 
 order = {
 	"HideScript";
@@ -635,7 +633,6 @@ order = {
 	"AntiBuildingTools";
 	"AntiAntiIdle";
 	"ExploitGuiDetection";
-	"Anti32bit";
 }
 
 return {Settings = settings, Descriptions = descs, Order = order}


### PR DESCRIPTION
A maintainer (me) overlooked the flaws of #1186, and merged it before further discussion concluded that it would be a bad idea to implement. This PR undoes #1186, removing the (currently optional and unreleased) detection & rejection of 32-bit Roblox clients.

At best, Anti32bit has highly limited use cases; at worst, its built-in availability as an anti-exploit setting is misleading, as there is a strong risk of rejecting legitimate players on the UWP app from joining experiences.