### PR TITLE
Use string interpolation in favor of concatenation

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -247,7 +247,7 @@ return function(Vargs, env)
 				assert(tonumber(args[1]), "Invalid time amount (must be number)")
 				assert(args[2], "Missing message")
 
-				Functions.Message("Message from ".. service.FormatPlayer(plr), service.BroadcastFilter(args[2], plr), service.GetPlayers(), true, args[1])
+				Functions.Message(`Message from {service.FormatPlayer(plr)}`, service.BroadcastFilter(args[2], plr), service.GetPlayers(), true, args[1])
 			end
 		};
 
@@ -261,7 +261,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing message")
 
-				Functions.Message("Message from ".. service.FormatPlayer(plr), service.BroadcastFilter(args[1], plr), service.GetPlayers(), true)
+				Functions.Message(`Message from {service.FormatPlayer(plr)}`, service.BroadcastFilter(args[1], plr), service.GetPlayers(), true)
 			end
 		};
 
@@ -1930,7 +1930,7 @@ return function(Vargs, env)
 				})
 
 				service.TeleportService:TeleportAsync(game.PlaceId, players, teleportOptions)
-				Functions.Message("Adonis", "Teleporting to server \""..args[2].."\"\nPlease wait...", players, false, 10)
+				Functions.Message("Adonis", `Teleporting to server "{args[2]}"\nPlease wait...`, players, false, 10)
 			end
 		};
 
@@ -4668,7 +4668,7 @@ return function(Vargs, env)
 						end
 					end
 
-					if not point then Functions.Hint("Waypoint "..m.." was not found.", {plr}) end
+					if not point then Functions.Hint(`Waypoint {m} was not found.`, {plr}) end
 				elseif args[2] and string.find(args[2], ",") then
 					local x, y, z = string.match(args[2], "(.*),(.*),(.*)")
 					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
@@ -6291,10 +6291,10 @@ return function(Vargs, env)
 						if success then
 							for _, v in service.GetPlayers(plr, args[1]) do
 								task.defer(function()
-									local char = Deps.Assets["Rig"..AvatarType]:Clone()
+									local char = Deps.Assets[`Rig{AvatarType}`]:Clone()
 									char.Name = Functions.GetNameFromUserIdAsync(target)
 									char.Parent = workspace
-									if char:FindFirstChild("Animate") then char.Animate:Destroy() local Anima = Deps.Assets[AvatarType.."Animate"]:Clone() Anima.Parent = char Anima.Disabled = false end
+									if char:FindFirstChild("Animate") then char.Animate:Destroy() local Anima = Deps.Assets[`AvatarType{Animate}`]:Clone() Anima.Parent = char Anima.Disabled = false end
 									char.Humanoid:ApplyDescription(desc, Enum.AssetTypeVerification.Always)
 									char.HumanoidRootPart.CFrame = (v.Character.HumanoidRootPart.CFrame * CFrame.Angles(0, math.rad(90), 0) * CFrame.new(5, 0, 0)) * CFrame.Angles(0, math.rad(90), 0)
 

--- a/MainModule/Server/Plugins/Anti_Cheat.lua
+++ b/MainModule/Server/Plugins/Anti_Cheat.lua
@@ -79,12 +79,12 @@ return function(Vargs, GetEnv)
 					end
 
 					Logs.AddLog(Logs.Script, {
-						Text = "Character AE Detected "..tostring(player);
-						Desc = "The Anti-Exploit character check detected player: "..tostring(player).." action: "..tostring(action).." reason: "..tostring(reason);
+						Text = `Character AE Detected {player}`;
+						Desc = `The Anti-Exploit character check detected player: {player} action: {action} reason: {reason}`;
 						Player = player;
 					})
 
-					warn("Charactercheck detected player: "..tostring(player).." action: "..tostring(action).." reason: "..tostring(reason))
+					warn(`Charactercheck detected player: {player} action: {action} reason: {reason}`)
 				else
 					Anti.Detected(player, action, reason)
 				end
@@ -111,8 +111,8 @@ return function(Vargs, GetEnv)
 						end
 
 						Logs.AddLog(Logs.Script, {
-							Text = "AE: Hat joint deletion reset network ownership for player: "..tostring(player);
-							Desc = "The AE reset joint handle network ownership for player: "..tostring(player);
+							Text = `AE: Hat joint deletion reset network ownership for player: {player}`;
+							Desc = `The AE reset joint handle network ownership for player: {player}`;
 							Player = player;
 						})
 					end)
@@ -188,8 +188,8 @@ return function(Vargs, GetEnv)
 					humanoid.Health = 0
 					humanoid:ChangeState(Enum.HumanoidStateType.Dead)
 					Logs.AddLog(Logs.Script, {
-						Text = "AE: Humanoid came out of dead state for player: "..tostring(player);
-						Desc = "AE: Humanoid came out of dead state for player: "..tostring(player);
+						Text = `AE: Humanoid came out of dead state for player: {player}`;
+						Desc = `AE: Humanoid came out of dead state for player: {player}`;
 						Player = player;
 					})
 				end
@@ -243,8 +243,8 @@ return function(Vargs, GetEnv)
 							humanoid.Health = 0
 							humanoid:ChangeState(Enum.HumanoidStateType.Dead)
 							Logs.AddLog(Logs.Script, {
-								Text = "AE: Waist joint deleted by player: "..tostring(player);
-								Desc = "AE: Waist joint deleted by player: "..tostring(player);
+								Text = `AE: Waist joint deleted by player: {player}`;
+								Desc = `AE: Waist joint deleted by player: {player}`;
 								Player = player;
 							})
 						end

--- a/MainModule/Server/Plugins/Urgent_Messages.lua
+++ b/MainModule/Server/Plugins/Urgent_Messages.lua
@@ -84,7 +84,7 @@ return function(Vargs, GetEnv)
 		AdminLevel = "Players";
 		Function = function(plr,args)
 			Remote.MakeGui(plr,"List",{
-				Title = "URGENT MESSAGES [Recent: ".. LastDateTime .."]",
+				Title = `URGENT MESSAGES [Recent: {LastDateTime}]`,
 				Icon = "rbxassetid://7467273592",
 				Table = Messages,
 				Font = "Code",


### PR DESCRIPTION
I've cleaned up some code to use string interpolation instead of concatenation. Additionally, I have modified the server-side anti-cheat and removed the explicit calls to `tostring`, which I don't think is necessary since it should be called automatically.