### PR TITLE
Fix longstanding issue with `:bot` animations not working with R15

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1234,8 +1234,7 @@ return function(Vargs, GetEnv)
 				local event = brain.Event
 
 				local oldAnim = new:FindFirstChild("Animate")
-				local isR15 = hum.RigType == "R15"
-				local anim = isR15 and Deps.Assets.R15Animate:Clone() or Deps.Assets.R6Animate:Clone()
+				local anim = hum.RigType == Enum.HumanoidRigType.R15 and Deps.Assets.R15Animate:Clone() or Deps.Assets.R6Animate:Clone()
 
 				new.Name = player.Name
 				new.Archivable = false


### PR DESCRIPTION
This used to work but no longer appears to do because at some point Roblox probably changed how Enums work