### PR TITLE
Make `:BuyItem` only block limiteds

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -283,7 +283,6 @@ settings.CreatorPowers = true			-- Gives me creator-level admin; This is strictl
 settings.CodeExecution = false			-- Enables the use of code execution in Adonis; Scripting related (such as :s) and a few other commands require this
 settings.SilentCommandDenials = false	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
 settings.OverrideChatCallbacks = true		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
-settings.DisableBuyItem = true			-- Disable a security vulnerability related to UGCs being able to be taken for free using adonis.
 
 settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is :slocked
@@ -451,7 +450,6 @@ descs.CrossServerCommands = [[ Are commands which affect more than one server en
 descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands ]]
 descs.SilentCommandDenials = [[ If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command ]]
 descs.OverrideChatCallbacks = [[ If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for muting ]]
-descs.DisableBuyItem = [[ Disable a security vulnerability related to UGCs being able to be taken for free using Adonis. ]]
 
 
 descs.BanMessage = [[ Message shown to banned users ]]
@@ -593,7 +591,6 @@ order = {
 	"CodeExecution";
 	"SilentCommandDenials";
 	"OverrideChatCallbacks";
-	"DisableBuyItem";
 	" ";
 	"BanMessage";
 	"LockMessage";

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -1155,6 +1155,8 @@ return function(Vargs, env)
 				local assetId = assert(tonumber(args[1]), "Missing asset ID (argument #1)")
 				local success, assetAlreadyOwned = pcall(service.MarketplaceService.PlayerOwnsAsset, service.MarketplaceService, plr, assetId)
 				assert(not (success and assetAlreadyOwned), "You already own the asset!")
+				local success, assetInfo = pcall(service.MarketPlaceService.GetProductInfo, service.MarketPlaceService, assetId)
+				assert(success and not assetInfo.IsLimited, "Cannot buy limited assets!")
 				local connection; connection = service.MarketplaceService.PromptPurchaseFinished:Connect(function(_, boughtAssetId, isPurchased)
 					if boughtAssetId == assetId then
 						connection:Disconnect()

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -283,7 +283,6 @@ settings.CreatorPowers = true			-- Gives me creator-level admin; This is strictl
 settings.CodeExecution = false			-- Enables the use of code execution in Adonis; Scripting related (such as :s) and a few other commands require this
 settings.SilentCommandDenials = false	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
 settings.OverrideChatCallbacks = true		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
-settings.DisableBuyItem = true			-- Disable a security vulnerability related to UGCs being able to be taken for free using adonis.
 
 settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is :slocked
@@ -451,7 +450,6 @@ descs.CrossServerCommands = [[ Are commands which affect more than one server en
 descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands ]]
 descs.SilentCommandDenials = [[ If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command ]]
 descs.OverrideChatCallbacks = [[ If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for muting ]]
-descs.DisableBuyItem = [[ Disable a security vulnerability related to UGCs being able to be taken for free using Adonis. ]]
 
 descs.BanMessage = [[ Message shown to banned users ]]
 descs.LockMessage = [[ Message shown to people when they are kicked while the game is :slocked ]]
@@ -592,7 +590,6 @@ order = {
 	"CodeExecution";
 	"SilentCommandDenials";
 	"OverrideChatCallbacks";
-	"DisableBuyItem";
 	" ";
 	"BanMessage";
 	"LockMessage";


### PR DESCRIPTION
In a new update Roblox added creator UGC which can be purchased from in game. Due to this update some types of UGC limiteds can be purchased free if they are purchased from the creators game.
A vulnerability appeared which allowed people to steal UGC limiteds by doing this.

The pull #1221 fixed this by disabling the command altogether but introduces more setting bloats (boolean parameters should be avoided). This pull fixes it so that you can still buy items if they are not limiteds avoiding the boolean parameter.

Things that need to be tested:

- Are non-limited UGCs still problematic to buy??