### PR TITLE
[Part1 of softshutdown fix]: Fix softshutdown failing and not retrying

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1018,12 +1018,12 @@ return function(Vargs, GetEnv)
 		end;
 
 		Notification = function(title, message, players, duration, icon)
-			if image then
+			if icon then
 				-- Support "MatIcon://" for fast access to maticons
-				local MatIcon = image:match('MatIcon://(.+)')
+				local MatIcon = icon:match('MatIcon://(.+)')
 
 				if MatIcon then
-					image = server.MatIcons[MatIcon]
+					icon = server.MatIcons[MatIcon]
 				end
 			end
 

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1024,8 +1024,6 @@ return function(Vargs, GetEnv)
 
 				if MatIcon then
 					image = server.MatIcons[MatIcon]
-				elseif sender and (image == 'HeadShot') then
-					image = `rbxthumb://type=AvatarHeadShot&id={sender.UserId}&w=48&h=48`
 				end
 			end
 

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -978,7 +978,6 @@ return function(Vargs, GetEnv)
 			duration = duration or (#tostring(message) / 19) + 2.5
 
 			if image then
-
 				-- Support "MatIcon://" for fast access to maticons
 				local MatIcon = image:match('MatIcon://(.+)')
 
@@ -1019,6 +1018,17 @@ return function(Vargs, GetEnv)
 		end;
 
 		Notification = function(title, message, players, duration, icon)
+			if image then
+				-- Support "MatIcon://" for fast access to maticons
+				local MatIcon = image:match('MatIcon://(.+)')
+
+				if MatIcon then
+					image = server.MatIcons[MatIcon]
+				elseif sender and (image == 'HeadShot') then
+					image = `rbxthumb://type=AvatarHeadShot&id={sender.UserId}&w=48&h=48`
+				end
+			end
+
 			for _, v in players do
 				Remote.MakeGui(v, "Notification", {
 					Title = title;

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1018,7 +1018,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		Notification = function(title, message, players, duration, icon, onClick)
-			icon = icon:match('MatIcon://(.+)') or icon
+			icon = icon and icon:match('MatIcon://(.+)') or icon
 
 			for _, v in players do
 				Remote.MakeGui(v, "Notification", {

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1017,15 +1017,8 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
-		Notification = function(title, message, players, duration, icon)
-			if icon then
-				-- Support "MatIcon://" for fast access to maticons
-				local MatIcon = icon:match('MatIcon://(.+)')
-
-				if MatIcon then
-					icon = server.MatIcons[MatIcon]
-				end
-			end
+		Notification = function(title, message, players, duration, icon, onClick)
+			icon = icon:match('MatIcon://(.+)') or icon
 
 			for _, v in players do
 				Remote.MakeGui(v, "Notification", {
@@ -1033,6 +1026,7 @@ return function(Vargs, GetEnv)
 					Message = message;
 					Time = duration;
 					Icon = server.MatIcons[icon or "Info"];
+					OnClick = onClick;
 				})
 			end
 		end;

--- a/MainModule/Server/Plugins/Server-SoftShutdown.lua
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.lua
@@ -29,7 +29,7 @@ return function(Vargs, GetEnv)
 				task.wait(RETRY_WAIT * teleportedPlayers[player])
 				teleportedPlayers[player] += 1
 				Logs:AddLog("Script", `Failed to teleport {player.Name} {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"} due to {result.Name}. Retrying... Details: {message}`)
-				Functions.Notification("Teleport failed", `SoftShutdown failed to teleport {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"}. Retrying...`, {player}, 10, "MatIcon://Warning"
+				Functions.Notification("Teleport failed", `SoftShutdown failed to teleport {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"}. Retrying...`, {player}, 10, "MatIcon://Warning")
 				TeleportService:Teleport(game.PlaceId, player, {[PARAMETER_2_NAME] = true})
 			else
 				Logs:AddLog("Script", `Failed to teleport {player.Name} {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"} due to {result.Name}. Details: {message}`)

--- a/MainModule/Server/Plugins/Server-SoftShutdown.lua
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.lua
@@ -84,6 +84,10 @@ return function(Vargs, GetEnv)
 			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
 			task.wait(2)
 
+			for _, v in Players:GetPlayers() do
+				teleportedPlayers[v] = 1
+			end
+
 			Logs:AddLog("Script", `Teleporting {#Players:GetPlayers()} players to a temporary softshutdown server`)
 			TeleportService:TeleportToPrivateServer(game.PlaceId, newserver, Players:GetPlayers(), "", {[PARAMETER_NAME] = true})
 			Players.PlayerAdded:Connect(function(player)
@@ -138,6 +142,10 @@ return function(Vargs, GetEnv)
 			local newserver = TeleportService:ReserveServer(game.PlaceId)
 			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
 			task.wait(1)
+
+			for _, v in Players:GetPlayers() do
+				teleportedPlayers[v] = 1
+			end
 
 			Logs:AddLog("Script", `Teleporting {#Players:GetPlayers()} players to a temporary softshutdown server`)
 			TeleportService:TeleportToPrivateServer(game.PlaceId, newserver, Players:GetPlayers(), "", {[PARAMETER_NAME] = true})

--- a/MainModule/Server/Plugins/Server-SoftShutdown.lua
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.lua
@@ -29,22 +29,12 @@ return function(Vargs, GetEnv)
 				task.wait(RETRY_WAIT * teleportedPlayers[player])
 				teleportedPlayers[player] += 1
 				Logs:AddLog("Script", `Failed to teleport {player.Name} {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"} due to {result.Name}. Retrying... Details: {message}`)
-				Remote.MakeGui(plr, "Notification", {
-					Title = "Notification",
-					Icon = "MatIcon://Warning";
-					Message = `SoftShutdown failed to teleport {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"}. Retrying...`;
-					Time = 10;
-				})
+				Functions.Notification("Teleport failed", `SoftShutdown failed to teleport {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"}. Retrying...`, {player}, 10, "MatIcon://Warning"
 				TeleportService:Teleport(game.PlaceId, player, {[PARAMETER_2_NAME] = true})
 			else
 				Logs:AddLog("Script", `Failed to teleport {player.Name} {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"} due to {result.Name}. Details: {message}`)
 				Logs:AddLog("Error", `Failed to teleport {player.Name} {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"} to {result.Name}. Details: {message}`)
-				Remote.MakeGui(plr, "Notification", {
-					Title = "Notification",
-					Icon = "MatIcon://Error";
-					Message = `SoftShutdown failed to teleport {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"}. Details {message}`;
-					Time = 35;
-				})
+				Functions.Notification("Teleport failed", `SoftShutdown failed to teleport {isPrivateServer and "back to the main game" or "to a temporary softshutdown server"}. Details {message}`, {player}, 35, "MatIcon://Error")
 			end
 		end
 	end)
@@ -91,13 +81,14 @@ return function(Vargs, GetEnv)
 			if #Players:GetPlayers() == 0 then return end
 
 			local newserver = TeleportService:ReserveServer(game.PlaceId)
-			Functions.Message('Adonis', "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
+			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
 			task.wait(2)
 
 			Logs:AddLog("Script", `Teleporting {#Players:GetPlayers()} players to a temporary softshutdown server`)
 			TeleportService:TeleportToPrivateServer(game.PlaceId, newserver, Players:GetPlayers(), "", {[PARAMETER_NAME] = true})
 			Players.PlayerAdded:Connect(function(player)
 				Logs:AddLog("Script", `Teleporting {player.Name} to a temporary softshutdown server`)
+				teleportedPlayers[player] = 1
 				TeleportService:TeleportToPrivateServer(game.PlaceId, newserver, { player }, "", {[PARAMETER_NAME] = true})
 			end)
 
@@ -145,13 +136,14 @@ return function(Vargs, GetEnv)
 
 
 			local newserver = TeleportService:ReserveServer(game.PlaceId)
-			Functions.Message('Adonis', "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
+			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
 			task.wait(1)
 
 			Logs:AddLog("Script", `Teleporting {#Players:GetPlayers()} players to a temporary softshutdown server`)
 			TeleportService:TeleportToPrivateServer(game.PlaceId, newserver, Players:GetPlayers(), "", {[PARAMETER_NAME] = true})
 			Players.PlayerAdded:Connect(function(player)
 				Logs:AddLog("Script", `Teleporting {player.Name} to a temporary softshutdown server`)
+				teleportedPlayers[player] = 1
 				TeleportService:TeleportToPrivateServer(game.PlaceId, newserver, { player }, "", {[PARAMETER_NAME] = true})
 			end)
 


### PR DESCRIPTION
If the teleport fails the script doesn't attempt to re-teleport the user leading to them being stuck.

- Part1 - Fix softshutdown not retrying on failure
- Part2 - Switch softshutdown (and maybe other teleports) to [TeleportService:TeleportAsync](https://robloxapi.github.io/ref/class/TeleportService.html#member-TeleportAsync)
- Part3 - Add loading screen for softshutdown servers