### PR TITLE
Update setup-foreman to v2.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: Roblox/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v2.1
       with:
           token: ${{ SECRETS.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Currently it uses node12 which is being depracated soon, v2.1 uses node16 which is still supported