### PR TITLE
Small fix/improvement to zombie detection

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -623,7 +623,7 @@ return function(Vargs, env)
 						Face = math.random(1, 3) == 3 and 173789114 or 133360789
 					}
 
-					if humanoid and humanoid.RootPart and not humanoid.Parent:FindFirstChild("Infected") then
+					if humanoid and humanoid.RootPart and string.lower(humanoid.Name) ~= "zombie" and not humanoid.Parent:FindFirstChild("Infected") then
 						local description = humanoid:GetAppliedDescription()
 						local cl = service.New("StringValue")
 						cl.Name = "Infected"


### PR DESCRIPTION
Having humanoids named to `Zombie` is a common de facto way of characterizing certain humanoids as zombies. This add support for that so the infect script doesn't infect those.