### PR TITLE
Fix remotespy detection

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -569,7 +569,7 @@ return function(Vargs, GetEnv)
 							Detected("kick", "FireServer function hooks detected")
 						end
 					end
-					pcall(remEventCheck.FireServer, remEventCheck, proxyDetector)
+					pcall(remEventCheck.FireServer, proxyDetector, proxyDetector)
 
 					-- // RemoteFunction hook detection
 					do


### PR DESCRIPTION
Unfortunately Roblox has a bug that adds local events to the remote queue as well, we have to use a less powerful detection here for remotespy.