### PR TITLE
Disabled protections superseded by `Workspace.RejectCharacterDeletions` on new games

### DIFF
--- a/MainModule/Server/Plugins/Anti_Cheat.lua
+++ b/MainModule/Server/Plugins/Anti_Cheat.lua
@@ -257,7 +257,7 @@ return function(Vargs, GetEnv)
 			local humanoidRootPart = character:WaitForChild("HumanoidRootPart")
 			local rootJoint = humanoid.RigType == Enum.HumanoidRigType.R15 and character:WaitForChild("LowerTorso"):WaitForChild("Root") or humanoid.RigType == Enum.HumanoidRigType.R6 and (humanoidRootPart:FindFirstChild("Root Hip") or humanoidRootPart:WaitForChild("RootJoint"))
 
-			if (Settings.AntiRootJointDeletion or Settings.AntiParanoid) --[[and game.PlaceId < 13308063561]] then -- // Enable workspace.RejectCharacterDeletions instead
+			if Settings.AntiRootJointDeletion or Settings.AntiParanoid --[[and game.PlaceId < 13308063561]] then -- // Enable workspace.RejectCharacterDeletions instead
 				makeConnection(rootJoint.AncestryChanged)
 
 				if humanoid.RigType == Enum.HumanoidRigType.R15 then

--- a/MainModule/Server/Plugins/Anti_Cheat.lua
+++ b/MainModule/Server/Plugins/Anti_Cheat.lua
@@ -141,13 +141,13 @@ return function(Vargs, GetEnv)
 			charGood = true
 
 			for _, v in ipairs(character:GetChildren()) do
-				if v:IsA("Accoutrement") and Settings.ProtectHats == true then
+				if v:IsA("Accoutrement") and Settings.ProtectHats == true and game.PlaceId < 13308063561 then -- // Enable workspace.RejectCharacterDeletions instead
 					coroutine.wrap(protectHat)(v)
 				end
 			end
 
 			character.ChildAdded:Connect(function(child)
-				if child:IsA("Accoutrement") and Settings.ProtectHats == true then
+				if child:IsA("Accoutrement") and Settings.ProtectHats == true and game.PlaceId < 13308063561 then -- // Enable workspace.RejectCharacterDeletions instead
 					protectHat(child)
 				elseif child:IsA("BackpackItem") and Settings.AntiMultiTool == true then
 					local count = 0
@@ -172,7 +172,7 @@ return function(Vargs, GetEnv)
 
 			local humanoid = character:FindFirstChildOfClass("Humanoid") or character:WaitForChild("Humanoid")
 
-			if Settings.AntiHumanoidDeletion then
+			if Settings.AntiHumanoidDeletion and game.PlaceId < 13308063561 then -- // Enable workspace.RejectCharacterDeletions instead
 				humanoid.AncestryChanged:Connect(function(child, parent)
 					task.defer(function()
 						if child == humanoid and character and (not parent or not character:IsAncestorOf(humanoid)) then
@@ -257,7 +257,7 @@ return function(Vargs, GetEnv)
 			local humanoidRootPart = character:WaitForChild("HumanoidRootPart")
 			local rootJoint = humanoid.RigType == Enum.HumanoidRigType.R15 and character:WaitForChild("LowerTorso"):WaitForChild("Root") or humanoid.RigType == Enum.HumanoidRigType.R6 and (humanoidRootPart:FindFirstChild("Root Hip") or humanoidRootPart:WaitForChild("RootJoint"))
 
-			if Settings.AntiRootJointDeletion or Settings.AntiParanoid then
+			if (Settings.AntiRootJointDeletion or Settings.AntiParanoid) and game.PlaceId < 13308063561 then -- // Enable workspace.RejectCharacterDeletions instead
 				makeConnection(rootJoint.AncestryChanged)
 
 				if humanoid.RigType == Enum.HumanoidRigType.R15 then

--- a/MainModule/Server/Plugins/Anti_Cheat.lua
+++ b/MainModule/Server/Plugins/Anti_Cheat.lua
@@ -257,7 +257,7 @@ return function(Vargs, GetEnv)
 			local humanoidRootPart = character:WaitForChild("HumanoidRootPart")
 			local rootJoint = humanoid.RigType == Enum.HumanoidRigType.R15 and character:WaitForChild("LowerTorso"):WaitForChild("Root") or humanoid.RigType == Enum.HumanoidRigType.R6 and (humanoidRootPart:FindFirstChild("Root Hip") or humanoidRootPart:WaitForChild("RootJoint"))
 
-			if (Settings.AntiRootJointDeletion or Settings.AntiParanoid) and game.PlaceId < 13308063561 then -- // Enable workspace.RejectCharacterDeletions instead
+			if (Settings.AntiRootJointDeletion or Settings.AntiParanoid) --[[and game.PlaceId < 13308063561]] then -- // Enable workspace.RejectCharacterDeletions instead
 				makeConnection(rootJoint.AncestryChanged)
 
 				if humanoid.RigType == Enum.HumanoidRigType.R15 then


### PR DESCRIPTION
`Workspace.RejectCharacterDeletions` was added in https://devforum.roblox.com/t/action-required-workspacerejectcharacterdeletions/2196175/1 and enabled by default on games on May 1st 2023 https://devforum.roblox.com/t/workspacerejectcharacterdeletions-default-transition/2269179 .
RejectCharacterDeletions does the same thing as `settings.AntiHumanoidDeletion`, `settings.ProtectHats` and partially `settings.AntiRootJointDeletion/settings.AntiParanoid`.

Also do not remove `settings.AntiRootJointDeletion` explosions and joint breakers can still break the character so some games rely on it!!

1. Phase 1 ✅ - Remove legacy settings from settings files and suggest alternative in settings file (expect for settings.AntiRootJointDeletion) - Already done in #778
2. Phase 2 🔄 - Make all games after May 1st have `settings.AntiHumanoidDeletion`, `settings.ProtectHats` and `settings.AntiRootJointDeletion/settings.AntiParanoid` disabled even if they are enabled via settings. - Done when this pull gets merged and Adonis gets updated.
3. Phase 3 ❌ - Remove the pieces of code totally (maybe notify games that depend on the settings??) - Not yet. Some games may still rely on them, we first have to force disable them on new games

Also here is the [first game on may 1st](https://www.roblox.com/games/13308063561/lalaprincesa0601s-Place) and [the first user on may 1st](https://www.roblox.com/users/4578988859/profile/#!/about).