### PR TITLE
Whitelist RBLX Camera SFX - Update Anti_Cheat.lua

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -292,7 +292,7 @@ return function(Vargs)
 			service.StartLoop("AntiCoreGui", 15, function()
 				xpcall(function()
 					local function getCoreUrls()
-						local coreUrls = {}
+						local coreUrls = {"rbxassetid://0","rbxassetid://10066921516"}	-- Whitelist for Roblox Camera SFX
 						local backpack = Player:FindFirstChildOfClass("Backpack")
 						local character = Player.Character
 						local starterPack = service.StarterPack

--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -292,7 +292,7 @@ return function(Vargs)
 			service.StartLoop("AntiCoreGui", 15, function()
 				xpcall(function()
 					local function getCoreUrls()
-						local coreUrls = {"rbxassetid://0","rbxassetid://10066921516"}	-- Whitelist for Roblox Camera SFX
+						local coreUrls = {"rbxassetid://0", "rbxassetid://10066921516"}	-- Whitelist for Roblox Camera SFX
 						local backpack = Player:FindFirstChildOfClass("Backpack")
 						local character = Player.Character
 						local starterPack = service.StarterPack

--- a/MainModule/Server/Shared/Credits.lua
+++ b/MainModule/Server/Shared/Credits.lua
@@ -76,6 +76,7 @@ return {
 		{Text = "@watameln",			Desc = "Open Source Contributor"};
 		{Text = "@bigbenster702",	Desc = "Open Source Contributor"};
 		{Text = "@WalkerOfBacon", 	Desc = "Open Source Contributor"};
+		{Text = "@wilsontulus", 	Desc = "Open Source Contributor"};
 	};
 
 	Misc = {


### PR DESCRIPTION
Since recent updates many false kicks happened due to how Roblox implemented their Face Camera UI, they started the UI after game scripts were loaded. This commit is going to whitelist the rbxassetid for Camera UI and also the "rbxassetid://0" occuring on some low-end devices.