### PR TITLE
Show users device on exploitlogs for better metrics

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -48,8 +48,9 @@ return function(Vargs, GetEnv)
 	local Player = service.Players.LocalPlayer
 	local isStudio = select(2, pcall(service.RunService.IsStudio, service.RunService))
 	local Kick = Player.Kick
+	local isXbox = service.GuiService:IsTenFootInterface()
 	local isMobile = service.UserInputService.TouchEnabled and not service.UserInputService.KeyboardEnabled and not service.UserInputService.MouseEnabled
-	local hyperionEnabled = not service.GuiService:IsTenFootInterface() and not isMobile and (#tostring(tonumber(string.sub(tostring{}, 8))) > 10)
+	local hyperionEnabled = not isXbox and not isMobile and (#tostring(tonumber(string.sub(tostring{}, 8))) > 10)
 
 	local function Init()
 		UI = client.UI;
@@ -80,7 +81,7 @@ return function(Vargs, GetEnv)
 
 	local Detected = function(action, info, nocrash)
 		if NetworkClient and action ~= "_" then
-			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " (Hyperion is enabled, not giving punishment)" or ""))
+			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " - Hyperion is enabled, not giving punishment" or isXbox and " - On Xbox" or isMobile and " - On Mobile" or ""))
 			task.wait(0.5)
 			if not hyperionEnabled then
 				if action == "k".."i".."c".."k" then

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -81,7 +81,7 @@ return function(Vargs, GetEnv)
 
 	local Detected = function(action, info, nocrash)
 		if NetworkClient and action ~= "_" then
-			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " - Hyperion is enabled, not giving punishment" or isXbox and " - On Xbox" or isMobile and " - On Mobile" or ""))
+			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " - Hyperion is enabled, not giving punishment" or isXbox and " - On Xbox" or isMobile and " - On mobile" or ""))
 			task.wait(0.5)
 			if not hyperionEnabled then
 				if action == "k".."i".."c".."k" then

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -83,18 +83,16 @@ return function(Vargs, GetEnv)
 		if NetworkClient and action ~= "_" then
 			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " - Hyperion is enabled, not giving punishment" or isXbox and " - On Xbox" or isMobile and " - On mobile" or ""))
 			task.wait(0.5)
-			if not hyperionEnabled then
-				if action == "k".."i".."c".."k" then
-					if not isStudio then
-						if nocrash then
-							Player:Kick(":"..":".." ".."A".."d".."o".."n".."i".."s".." ".."A".."n".."t".."i".." ".."C".."h".."e".."a".."t"..":"..":".."\n".. tostring(info)); -- service.Players.LocalPlayer
-						else
-							Disconnect(info)
-						end
+			if action == "k".."i".."c".."k" then
+				if not isStudio then
+					if nocrash then
+						Player:Kick(":"..":".." ".."A".."d".."o".."n".."i".."s".." ".."A".."n".."t".."i".." ".."C".."h".."e".."a".."t"..":"..":".."\n".. tostring(info)); -- service.Players.LocalPlayer
+					else
+						Disconnect(info)
 					end
-				elseif action == "c".."r".."a".."s".."h" then
-					Kill(info)
 				end
+			elseif action == "c".."r".."a".."s".."h" then
+				Kill(info)
 			end
 		end
 		return true

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -48,6 +48,8 @@ return function(Vargs, GetEnv)
 	local Player = service.Players.LocalPlayer
 	local isStudio = select(2, pcall(service.RunService.IsStudio, service.RunService))
 	local Kick = Player.Kick
+	local isMobile = service.UserInputService.TouchEnabled and not service.UserInputService.KeyboardEnabled and not service.UserInputService.MouseEnabled
+	local hyperionEnabled = not service.GuiService:IsTenFootInterface() and not isMobile and (#tostring(tonumber(string.sub(tostring{}, 8))) > 10)
 
 	local function Init()
 		UI = client.UI;
@@ -78,18 +80,20 @@ return function(Vargs, GetEnv)
 
 	local Detected = function(action, info, nocrash)
 		if NetworkClient and action ~= "_" then
-			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", action, info)
+			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " (Hyperion is enabled, not giving punishment)"))
 			task.wait(0.5)
-			if action == "k".."i".."c".."k" then
-				if not isStudio then
-					if nocrash then
-						Player:Kick(":"..":".." ".."A".."d".."o".."n".."i".."s".." ".."A".."n".."t".."i".." ".."C".."h".."e".."a".."t"..":"..":".."\n".. tostring(info)); -- service.Players.LocalPlayer
-					else
-						Disconnect(info)
+			if not hyperionEnabled then
+				if action == "k".."i".."c".."k" then
+					if not isStudio then
+						if nocrash then
+							Player:Kick(":"..":".." ".."A".."d".."o".."n".."i".."s".." ".."A".."n".."t".."i".." ".."C".."h".."e".."a".."t"..":"..":".."\n".. tostring(info)); -- service.Players.LocalPlayer
+						else
+							Disconnect(info)
+						end
 					end
+				elseif action == "c".."r".."a".."s".."h" then
+					Kill(info)
 				end
-			elseif action == "c".."r".."a".."s".."h" then
-				Kill(info)
 			end
 		end
 		return true

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -80,7 +80,7 @@ return function(Vargs, GetEnv)
 
 	local Detected = function(action, info, nocrash)
 		if NetworkClient and action ~= "_" then
-			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " (Hyperion is enabled, not giving punishment)"))
+			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", hyperionEnabled and "log" or action, tostring(info)..(hyperionEnabled and " (Hyperion is enabled, not giving punishment)" or ""))
 			task.wait(0.5)
 			if not hyperionEnabled then
 				if action == "k".."i".."c".."k" then


### PR DESCRIPTION
User @moo1210 raiser potential concerns in #1204 that having the AC enabled while the Roblox client is using Hyperion would have false detections occuring because of other reasons punish users even when not necessary.

~~This fixes the primary concern raised in #1204 without disabling the AC globally for all games like #1205 does which would lead to games having AC enabled but old loaders not being able to easily re-enable it.
This pull has no such issue.~~

This pull also makes debugging the AC a lot easier.