### PR TITLE
Fix accidental mistype of creaper breaking R6

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -3624,7 +3624,7 @@ return function(Vargs, env)
 								{rarm, CFrame.new(Vector3.new(-1, -1.5, -0.5) * magnitude) * (isR15 and blankFrame or CFrame.Angles(0, math.rad(90), 0))};
 								{larm, CFrame.new(Vector3.new(1, -1.5, -0.5) * magnitude) * (isR15 and blankFrame or CFrame.Angles(0, math.rad(-90), 0))};
 								{rleg, CFrame.new(Vector3.new(isR15 and -0.5 or 0, isR15 and -0.5 or -1, 0.5) * magnitude) * CFrame.Angles(0, math.rad(isR15 and 180 or -90), 0)};
-								{lleg, isR15 and CFrame.new(Vector3.new(isR15 and 0.5 or 0, isR15 and -0.5 or -1, 0.5) * magnitude) * CFrame.Angles(0, math.rad(isR15 and 180 or -90), 0)};
+								{lleg, CFrame.new(Vector3.new(isR15 and 0.5 or 0, isR15 and -0.5 or -1, 0.5) * magnitude) * CFrame.Angles(0, math.rad(isR15 and 180 or -90), 0)};
 							}
 
 							for _, frame in frames do


### PR DESCRIPTION
Didn't test this on R6 so this was left here accidentally. A leftover from the previous command