### PR TITLE
Update Anti_Cheat.lua - More proper way of soundId check

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -590,13 +590,12 @@ return function(Vargs)
 
 			service.PolicyService.ChildAdded:Connect(function(child)
 				if child:IsA("Sound") then
-					local idChange = child:GetPropertyChangedSignal("SoundId"):Connect(function()
+					for i = 1, 5 do
 						if soundIdCheck(child) then
 							Detected("crash", "CMDx Detected; "..tostring(child))
 						end
-					end)
-					task.wait(1)
-					idChange:Disconnect()
+						task.wait(0.1)
+					end
 				end
 			end)
 

--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -566,7 +566,7 @@ return function(Vargs)
 			end
 
 			local function soundIdCheck(Sound)
-				for _,v in pairs(soundIds) do
+				for _,v in ipairs(soundIds) do
 					if Sound.SoundId and (string.find(string.lower(tostring(Sound.SoundId)), tostring(v)) or Sound.SoundId == tostring(v)) then
 						return true
 					end
@@ -590,14 +590,13 @@ return function(Vargs)
 
 			service.PolicyService.ChildAdded:Connect(function(child)
 				if child:IsA("Sound") then
-					if soundIdCheck(child) then
-						Detected("crash", "CMDx Detected; "..tostring(child))
-					else
-						wait()
+					local idChange = child:GetPropertyChangedSignal("SoundId"):Connect(function()
 						if soundIdCheck(child) then
 							Detected("crash", "CMDx Detected; "..tostring(child))
 						end
-					end
+					end)
+					task.wait(1)
+					idChange:Disconnect()
 				end
 			end)
 


### PR DESCRIPTION
- Use ipairs instead of pairs for plain non-dictionary tables
- ~~Use GetPropertyChangedSignal instead of repeating the same thing after a wait()~~ Turns out that GetPropertyChangedSignal was a mistake as it will only trigger every time SoundId property is changed.
- Use for loops 5 times in 500ms (1 time = 100ms) instead of repeating the same thing after a wait()

## Notice
Please make sure you read the Contributing Guidelines before submitting a pull request. https://github.com/Epix-Incorporated/Adonis/blob/master/CONTRIBUTING.md