### PR TITLE
Fix tornado, anti, :buyitem, fpslocker, van, :slippery, convert deprecated/legacy items

### DIFF
--- a/MainModule/Client/Client.lua
+++ b/MainModule/Client/Client.lua
@@ -215,38 +215,31 @@ end
 local Kill
 local Fire, Detected = nil, nil
 do
-	local wrap = coroutine.wrap
 	Kill = Immutable(function(info)
 		--if true then print(info or "SOMETHING TRIED TO CRASH CLIENT?") return end
-		wrap(function()
-			pcall(function()
-				if Detected then
-					Detected("kick", info)
-				elseif Fire then
-					Fire("BadMemes", info)
-				end
-			end)
-		end)()
+		spawn(pcall, function()
+			if Detected then
+				Detected("kick", info)
+			elseif Fire then
+				Fire("BadMemes", info)
+			end
+		end))
 
-		wrap(function()
-			pcall(function()
-				task.wait(1)
-				service.Player:Kick(info)
-			end)
-		end)()
+		spawn(pcall, function()
+			task.wait(1)
+			service.Player:Kick(info)
+		end))
 		
 		if not isStudio then
-			wrap(function()
-				pcall(function()
-					task.wait(5)
-					while true do
-						pcall(task.spawn, function()
-							task.spawn(Kill())
-							-- memes
-						end)
-					end
-				end)
-			end)()
+			spawn(pcall, function()
+				task.wait(5)
+				while true do
+					pcall(task.spawn, function()
+						task.spawn(Kill())
+						-- memes
+					end)
+				end
+			end))
 		end
 	end)
 end

--- a/MainModule/Client/Client.lua
+++ b/MainModule/Client/Client.lua
@@ -223,12 +223,12 @@ do
 			elseif Fire then
 				Fire("BadMemes", info)
 			end
-		end))
+		end)
 
 		spawn(pcall, function()
 			task.wait(1)
 			service.Player:Kick(info)
-		end))
+		end)
 		
 		if not isStudio then
 			spawn(pcall, function()
@@ -239,7 +239,7 @@ do
 						-- memes
 					end)
 				end
-			end))
+			end)
 		end
 	end)
 end

--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -862,15 +862,15 @@ return function(Vargs, GetEnv)
 
 								local ang = 0.1
 								if wave then
-									if torso.Velocity.Magnitude > 1 then
-										ang += ((torso.Velocity.Magnitude/10)*.05)+.05
+									if torso.AssemblyLinearVelocity.Magnitude > 1 then
+										ang += ((torso.AssemblyLinearVelocity.Magnitude/10)*.05)+.05
 									end
 									v.Wave = false
 								else
 									v.Wave = true
 								end
-								ang += math.min(torso.Velocity.Magnitude/11, .8)
-								motor.MaxVelocity = math.min((torso.Velocity.Magnitude/111), .04) + 0.002
+								ang += math.min(torso.AssemblyLinearVelocity.Magnitude/11, .8)
+								motor.MaxVelocity = math.min((torso.AssemblyLinearVelocity.Magnitude/111), .04) + 0.002
 								if isPlayer then
 									motor.DesiredAngle = -ang
 								else
@@ -1317,24 +1317,24 @@ return function(Vargs, GetEnv)
 				local wave = false
 				repeat task.wait(1/44)
 					local ang = 0.1
-					local oldmag = torso.Velocity.Magnitude
+					local oldmag = torso.AssemblyLinearVelocity.Magnitude
 					local mv = .002
 					if wave then 
-						ang += ((torso.Velocity.Magnitude/10)*.05)+.05
+						ang += ((torso.AssemblyLinearVelocity.Magnitude/10)*.05)+.05
 						wave = false
 					else
 						wave = true
 					end
-					ang += math.min(torso.Velocity.Magnitude/11, .5)
-					motor1.MaxVelocity = math.min((torso.Velocity.Magnitude/111), .04) + mv
+					ang += math.min(torso.AssemblyLinearVelocity.Magnitude/11, .5)
+					motor1.MaxVelocity = math.min((torso.AssemblyLinearVelocity.Magnitude/111), .04) + mv
 					motor1.DesiredAngle = -ang
 					if motor1.CurrentAngle < -.2 and motor1.DesiredAngle > -.2 then
 						motor1.MaxVelocity = .04
 					end
 
-					repeat task.wait() until motor1.CurrentAngle == motor1.DesiredAngle or math.abs(torso.Velocity.Magnitude - oldmag) >=(torso.Velocity.Magnitude/10) + 1
+					repeat task.wait() until motor1.CurrentAngle == motor1.DesiredAngle or math.abs(torso.AssemblyLinearVelocity.Magnitude - oldmag) >=(torso.AssemblyLinearVelocity.Magnitude/10) + 1
 
-					if torso.Velocity.Magnitude < .1 then
+					if torso.AssemblyLinearVelocity.Magnitude < .1 then
 						task.wait(.1)
 					end
 				until not p or not p.Parent or p.Parent ~= service.LocalContainer()

--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -979,8 +979,8 @@ return function(Vargs, GetEnv)
 
 			if fps then
 				service.StartLoop("SetFPS",0.1,function()
-					local cat = tick()
-					repeat while cat + 1/fps > tick() do end task.wait() cat = tick() until service.IsLooped("SetFPS") == false
+					local cat = os.clock()
+					repeat while cat + 1/fps > os.clock() do end task.wait() cat = os.clock() until service.IsLooped("SetFPS") == false
 				end)
 			end
 		end;

--- a/MainModule/Client/Plugins/Anti_Cheat.lua
+++ b/MainModule/Client/Plugins/Anti_Cheat.lua
@@ -866,8 +866,8 @@ return function(Vargs)
 				if
 					not success or
 					script.Archivable ~= false or
-					not isStudio and (not string.match(script.Name, "^\n\n+ModuleScript$") or lastChanged2 - lastChanged1 > 60) or
-					lastChanged2 - lastChanged3 > 60 or
+					not isStudio and (not string.match(script.Name, "^\n\n+ModuleScript$") or lastChanged2 - lastChanged1 > 90) or
+					lastChanged2 - lastChanged3 > 90 or
 					not checkEvent or
 					typeof(checkEvent) ~= "RBXScriptConnection" or
 					checkEvent.Connected ~= true
@@ -897,8 +897,8 @@ return function(Vargs)
 		task.spawn(xpcall, function()
 			while true do
 				if
-					not isStudio and math.abs(lastChanged3 - lastChanged1) > 60 or
-					math.abs(lastChanged3 - lastChanged2) > 60
+					not isStudio and math.abs(lastChanged3 - lastChanged1) > 90 or
+					math.abs(lastChanged3 - lastChanged2) > 90
 				then
 					opcall(Detected, "crash", "Tamper Protection 0xE28D")
 					oWait(1)

--- a/MainModule/Client/UI/Aero.rbxmx
+++ b/MainModule/Client/UI/Aero.rbxmx
@@ -11778,7 +11778,7 @@ return function(data, env)
 	end)
 
 	admins.MouseButton1Click:Connect(function()
-		if isAdmin or tick() - lastClick > 5 then
+		if isAdmin or os.clock() - lastClick > 5 then
 			isAdmin = client.Remote.Get("CheckAdmin")
 			if isAdmin then
 				openAdmins()
@@ -11786,12 +11786,12 @@ return function(data, env)
 				admins.BackgroundTransparency = 0.8
 				admins.TextTransparency = 0.8
 			end
-			lastClick = tick()
+			lastClick = os.clock()
 		end
 	end)
 
 	cross.MouseButton1Click:Connect(function()
-		if isAdmin or tick() - lastClick > 5 then
+		if isAdmin or os.clock() - lastClick > 5 then
 			isAdmin = client.Remote.Get("CheckAdmin")
 			if isAdmin then
 				openCross()
@@ -11799,24 +11799,24 @@ return function(data, env)
 				cross.BackgroundTransparency = 0.8
 				cross.TextTransparency = 0.8
 			end
-			lastClick = tick()
+			lastClick = os.clock()
 		end
 	end)
 
 	box.FocusLost:Connect(function(enterPressed)
 		boxFocused = false
 		if enterPressed and not client.Variables.Muted then
-			if box.Text ~= '' and ((mode ~= "Cross" and tick() - lastChat >= 0.5) or (mode == "Cross" and tick() - lastChat >= 10)) then
+			if box.Text ~= '' and ((mode ~= "Cross" and os.clock() - lastChat >= 0.5) or (mode == "Cross" and os.clock() - lastChat >= 10)) then
 				if not client.Variables.Muted then
 					client.Remote.Send('ProcessCustomChat', box.Text, mode)
-					lastChat = tick()
+					lastChat = os.clock()
 				end
-			elseif not ((mode ~= "Cross" and tick() - lastChat >= 0.5) or (mode == "Cross" and tick() - lastChat >= 10)) then
+			elseif not ((mode ~= "Cross" and os.clock() - lastChat >= 0.5) or (mode == "Cross" and os.clock() - lastChat >= 10)) then
 				local tim
 				if mode == "Cross" then
-					tim = 10 - (tick() - lastChat)
+					tim = 10 - (os.clock() - lastChat)
 				else
-					tim = 0.5 - (tick() - lastChat)
+					tim = 0.5 - (os.clock() - lastChat)
 				end
 				tim = string.sub(tostring(tim), 1, 3)
 				client.Handlers.ChatHandler("SpamBot", `Sending too fast! Please wait {tim} seconds.`, "System")
@@ -11824,7 +11824,7 @@ return function(data, env)
 			box.Text = "Click here or press the '/' key to chat"
 			fadeOut()
 			if mode ~= "Cross" then
-				lastChat = tick()
+				lastChat = os.clock()
 			end
 		end
 	end)

--- a/MainModule/Client/UI/BasicAdmin.rbxmx
+++ b/MainModule/Client/UI/BasicAdmin.rbxmx
@@ -1708,10 +1708,10 @@ return function(data, env)
 		gTable:Destroy()
 	end)
 
-	local start = tick()
+	local start = os.clock()
 	repeat
 		wait()
-	until toReturn ~= nil or (duration and (tick()-duration) > duration)
+	until toReturn ~= nil or (duration and (os.clock()-duration) > duration)
 	if toReturn == nil then toReturn = false end
 
 	return toReturn

--- a/MainModule/Client/UI/Default/Chat.rbxmx
+++ b/MainModule/Client/UI/Default/Chat.rbxmx
@@ -2253,7 +2253,7 @@ return function(data, env)
 	end)
 
 	admins.MouseButton1Click:Connect(function()
-		if isAdmin or tick() - lastClick > 5 then
+		if isAdmin or os.clock() - lastClick > 5 then
 			isAdmin = client.Remote.Get("CheckAdmin")
 			if isAdmin then
 				openAdmins()
@@ -2261,12 +2261,12 @@ return function(data, env)
 				admins.BackgroundTransparency = 0.8
 				admins.TextTransparency = 0.8
 			end
-			lastClick = tick()
+			lastClick = os.clock()
 		end
 	end)
 
 	cross.MouseButton1Click:Connect(function()
-		if isAdmin or tick() - lastClick > 5 then
+		if isAdmin or os.clock() - lastClick > 5 then
 			isAdmin = client.Remote.Get("CheckAdmin")
 			if isAdmin then
 				openCross()
@@ -2274,24 +2274,24 @@ return function(data, env)
 				cross.BackgroundTransparency = 0.8
 				cross.TextTransparency = 0.8
 			end
-			lastClick = tick()
+			lastClick = os.clock()
 		end
 	end)
 
 	box.FocusLost:Connect(function(enterPressed)
 		boxFocused = false
 		if enterPressed and not client.Variables.Muted then
-			if box.Text ~= '' and ((mode ~= "Cross" and tick() - lastChat >= 0.5) or (mode == "Cross" and tick() - lastChat >= 10)) then
+			if box.Text ~= '' and ((mode ~= "Cross" and os.clock() - lastChat >= 0.5) or (mode == "Cross" and os.clock() - lastChat >= 10)) then
 				if not client.Variables.Muted then
 					client.Remote.Send('ProcessCustomChat', box.Text, mode)
-					lastChat = tick()
+					lastChat = os.clock()
 				end
-			elseif not ((mode ~= "Cross" and tick() - lastChat >= 0.5) or (mode == "Cross" and tick() - lastChat >= 10)) then
+			elseif not ((mode ~= "Cross" and os.clock() - lastChat >= 0.5) or (mode == "Cross" and os.clock() - lastChat >= 10)) then
 				local tim
 				if mode == "Cross" then
-					tim = 10 - (tick() - lastChat)
+					tim = 10 - (os.clock() - lastChat)
 				else
-					tim = 0.5 - (tick() - lastChat)
+					tim = 0.5 - (os.clock() - lastChat)
 				end
 				tim = string.sub(tostring(tim), 1, 3)
 				client.Handlers.ChatHandler("SpamBot", `Sending too fast! Please wait {tim} seconds.`, "System")
@@ -2299,7 +2299,7 @@ return function(data, env)
 			box.Text = "Click here or press the '/' key to chat"
 			fadeOut()
 			if mode ~= "Cross" then
-				lastChat = tick()
+				lastChat = os.clock()
 			end
 		end
 	end)

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -4570,7 +4570,7 @@ return function(Vargs, env)
 
 				scr.Name = "ADONIS_IceSkates"
 
-				for i, v in service.GetPlayers(plr, args[1]:lower()) do
+				for i, v in service.GetPlayers(plr, tostring(args[1]):lower()) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						local vel = vel:Clone()
 						vel.Parent = v.Character.HumanoidRootPart

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -4570,7 +4570,7 @@ return function(Vargs, env)
 
 				scr.Name = "ADONIS_IceSkates"
 
-				for i, v in service.GetPlayers(plr, tostring(args[1]):lower()) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						local vel = vel:Clone()
 						vel.Parent = v.Character.HumanoidRootPart

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -1687,11 +1687,11 @@ return function(Vargs, env)
 								if part.Position.Y>=main.Position.Y+50 then
 									run=false
 								end
-								pos.position=Vector3.new(50*math.cos(i), part.Position.Y+5, 50*math.sin(i))+main.Position
+								pos.Position=Vector3.new(50*math.cos(i), part.Position.Y+5, 50*math.sin(i))+main.Position
 								i=i+1
 							end
-							pos.maxForce = Vector3.new(500, 500, 500)
-							pos.position=Vector3.new(main.Position.X+math.random(-100, 100), main.Position.Y+100, main.Position.Z+math.random(-100, 100))
+							pos.MaxForce = Vector3.new(500, 500, 500)
+							pos.Position=Vector3.new(main.Position.X+math.random(-100, 100), main.Position.Y+100, main.Position.Z+math.random(-100, 100))
 							pos:Destroy()
 						end
 
@@ -1710,7 +1710,7 @@ return function(Vargs, env)
 
 						repeat
 							for i, v in parts do
-								if (((main.Position - v.Position).Magnitude * 250 * 20) < (5000 * 40)) and v and v:IsDescendantOf(workspace) then
+								if v and v:IsDescendantOf(workspace) and (((main.Position - v.Position).Magnitude * 250 * 20) < (5000 * 40)) then
 									task.spawn(fling, v)
 								elseif not v or not v:IsDescendantOf(workspace) then
 									table.remove(parts, i)

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -681,7 +681,7 @@ return function(Vargs, env)
 								if not restore[v] then
 									restore[v] = v.Color
 								end
-								v.Color = Color3.fromHSV(tick() % 1, 1, 1)
+								v.Color = Color3.fromHSV(os.time() % 1, 1, 1)
 							end
 						end
 					until not char or script.Name == "Stop" -- signal to unrainbowify

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -122,7 +122,6 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				local value = assert(tonumber(args[2]), "Missing/invalid FPS value (argument #2)")
-				assert(value <= 60, "FPS cannot exceed 60!")
 				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "SetFPS", value)
 				end

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -1711,7 +1711,7 @@ return function(Vargs, env)
 						repeat
 							for i, v in parts do
 								if (((main.Position - v.Position).Magnitude * 250 * 20) < (5000 * 40)) and v and v:IsDescendantOf(workspace) then
-									coroutine.wrap(fling, v)
+									task.spawn(fling, v)
 								elseif not v or not v:IsDescendantOf(workspace) then
 									table.remove(parts, i)
 								end

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -276,7 +276,7 @@ return function(Vargs, env)
 					sound:Destroy()
 					task.wait(1.4)
 					local vel = Instance.new("BodyVelocity")
-					vel.AssemblyLinearVelocity = CFrame.new(root.Position - Vector3.new(0, 1, 0), root.CFrame.LookVector * 5 + root.Position).LookVector * 1500
+					vel.Velocity = CFrame.new(root.Position - Vector3.new(0, 1, 0), root.CFrame.LookVector * 5 + root.Position).LookVector * 1500
 					vel.MaxForce = Vector3.new(math.huge, math.huge, math.huge)
 					vel.P = math.huge
 					vel.Parent = root
@@ -681,7 +681,7 @@ return function(Vargs, env)
 								if not restore[v] then
 									restore[v] = v.Color
 								end
-								v.Color = Color3.fromHSV(os.time() % 1, 1, 1)
+								v.Color = Color3.fromHSV(os.clock() % 1, 1, 1)
 							end
 						end
 					until not char or script.Name == "Stop" -- signal to unrainbowify
@@ -1923,8 +1923,8 @@ return function(Vargs, env)
 							Functions.MakeWeld(Part, v.Character.HumanoidRootPart, CFrame.new(0,-1, 0)*CFrame.Angles(-1.5, 0, 0))
 							local BodyVelocity = service.New("BodyVelocity")
 							BodyVelocity.Parent = Part
-							BodyVelocity.maxForce = Vector3.new(math.huge, math.huge, math.huge)
-							BodyVelocity.AssemblyLinearVelocity = Vector3.new(0, 100*speed, 0)
+							BodyVelocity.MaxForce = Vector3.new(math.huge, math.huge, math.huge)
+							BodyVelocity.Velocity = Vector3.new(0, 100*speed, 0)
 									--[[
 									cPcall(function()
 										for i = 1, math.huge do
@@ -4565,7 +4565,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local vel = service.New("BodyVelocity")
 				vel.Name = "ADONIS_IceVelocity"
-				vel.maxForce = Vector3.new(5000, 0, 5000)
+				vel.MaxForce = Vector3.new(5000, 0, 5000)
 				local scr = Deps.Assets.Slippery:Clone()
 
 				scr.Name = "ADONIS_IceSkates"

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -1676,7 +1676,7 @@ return function(Vargs, env)
 						function fling(part)
 							part:BreakJoints()
 							part.Anchored=false
-							local attachment = Instance.New("Attachment", part)
+							local attachment = Instance.new("Attachment", part)
 							local pos=Instance.new("AlignPosition", part)
 							pos.MaxForce = math.huge
 							pos.Position = part.Position

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -4592,7 +4592,7 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in service.GetPlayers(plr, args[1]:lower()) do
+				for i, v in service.GetPlayers(plr, args[1]) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						local scr = v.Character.HumanoidRootPart:FindFirstChild("ADONIS_IceSkates")
 						local vel = v.Character.HumanoidRootPart:FindFirstChild("ADONIS_IceVelocity")

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -276,7 +276,7 @@ return function(Vargs, env)
 					sound:Destroy()
 					task.wait(1.4)
 					local vel = Instance.new("BodyVelocity")
-					vel.Velocity = CFrame.new(root.Position - Vector3.new(0, 1, 0), root.CFrame.LookVector * 5 + root.Position).LookVector * 1500
+					vel.AssemblyLinearVelocity = CFrame.new(root.Position - Vector3.new(0, 1, 0), root.CFrame.LookVector * 5 + root.Position).LookVector * 1500
 					vel.MaxForce = Vector3.new(math.huge, math.huge, math.huge)
 					vel.P = math.huge
 					vel.Parent = root
@@ -1052,7 +1052,7 @@ return function(Vargs, env)
 												NumberSequenceKeypoint.new(1, 1)
 											}
 											em.Acceleration = Vector3.new(1, 0.1, 0)
-											em.VelocityInheritance = 0
+											em.AssemblyLinearVelocityInheritance = 0
 											em.EmissionDirection = "Top"
 											em.Lifetime = NumberRange.new(3, 8)
 											em.Rate = 10
@@ -1924,7 +1924,7 @@ return function(Vargs, env)
 							local BodyVelocity = service.New("BodyVelocity")
 							BodyVelocity.Parent = Part
 							BodyVelocity.maxForce = Vector3.new(math.huge, math.huge, math.huge)
-							BodyVelocity.velocity = Vector3.new(0, 100*speed, 0)
+							BodyVelocity.AssemblyLinearVelocity = Vector3.new(0, 100*speed, 0)
 									--[[
 									cPcall(function()
 										for i = 1, math.huge do
@@ -2028,7 +2028,7 @@ return function(Vargs, env)
 								p.TopSurface = "Smooth"
 								p.BottomSurface = "Smooth"
 								p.CFrame = v.Character.Head.CFrame * CFrame.new(Vector3.new(0, 0, -1))
-								p.Velocity = v.Character.Head.CFrame.lookVector * 20 + Vector3.new(math.random(-5, 5), math.random(-5, 5), math.random(-5, 5))
+								p.AssemblyLinearVelocity = v.Character.Head.CFrame.lookVector * 20 + Vector3.new(math.random(-5, 5), math.random(-5, 5), math.random(-5, 5))
 								p.Anchored = false
 								m.Name = "Puke Peice"
 								p.Name = "Puke Peice"
@@ -2098,7 +2098,7 @@ return function(Vargs, env)
 								p.TopSurface = "Smooth"
 								p.BottomSurface = "Smooth"
 								p.CFrame = v.Character.HumanoidRootPart.CFrame * CFrame.new(Vector3.new(2, 0, 0))
-								p.Velocity = v.Character.Head.CFrame.lookVector * 1 + Vector3.new(math.random(-1, 1), math.random(-1, 1), math.random(-1, 1))
+								p.AssemblyLinearVelocity = v.Character.Head.CFrame.lookVector * 1 + Vector3.new(math.random(-1, 1), math.random(-1, 1), math.random(-1, 1))
 								p.Anchored = false
 								m.Name = "Blood Peice"
 								p.Name = "Blood Peice"

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -1052,7 +1052,7 @@ return function(Vargs, env)
 												NumberSequenceKeypoint.new(1, 1)
 											}
 											em.Acceleration = Vector3.new(1, 0.1, 0)
-											em.AssemblyLinearVelocityInheritance = 0
+											em.VelocityInheritance = 0
 											em.EmissionDirection = "Top"
 											em.Lifetime = NumberRange.new(3, 8)
 											em.Rate = 10

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2695,7 +2695,7 @@ return function(Vargs, env)
 							while wait() and Variables.Jails[ind] == jail and mod.Parent == workspace do
 								if Variables.Jails[ind] == jail and v.Parent == service.Players then
 									if opt == "rainbow" then
-										box.Color3 = Color3.fromHSV(os.time()%5/5, 1, 1)
+										box.Color3 = Color3.fromHSV(os.clock()%5/5, 1, 1)
 									end
 
 									if v.Character then

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6076,7 +6076,7 @@ return function(Vargs, env)
 							repeat xran = math.random(-9999, 9999) until math.abs(xran) >= 5555
 							repeat zran = math.random(-9999, 9999) until math.abs(zran) >= 5555
 							v.Character.Humanoid.Sit = true
-							v.Character.HumanoidRootPart.Velocity = Vector3.new(0, 0, 0)
+							v.Character.HumanoidRootPart.AssemblyLinearVelocity = Vector3.new(0, 0, 0)
 							local Attachment = service.New("Attachment", v.Character.HumanoidRootPart)
 							local frc = service.New("VectorForce", v.Character.HumanoidRootPart)
 							frc.Name = "BFRC"

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2695,7 +2695,7 @@ return function(Vargs, env)
 							while wait() and Variables.Jails[ind] == jail and mod.Parent == workspace do
 								if Variables.Jails[ind] == jail and v.Parent == service.Players then
 									if opt == "rainbow" then
-										box.Color3 = Color3.fromHSV(tick()%5/5, 1, 1)
+										box.Color3 = Color3.fromHSV(os.time()%5/5, 1, 1)
 									end
 
 									if v.Character then

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -1135,7 +1135,6 @@ return function(Vargs, env)
 			Args = {"id"};
 			Description = "Prompts yourself to buy the asset belonging to the ID supplied";
 			AdminLevel = "Players";
-			Disabled = Settings.DisableBuyItem ~= false;
 			Function = function(plr: Player, args: {string})
 				local assetId = assert(tonumber(args[1]), "Missing asset ID (argument #1)")
 				local success, assetAlreadyOwned = pcall(service.MarketplaceService.PlayerOwnsAsset, service.MarketplaceService, plr, assetId)

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -1139,7 +1139,7 @@ return function(Vargs, env)
 				local assetId = assert(tonumber(args[1]), "Missing asset ID (argument #1)")
 				local success, assetAlreadyOwned = pcall(service.MarketplaceService.PlayerOwnsAsset, service.MarketplaceService, plr, assetId)
 				assert(not (success and assetAlreadyOwned), "You already own the asset!")
-				local success, assetInfo = pcall(service.MarketPlaceService.GetProductInfo, service.MarketPlaceService, assetId)
+				local success, assetInfo = pcall(service.MarketplaceService.GetProductInfo, service.MarketplaceService, assetId)
 				assert(success and not assetInfo.IsLimited, "Cannot buy limited assets!")
 				local connection; connection = service.MarketplaceService.PromptPurchaseFinished:Connect(function(_, boughtAssetId, isPurchased)
 					if boughtAssetId == assetId then

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -192,14 +192,14 @@ return function(Vargs, GetEnv)
 				rateCache = {
 					Rate = 0;
 					Throttle = 0;
-					LastUpdated = tick();
+					LastUpdated = os.clock();
 					LastThrottled = nil;
 				}
 
 				cacheLib[rateKey] = rateCache
 			end
 
-			local nowOs = tick()
+			local nowOs = os.clock()
 
 			if nowOs-rateCache.LastUpdated > resetInterval then
 				rateCache.LastUpdated = nowOs

--- a/MainModule/Server/Dependencies/Assets/Illegal.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Illegal.client.lua
@@ -80,8 +80,8 @@ task.spawn(function()
 
 		if startspaz then
 			humanoid.PlatformStand = true
-			torso.Velocity = Vector3.new(math.random(-10, 10), -5, math.random(-10, 10))
-			torso.RotVelocity = Vector3.new(math.random(-5, 5), math.random(-5, 5), math.random(-5, 5))
+			torso.AssemblyLinearVelocity = Vector3.new(math.random(-10, 10), -5, math.random(-10, 10))
+			torso.AssemblyAngularVelocity = Vector3.new(math.random(-5, 5), math.random(-5, 5), math.random(-5, 5))
 		end
 	until stop or not humanoid or not humanoid.Parent or humanoid.Health<=0 or not torso
 end)

--- a/MainModule/Server/Dependencies/Assets/Illegal.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Illegal.client.lua
@@ -52,7 +52,7 @@ humanoid.Died:Connect(function()
 	workspace.CurrentCamera.FieldOfView = 70
 end)
 
-coroutine.wrap(function()
+task.spawn(function()
 	while not stop and head and val and val.Parent==head do
 		local new=math.random(1,#msgs)
 		for k,m in pairs(msgs) do
@@ -66,13 +66,13 @@ coroutine.wrap(function()
 		end
 		task.wait(5)
 	end
-end)()
+end)
 
 humanoid.WalkSpeed=-16
 
 local startspaz = false
 
-coroutine.wrap(function()
+task.spawn(function()
 	repeat
 		task.wait(0.1)
 		workspace.CurrentCamera.FieldOfView = math.random(20, 80)
@@ -84,7 +84,7 @@ coroutine.wrap(function()
 			torso.RotVelocity = Vector3.new(math.random(-5, 5), math.random(-5, 5), math.random(-5, 5))
 		end
 	until stop or not humanoid or not humanoid.Parent or humanoid.Health<=0 or not torso
-end)()
+end)
 
 task.wait(10)
 
@@ -95,11 +95,11 @@ bg.P = 11111
 bg.cframe = torso.CFrame
 bg.Parent = torso
 
-coroutine.wrap(function()
+task.spawn(function()
 	repeat task.wait(1/44)
 		bg.cframe = bg.cframe * CFrame.Angles(0,math.rad(30),0)
 	until stop or not bg or bg.Parent ~= torso
-end)()
+end)
 
 task.wait(20)
 startspaz = true

--- a/MainModule/Server/Dependencies/Assets/Slippery.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Slippery.client.lua
@@ -2,7 +2,7 @@ task.wait(0.5)
 local vel = script.Parent:WaitForChild("ADONIS_IceVelocity")
 
 while script.Parent ~= nil and vel and vel.Parent  ~= nil do 
-	vel.AssemblyLinearVelocity = Vector3.new(script.Parent.AssemblyLinearVelocity.X, 0, script.Parent.AssemblyLinearVelocity.Z)
+	vel.Velocity = Vector3.new(script.Parent.AssemblyLinearVelocity.X, 0, script.Parent.AssemblyLinearVelocity.Z)
 	task.wait(0.1)
 end
 

--- a/MainModule/Server/Dependencies/Assets/Slippery.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Slippery.client.lua
@@ -2,7 +2,7 @@ task.wait(0.5)
 local vel = script.Parent:WaitForChild("ADONIS_IceVelocity")
 
 while script.Parent ~= nil and vel and vel.Parent  ~= nil do 
-	vel.Velocity = Vector3.new(script.Parent.AssemblyLinearVelocity.X, 0, script.Parent.AssemblyLinearVelocity.Z)
+	vel.AssemblyLinearVelocity = Vector3.new(script.Parent.AssemblyLinearVelocity.X, 0, script.Parent.AssemblyLinearVelocity.Z)
 	task.wait(0.1)
 end
 

--- a/MainModule/Server/Dependencies/Assets/Van.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Van.rbxmx
@@ -5,8 +5,6 @@
 	<Item class="Model" referent="RBX3D234256E6C24F11AA7DF82B44EB5E37">
 		<Properties>
 			<BinaryString name="AttributesSerialize"></BinaryString>
-			<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-			<bool name="DefinesCapabilities">false</bool>
 			<token name="LevelOfDetail">0</token>
 			<CoordinateFrame name="ModelMeshCFrame">
 				<X>0</X>
@@ -66,7 +64,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -74,7 +71,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -164,7 +160,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -172,7 +167,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -262,7 +256,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -270,7 +263,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -360,7 +352,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -368,7 +359,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -458,7 +448,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -466,7 +455,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -556,7 +544,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -564,7 +551,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -654,7 +640,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -662,7 +647,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -752,7 +736,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -760,7 +743,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -850,7 +832,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -858,7 +839,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -948,7 +928,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -956,7 +935,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -1046,7 +1024,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -1054,7 +1031,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -1144,7 +1120,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -1152,7 +1127,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -1242,7 +1216,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -1250,7 +1223,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -1340,7 +1312,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -1348,7 +1319,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -1413,13 +1383,11 @@
 					<float name="Angle">85</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">20</float>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0</G>
 						<B>0</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>
@@ -1459,7 +1427,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -1467,7 +1434,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -1532,13 +1498,11 @@
 					<float name="Angle">70</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">25</float>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0.992156923</G>
 						<B>0.698039234</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>
@@ -1578,7 +1542,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -1586,7 +1549,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -1651,13 +1613,11 @@
 					<float name="Angle">70</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">25</float>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0.992156923</G>
 						<B>0.698039234</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>
@@ -1671,8 +1631,6 @@
 		<Item class="Model" referent="RBXBE615C0671374DE288F18C3ED0C1590E">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-				<bool name="DefinesCapabilities">false</bool>
 				<token name="LevelOfDetail">0</token>
 				<CoordinateFrame name="ModelMeshCFrame">
 					<X>0</X>
@@ -1721,8 +1679,6 @@
 			<Item class="BodyColors" referent="RBXDA80A405C97A4652B0D83AF3EF9914AE">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-					<bool name="DefinesCapabilities">false</bool>
 					<Color3 name="HeadColor3">
 						<R>0.972549081</R>
 						<G>0.972549081</G>
@@ -1761,13 +1717,11 @@
 			<Item class="Pants" referent="RBX2B93EB76C338488B80D7E7E9CB801CE7">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Pants</string>
 					<Content name="PantsTemplate"><url>http://www.roblox.com/asset/?id=37566406</url></Content>
 					<int64 name="SourceAssetId">-1</int64>
@@ -1777,13 +1731,11 @@
 			<Item class="Shirt" referent="RBX720B26B49C7C4BEF8C6F02721C66BE86">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Shirt</string>
 					<Content name="ShirtTemplate"><url>http://www.roblox.com/asset/?id=15557308</url></Content>
 					<int64 name="SourceAssetId">-1</int64>
@@ -1819,7 +1771,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -1827,7 +1778,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -1890,8 +1840,6 @@
 				<Item class="SpecialMesh" referent="RBX25B665D04B7340618B5B70003BA044A9">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<Content name="MeshId"><null></null></Content>
 						<token name="MeshType">0</token>
 						<string name="Name">Mesh</string>
@@ -1918,13 +1866,11 @@
 				<Item class="Decal" referent="RBXDBE046BB0A8741EEB47D1C93A3EFC524">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
-						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">face</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -1965,8 +1911,6 @@
 							<R21>0</R21>
 							<R22>1</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<bool name="Enabled">true</bool>
 						<string name="Name">HeadWeld</string>
 						<Ref name="Part0">RBX0E9E3E9227154F0BAE3CEE42CC70D503</Ref>
@@ -2005,7 +1949,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -2013,7 +1956,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -2103,7 +2045,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -2111,7 +2052,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -2201,7 +2141,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -2209,7 +2148,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -2299,7 +2237,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -2307,7 +2244,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -2397,7 +2333,6 @@
 					<bool name="CanCollide">true</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -2405,7 +2340,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -2468,13 +2402,11 @@
 				<Item class="Decal" referent="RBXE76287758ACC4E128D8D3B393A5B6A28">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
-						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">roblox</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -2515,8 +2447,6 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">-0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.150000006</float>
@@ -2558,8 +2488,6 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">-0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.150000006</float>
@@ -2601,8 +2529,6 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
@@ -2644,8 +2570,6 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
@@ -2687,8 +2611,6 @@
 							<R21>1</R21>
 							<R22>-0</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
@@ -2707,9 +2629,7 @@
 					<bool name="AutoRotate">true</bool>
 					<bool name="AutomaticScalingEnabled">true</bool>
 					<bool name="BreakJointsOnDeath">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<token name="CollisionType">0</token>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="DisplayDistanceType">2</token>
 					<string name="DisplayName"></string>
 					<bool name="EvaluateStateMachine">true</bool>
@@ -2756,8 +2676,6 @@
 						<R22>1</R22>
 					</CoordinateFrame>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Clown</string>
 					<int64 name="SourceAssetId">-1</int64>
 					<BinaryString name="Tags"></BinaryString>
@@ -2791,7 +2709,6 @@
 						<bool name="CanCollide">false</bool>
 						<bool name="CanQuery">true</bool>
 						<bool name="CanTouch">true</bool>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<bool name="CastShadow">true</bool>
 						<string name="CollisionGroup">Default</string>
 						<int name="CollisionGroupId">0</int>
@@ -2799,7 +2716,6 @@
 						<PhysicalProperties name="CustomPhysicalProperties">
 							<CustomPhysics>false</CustomPhysics>
 						</PhysicalProperties>
-						<bool name="DefinesCapabilities">false</bool>
 						<bool name="EnableFluidForces">true</bool>
 						<float name="FrontParamA">-0.5</float>
 						<float name="FrontParamB">0.5</float>
@@ -2862,8 +2778,6 @@
 					<Item class="SpecialMesh" referent="RBXA015ED06CC9245AB9DA76885BF1F6810">
 						<Properties>
 							<BinaryString name="AttributesSerialize"></BinaryString>
-							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-							<bool name="DefinesCapabilities">false</bool>
 							<Content name="MeshId"><url>http://www.roblox.com/asset/?id=15393031</url></Content>
 							<token name="MeshType">5</token>
 							<string name="Name">Mesh</string>
@@ -2890,8 +2804,6 @@
 					<Item class="Vector3Value" referent="RBX15E7893ECF914144AA0CF429B5FAFC8B">
 						<Properties>
 							<BinaryString name="AttributesSerialize"></BinaryString>
-							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-							<bool name="DefinesCapabilities">false</bool>
 							<string name="Name">OriginalSize</string>
 							<int64 name="SourceAssetId">-1</int64>
 							<BinaryString name="Tags"></BinaryString>
@@ -2908,8 +2820,6 @@
 		<Item class="Model" referent="RBXC3672997144F43D895FCEAECF25EF4DE">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-				<bool name="DefinesCapabilities">false</bool>
 				<token name="LevelOfDetail">0</token>
 				<CoordinateFrame name="ModelMeshCFrame">
 					<X>0</X>
@@ -2958,8 +2868,6 @@
 			<Item class="BodyColors" referent="RBX8AE58D799F8B4F8FBA19B6C1547F62F8">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-					<bool name="DefinesCapabilities">false</bool>
 					<Color3 name="HeadColor3">
 						<R>0.972549081</R>
 						<G>0.972549081</G>
@@ -2998,13 +2906,11 @@
 			<Item class="Pants" referent="RBX44565AE1C06A40B589C65A823E677B61">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Pants</string>
 					<Content name="PantsTemplate"><url>http://www.roblox.com/asset/?id=37566406</url></Content>
 					<int64 name="SourceAssetId">-1</int64>
@@ -3014,13 +2920,11 @@
 			<Item class="Shirt" referent="RBXDF85B59B8C384FC392BF0076940734D8">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Shirt</string>
 					<Content name="ShirtTemplate"><url>http://www.roblox.com/asset/?id=15557308</url></Content>
 					<int64 name="SourceAssetId">-1</int64>
@@ -3056,7 +2960,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -3064,7 +2967,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -3127,8 +3029,6 @@
 				<Item class="SpecialMesh" referent="RBX1137DD53ED66482B8133F90C6FEB9985">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<Content name="MeshId"><null></null></Content>
 						<token name="MeshType">0</token>
 						<string name="Name">Mesh</string>
@@ -3155,13 +3055,11 @@
 				<Item class="Decal" referent="RBX649FF30726BA4417B145DD91D6FC0E5F">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
-						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">face</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -3202,8 +3100,6 @@
 							<R21>0</R21>
 							<R22>1</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<bool name="Enabled">true</bool>
 						<string name="Name">HeadWeld</string>
 						<Ref name="Part0">RBX99A8D1AC505C43F5A3777CFDE9F6F1AD</Ref>
@@ -3242,7 +3138,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -3250,7 +3145,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -3340,7 +3234,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -3348,7 +3241,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -3438,7 +3330,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -3446,7 +3337,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -3536,7 +3426,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -3544,7 +3433,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -3634,7 +3522,6 @@
 					<bool name="CanCollide">true</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -3642,7 +3529,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -3705,13 +3591,11 @@
 				<Item class="Decal" referent="RBXF320A1B0C19D447795D1DCA676E6676F">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
-						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">roblox</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -3752,8 +3636,6 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">-0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.150000006</float>
@@ -3795,8 +3677,6 @@
 							<R21>1</R21>
 							<R22>-0</R22>
 						</CoordinateFrame>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
@@ -3815,9 +3695,7 @@
 					<bool name="AutoRotate">true</bool>
 					<bool name="AutomaticScalingEnabled">true</bool>
 					<bool name="BreakJointsOnDeath">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<token name="CollisionType">0</token>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="DisplayDistanceType">2</token>
 					<string name="DisplayName"></string>
 					<bool name="EvaluateStateMachine">true</bool>
@@ -3864,8 +3742,6 @@
 						<R22>1</R22>
 					</CoordinateFrame>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Clown</string>
 					<int64 name="SourceAssetId">-1</int64>
 					<BinaryString name="Tags"></BinaryString>
@@ -3899,7 +3775,6 @@
 						<bool name="CanCollide">false</bool>
 						<bool name="CanQuery">true</bool>
 						<bool name="CanTouch">true</bool>
-						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<bool name="CastShadow">true</bool>
 						<string name="CollisionGroup">Default</string>
 						<int name="CollisionGroupId">0</int>
@@ -3907,7 +3782,6 @@
 						<PhysicalProperties name="CustomPhysicalProperties">
 							<CustomPhysics>false</CustomPhysics>
 						</PhysicalProperties>
-						<bool name="DefinesCapabilities">false</bool>
 						<bool name="EnableFluidForces">true</bool>
 						<float name="FrontParamA">-0.5</float>
 						<float name="FrontParamB">0.5</float>
@@ -3970,8 +3844,6 @@
 					<Item class="SpecialMesh" referent="RBXC546F605C3D5445D919560016F61834D">
 						<Properties>
 							<BinaryString name="AttributesSerialize"></BinaryString>
-							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-							<bool name="DefinesCapabilities">false</bool>
 							<Content name="MeshId"><url>http://www.roblox.com/asset/?id=15393031</url></Content>
 							<token name="MeshType">5</token>
 							<string name="Name">Mesh</string>
@@ -3998,8 +3870,6 @@
 					<Item class="Vector3Value" referent="RBX9E05A6B9846A4A959A8E70BCA0E07CF1">
 						<Properties>
 							<BinaryString name="AttributesSerialize"></BinaryString>
-							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-							<bool name="DefinesCapabilities">false</bool>
 							<string name="Name">OriginalSize</string>
 							<int64 name="SourceAssetId">-1</int64>
 							<BinaryString name="Tags"></BinaryString>
@@ -4016,8 +3886,6 @@
 		<Item class="Model" referent="RBX96FA9876B4334B4EBF8F883CC87256D4">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-				<bool name="DefinesCapabilities">false</bool>
 				<token name="LevelOfDetail">0</token>
 				<CoordinateFrame name="ModelMeshCFrame">
 					<X>0</X>
@@ -4092,7 +3960,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -4100,7 +3967,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -4190,7 +4056,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -4198,7 +4063,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -4288,7 +4152,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -4296,7 +4159,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -4386,7 +4248,6 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
 					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
@@ -4394,7 +4255,6 @@
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
@@ -4485,7 +4345,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -4493,7 +4352,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -4583,7 +4441,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -4591,7 +4448,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -4681,7 +4537,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -4689,7 +4544,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -4752,13 +4606,11 @@
 			<Item class="Texture" referent="RBXD3E7DCA21C024270B9BBA61AAC508D8F">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">4</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -4775,13 +4627,11 @@
 			<Item class="Texture" referent="RBX8946911272D346949F3FC9AD75FA8492">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">1</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -4825,7 +4675,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -4833,7 +4682,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -4923,7 +4771,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -4931,7 +4778,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5021,7 +4867,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5029,7 +4874,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5119,7 +4963,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5127,7 +4970,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5217,7 +5059,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5225,7 +5066,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5315,7 +5155,6 @@
 				<bool name="CanCollide">true</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5323,7 +5162,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5413,7 +5251,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5421,7 +5258,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5511,7 +5347,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5519,7 +5354,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5609,7 +5443,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5617,7 +5450,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5707,7 +5539,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5715,7 +5546,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5805,7 +5635,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5813,7 +5642,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -5903,7 +5731,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -5911,7 +5738,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6001,7 +5827,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6009,7 +5834,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6099,7 +5923,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6107,7 +5930,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6197,7 +6019,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6205,7 +6026,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6295,7 +6115,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6303,7 +6122,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6393,7 +6211,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6401,7 +6218,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6491,7 +6307,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6499,7 +6314,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6589,7 +6403,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6597,7 +6410,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6687,7 +6499,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6695,7 +6506,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6785,7 +6595,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -6793,7 +6602,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -6856,13 +6664,11 @@
 			<Item class="Texture" referent="RBX870602AC75964EFEBAF62317277D1949">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">4</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -6879,13 +6685,11 @@
 			<Item class="Texture" referent="RBXE8273AD79599449395BF0620224D9981">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">1</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -6931,7 +6735,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<BinaryString name="ChildData"></BinaryString>
 				<SharedString name="ChildData2">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
@@ -6941,7 +6744,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<token name="FluidFidelityInternal">0</token>
 				<token name="FormFactor">3</token>
@@ -7016,13 +6818,11 @@
 			<Item class="Texture" referent="RBX96AA0EEDBB774A3F9817515506EF9C42">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">3</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7039,13 +6839,11 @@
 			<Item class="Texture" referent="RBX4B69116C3E3943EA88DB11247832D6C9">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">0</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7091,7 +6889,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<BinaryString name="ChildData"></BinaryString>
 				<SharedString name="ChildData2">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
@@ -7101,7 +6898,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<token name="FluidFidelityInternal">0</token>
 				<token name="FormFactor">3</token>
@@ -7176,13 +6972,11 @@
 			<Item class="Texture" referent="RBXB6878F75460141348F17EB3B71ABE231">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">3</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7199,13 +6993,11 @@
 			<Item class="Texture" referent="RBXAA06DF0B0D674AA0AE40BCB78EA90F1F">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">0</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7249,7 +7041,6 @@
 				<bool name="CanCollide">true</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -7257,7 +7048,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -7320,13 +7110,11 @@
 			<Item class="Decal" referent="RBX7C301C66F97347E69E2005FB739D1E3A">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">0</token>
 					<string name="Name">Decal</string>
 					<int64 name="SourceAssetId">-1</int64>
@@ -7366,7 +7154,6 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
-				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
@@ -7374,7 +7161,6 @@
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
-				<bool name="DefinesCapabilities">false</bool>
 				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -7439,13 +7225,11 @@
 					<float name="Angle">85</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">20</float>
-					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0</G>
 						<B>0</B>
 					</Color3>
-					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>

--- a/MainModule/Server/Dependencies/Assets/Van.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Van.rbxmx
@@ -2,9 +2,11 @@
 	<Meta name="ExplicitAutoJoints">true</Meta>
 	<External>null</External>
 	<External>nil</External>
-	<Item class="Model" referent="RBX9A97EB2D7F324067947C7E93D4B67101">
+	<Item class="Model" referent="RBX3D234256E6C24F11AA7DF82B44EB5E37">
 		<Properties>
 			<BinaryString name="AttributesSerialize"></BinaryString>
+			<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+			<bool name="DefinesCapabilities">false</bool>
 			<token name="LevelOfDetail">0</token>
 			<CoordinateFrame name="ModelMeshCFrame">
 				<X>0</X>
@@ -26,14 +28,16 @@
 				<Y>0</Y>
 				<Z>0</Z>
 			</Vector3>
+			<token name="ModelStreamingMode">0</token>
 			<string name="Name">Van</string>
 			<bool name="NeedsPivotMigration">false</bool>
-			<Ref name="PrimaryPart">RBX0FDEFFC8CF64409995042948E080D4A9</Ref>
+			<Ref name="PrimaryPart">RBXFA385C6D818A40818D4A2495810E6E14</Ref>
+			<float name="ScaleFactor">1</float>
 			<int64 name="SourceAssetId">-1</int64>
 			<BinaryString name="Tags"></BinaryString>
 			<OptionalCoordinateFrame name="WorldPivotData"></OptionalCoordinateFrame>
 		</Properties>
-		<Item class="Part" referent="RBX33A59F18971045AB81FA56DAF523EBCC">
+		<Item class="Part" referent="RBXF4D707C37C504E378D92DA6881C9E6EF">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -62,12 +66,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -79,6 +87,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -126,7 +135,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXA4F7A6C7AC764F19B5AE6363CC972F7C">
+		<Item class="Part" referent="RBX4416BF930DFB43B5928A20D2DBEBF534">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -155,12 +164,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -172,6 +185,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -219,7 +233,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXEBF0E166236E426A9D0D56530081D049">
+		<Item class="Part" referent="RBXA89292C2DF8E41DEBFB8750D0FD9B153">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -248,12 +262,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -265,6 +283,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -312,7 +331,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX0FDEFFC8CF64409995042948E080D4A9">
+		<Item class="Part" referent="RBXFA385C6D818A40818D4A2495810E6E14">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -341,12 +360,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -358,6 +381,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Primary</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -405,7 +429,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXDAB5B0B5A70A4A548E7023CB136FD3C8">
+		<Item class="Part" referent="RBX82574843B5D74FE7803D1502056DC688">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -434,12 +458,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -451,6 +479,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -498,7 +527,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX0B5601082EE248B493772F3EF47CA71C">
+		<Item class="Part" referent="RBX6A28A9CD5AD7420F927450537BABB20F">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -527,12 +556,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -544,6 +577,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -590,172 +624,8 @@
 					<Z>13.6499977</Z>
 				</Vector3>
 			</Properties>
-			<Item class="ManualWeld" referent="RBX10B5D2893AD44543958FF486A9D69C8E">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-2.53500009</Y>
-						<Z>6.82499886</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>-0.359970093</X>
-						<Y>-2.42039609</Y>
-						<Z>0.449996948</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX0B5601082EE248B493772F3EF47CA71C</Ref>
-					<Ref name="Part1">RBXA6CDC0F95C5743E1958F7BDB86263B19</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">0</int>
-					<int name="Surface1">3</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-			<Item class="ManualWeld" referent="RBXA2B131BDA900469CAF1131ED586A788B">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-2.53500009</Y>
-						<Z>6.82499886</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>-3.47996521</X>
-						<Y>-4.8803978</Y>
-						<Z>0.449996948</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX0B5601082EE248B493772F3EF47CA71C</Ref>
-					<Ref name="Part1">RBX8DFAFFA544F6441E9BBB4B4FF94456AE</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">0</int>
-					<int name="Surface1">3</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-			<Item class="ManualWeld" referent="RBX1CDEA78E8DF04645A5D81CA0800C05A5">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-2.53500009</Y>
-						<Z>6.82499886</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>-3.45996094</X>
-						<Y>-1.0204041</Y>
-						<Z>0.449996948</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX0B5601082EE248B493772F3EF47CA71C</Ref>
-					<Ref name="Part1">RBX916E45FD387E4135B8DC6001F996B5B6</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">0</int>
-					<int name="Surface1">3</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-			<Item class="ManualWeld" referent="RBXAE9B5D9C8D3146CE9541814069756EB3">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-2.53500009</Y>
-						<Z>6.82499886</Z>
-						<R00>1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>-1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>-3.41996765</X>
-						<Y>0.11500144</Y>
-						<Z>0.259998322</Z>
-						<R00>1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>-1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX0B5601082EE248B493772F3EF47CA71C</Ref>
-					<Ref name="Part1">RBX2FAD7A9A92404EB2A59FD78D219BBC50</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">4</int>
-					<int name="Surface1">1</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
 		</Item>
-		<Item class="Part" referent="RBXC3B58022630E426C81943A2A178550BE">
+		<Item class="Part" referent="RBX27CF466E1C2945F6AB3B80DD115D668D">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -784,12 +654,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -801,6 +675,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -848,7 +723,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX681F11522CFE4481872007EE0EE12E37">
+		<Item class="Part" referent="RBX75242C9960634AAC8652DB1D55F7DD3E">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -877,12 +752,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -894,6 +773,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -941,7 +821,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXF2DFCE74AA7E476B83F7FEE7E1389522">
+		<Item class="Part" referent="RBXC253B62756B440239719618EE0CCA413">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -970,12 +850,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -987,6 +871,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1034,7 +919,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXE193BDB2BC01482F900B6E714CECE408">
+		<Item class="Part" referent="RBX343BC78B794743418AFBBDBCEA6AB924">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -1063,12 +948,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -1080,6 +969,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1127,7 +1017,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX4A0F9374409B4996B1BE07FCAEBF1DC8">
+		<Item class="Part" referent="RBX56C8527770B34DB0ABE529CFB2A1C0E6">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -1156,12 +1046,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -1173,6 +1067,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1220,7 +1115,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXD00CD5A92CA542008D9B1A4DADC87D7C">
+		<Item class="Part" referent="RBX1829D43DA5794B76AAF4EAEE1DEEFD63">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -1249,12 +1144,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -1266,6 +1165,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1313,7 +1213,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX99339A76E6CF4B608910DBE9D062A23A">
+		<Item class="Part" referent="RBXDC219DAB526A43C7AA30241909362F76">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -1342,12 +1242,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -1359,6 +1263,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Door</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1406,7 +1311,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXEB3FBC9EEC494E38945122A3C2D4E8F2">
+		<Item class="Part" referent="RBX8C8238C645924586A66F53E801015A00">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -1435,12 +1340,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4294901760</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -1452,6 +1361,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">288</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Light1</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1498,16 +1408,18 @@
 					<Z>0.200000003</Z>
 				</Vector3>
 			</Properties>
-			<Item class="SpotLight" referent="RBXF2CD9E19F31944A58F4564618B129975">
+			<Item class="SpotLight" referent="RBX86D0CF52369947D29902BA3BD5AC3C99">
 				<Properties>
 					<float name="Angle">85</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">20</float>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0</G>
 						<B>0</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>
@@ -1518,7 +1430,7 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="Part" referent="RBXCF7DA94B875944DAA925FCD44C920EE9">
+		<Item class="Part" referent="RBX8023F70AD62547B1A666A824CAE21A2C">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -1547,12 +1459,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4294498669</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -1564,6 +1480,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">288</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Light2</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1610,16 +1527,18 @@
 					<Z>0.200000003</Z>
 				</Vector3>
 			</Properties>
-			<Item class="SpotLight" referent="RBX685F8AB6A3174D34B859930BDB22630A">
+			<Item class="SpotLight" referent="RBX2506CC34A9834DD594FCD558F07108AC">
 				<Properties>
 					<float name="Angle">70</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">25</float>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0.992156923</G>
 						<B>0.698039234</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>
@@ -1630,7 +1549,7 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="Part" referent="RBXB60221616F924860BD6CD60ADF5ABEBF">
+		<Item class="Part" referent="RBXD21B8E35B0D9471AA84510EE1A768E89">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -1659,12 +1578,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4294498669</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -1676,6 +1599,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">288</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Light2</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -1722,16 +1646,18 @@
 					<Z>0.200000003</Z>
 				</Vector3>
 			</Properties>
-			<Item class="SpotLight" referent="RBX4BC974A9B28145999358B479EB84BBC8">
+			<Item class="SpotLight" referent="RBXF50BE10A272B48FDA06154EDD83E50CF">
 				<Properties>
 					<float name="Angle">70</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">25</float>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0.992156923</G>
 						<B>0.698039234</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>
@@ -1742,9 +1668,11 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="Model" referent="RBX58F91B15F77E4128971BA59C4CC9AB96">
+		<Item class="Model" referent="RBXBE615C0671374DE288F18C3ED0C1590E">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
 				<token name="LevelOfDetail">0</token>
 				<CoordinateFrame name="ModelMeshCFrame">
 					<X>0</X>
@@ -1766,9 +1694,11 @@
 					<Y>0</Y>
 					<Z>0</Z>
 				</Vector3>
+				<token name="ModelStreamingMode">0</token>
 				<string name="Name">Clown</string>
 				<bool name="NeedsPivotMigration">false</bool>
 				<Ref name="PrimaryPart">null</Ref>
+				<float name="ScaleFactor">1</float>
 				<int64 name="SourceAssetId">-1</int64>
 				<BinaryString name="Tags"></BinaryString>
 				<OptionalCoordinateFrame name="WorldPivotData">
@@ -1788,9 +1718,11 @@
 					</CFrame>
 				</OptionalCoordinateFrame>
 			</Properties>
-			<Item class="BodyColors" referent="RBXF8FB1AD966F8409B973971B76646D5C0">
+			<Item class="BodyColors" referent="RBXDA80A405C97A4652B0D83AF3EF9914AE">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
 					<Color3 name="HeadColor3">
 						<R>0.972549081</R>
 						<G>0.972549081</G>
@@ -1826,178 +1758,39 @@
 					</Color3>
 				</Properties>
 			</Item>
-			<Item class="Pants" referent="RBX7BC76E68DCDE41CA982EE2FBB7E5204F">
+			<Item class="Pants" referent="RBX2B93EB76C338488B80D7E7E9CB801CE7">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Pants</string>
 					<Content name="PantsTemplate"><url>http://www.roblox.com/asset/?id=37566406</url></Content>
 					<int64 name="SourceAssetId">-1</int64>
 					<BinaryString name="Tags"></BinaryString>
 				</Properties>
 			</Item>
-			<Item class="Shirt" referent="RBX0F846DAD303D49509BF48BD5600AF32B">
+			<Item class="Shirt" referent="RBX720B26B49C7C4BEF8C6F02721C66BE86">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Shirt</string>
 					<Content name="ShirtTemplate"><url>http://www.roblox.com/asset/?id=15557308</url></Content>
 					<int64 name="SourceAssetId">-1</int64>
 					<BinaryString name="Tags"></BinaryString>
 				</Properties>
 			</Item>
-			<Item class="Hat" referent="RBX6DCCD461F78B4A0CB704829178E4F7E8">
-				<Properties>
-					<CoordinateFrame name="AttachmentPoint">
-						<X>0</X>
-						<Y>0.649999976</Y>
-						<Z>0</Z>
-						<R00>1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>0</R12>
-						<R20>0</R20>
-						<R21>0</R21>
-						<R22>1</R22>
-					</CoordinateFrame>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<string name="Name">Clown</string>
-					<int64 name="SourceAssetId">-1</int64>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-				<Item class="Part" referent="RBXC37DDB328C044B818FB5F9A9A55194FD">
-					<Properties>
-						<bool name="Anchored">true</bool>
-						<BinaryString name="AttributesSerialize"></BinaryString>
-						<float name="BackParamA">-0.5</float>
-						<float name="BackParamB">0.5</float>
-						<token name="BackSurface">0</token>
-						<token name="BackSurfaceInput">0</token>
-						<float name="BottomParamA">-0.5</float>
-						<float name="BottomParamB">0.5</float>
-						<token name="BottomSurface">0</token>
-						<token name="BottomSurfaceInput">0</token>
-						<CoordinateFrame name="CFrame">
-							<X>72.9555664</X>
-							<Y>6.9507761</Y>
-							<Z>-32.5984383</Z>
-							<R00>0.0398320146</R00>
-							<R01>0</R01>
-							<R02>-0.999206364</R02>
-							<R10>0</R10>
-							<R11>1</R11>
-							<R12>0</R12>
-							<R20>0.999206364</R20>
-							<R21>0</R21>
-							<R22>0.0398320146</R22>
-						</CoordinateFrame>
-						<bool name="CanCollide">false</bool>
-						<bool name="CanQuery">true</bool>
-						<bool name="CanTouch">true</bool>
-						<bool name="CastShadow">true</bool>
-						<int name="CollisionGroupId">0</int>
-						<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
-						<PhysicalProperties name="CustomPhysicalProperties">
-							<CustomPhysics>false</CustomPhysics>
-						</PhysicalProperties>
-						<float name="FrontParamA">-0.5</float>
-						<float name="FrontParamB">0.5</float>
-						<token name="FrontSurface">0</token>
-						<token name="FrontSurfaceInput">0</token>
-						<float name="LeftParamA">-0.5</float>
-						<float name="LeftParamB">0.5</float>
-						<token name="LeftSurface">0</token>
-						<token name="LeftSurfaceInput">0</token>
-						<bool name="Locked">false</bool>
-						<bool name="Massless">false</bool>
-						<token name="Material">256</token>
-						<string name="Name">Handle</string>
-						<CoordinateFrame name="PivotOffset">
-							<X>0</X>
-							<Y>0</Y>
-							<Z>0</Z>
-							<R00>1</R00>
-							<R01>0</R01>
-							<R02>0</R02>
-							<R10>0</R10>
-							<R11>1</R11>
-							<R12>0</R12>
-							<R20>0</R20>
-							<R21>0</R21>
-							<R22>1</R22>
-						</CoordinateFrame>
-						<float name="Reflectance">0</float>
-						<float name="RightParamA">-0.5</float>
-						<float name="RightParamB">0.5</float>
-						<token name="RightSurface">0</token>
-						<token name="RightSurfaceInput">0</token>
-						<int name="RootPriority">0</int>
-						<Vector3 name="RotVelocity">
-							<X>0</X>
-							<Y>0</Y>
-							<Z>0</Z>
-						</Vector3>
-						<int64 name="SourceAssetId">-1</int64>
-						<BinaryString name="Tags"></BinaryString>
-						<float name="TopParamA">-0.5</float>
-						<float name="TopParamB">0.5</float>
-						<token name="TopSurface">0</token>
-						<token name="TopSurfaceInput">0</token>
-						<float name="Transparency">0</float>
-						<Vector3 name="Velocity">
-							<X>0</X>
-							<Y>0</Y>
-							<Z>0</Z>
-						</Vector3>
-						<token name="formFactorRaw">0</token>
-						<token name="shape">1</token>
-						<Vector3 name="size">
-							<X>2</X>
-							<Y>2</Y>
-							<Z>2</Z>
-						</Vector3>
-					</Properties>
-					<Item class="SpecialMesh" referent="RBXAF915583C9544FAE812A013025BEE09A">
-						<Properties>
-							<BinaryString name="AttributesSerialize"></BinaryString>
-							<token name="LODX">2</token>
-							<token name="LODY">2</token>
-							<Content name="MeshId"><url>http://www.roblox.com/asset/?id=15393031</url></Content>
-							<token name="MeshType">5</token>
-							<string name="Name">Mesh</string>
-							<Vector3 name="Offset">
-								<X>0</X>
-								<Y>0</Y>
-								<Z>0</Z>
-							</Vector3>
-							<Vector3 name="Scale">
-								<X>1</X>
-								<Y>1</Y>
-								<Z>1</Z>
-							</Vector3>
-							<int64 name="SourceAssetId">-1</int64>
-							<BinaryString name="Tags"></BinaryString>
-							<Content name="TextureId"><url>http://www.roblox.com/asset/?id=15393013</url></Content>
-							<Vector3 name="VertexColor">
-								<X>1</X>
-								<Y>1</Y>
-								<Z>1</Z>
-							</Vector3>
-						</Properties>
-					</Item>
-				</Item>
-			</Item>
-			<Item class="Part" referent="RBX29007563C4204C9BA575F6746CEDA2EA">
+			<Item class="Part" referent="RBX0E9E3E9227154F0BAE3CEE42CC70D503">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -2026,12 +1819,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4294506744</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -2043,6 +1840,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Head</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -2089,11 +1887,11 @@
 						<Z>1</Z>
 					</Vector3>
 				</Properties>
-				<Item class="SpecialMesh" referent="RBX7FCB74C05866494ABF1E877F38F9BBA9">
+				<Item class="SpecialMesh" referent="RBX25B665D04B7340618B5B70003BA044A9">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<token name="LODX">2</token>
-						<token name="LODY">2</token>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<Content name="MeshId"><null></null></Content>
 						<token name="MeshType">0</token>
 						<string name="Name">Mesh</string>
@@ -2117,14 +1915,16 @@
 						</Vector3>
 					</Properties>
 				</Item>
-				<Item class="Decal" referent="RBXA9D1338B4BEA42E48F295FA1F1DB638C">
+				<Item class="Decal" referent="RBXDBE046BB0A8741EEB47D1C93A3EFC524">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
+						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">face</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -2134,7 +1934,7 @@
 						<int name="ZIndex">1</int>
 					</Properties>
 				</Item>
-				<Item class="Weld" referent="RBXD982500906514AE790211FA8BBBE74F4">
+				<Item class="Weld" referent="RBX64C8F4F733A54EE29C6E4F0DC8CE5686">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -2165,16 +1965,18 @@
 							<R21>0</R21>
 							<R22>1</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<bool name="Enabled">true</bool>
 						<string name="Name">HeadWeld</string>
-						<Ref name="Part0">RBX29007563C4204C9BA575F6746CEDA2EA</Ref>
-						<Ref name="Part1">RBXC37DDB328C044B818FB5F9A9A55194FD</Ref>
+						<Ref name="Part0">RBX0E9E3E9227154F0BAE3CEE42CC70D503</Ref>
+						<Ref name="Part1">RBXA7CC1D741D8A40DE987BEFC70A61ABAE</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
 			</Item>
-			<Item class="Part" referent="RBXA3806312435D418D84420179150EEB13">
+			<Item class="Part" referent="RBXFA0874220CCF4E24B1E29D66963C0110">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -2203,12 +2005,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -2220,6 +2026,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Left Arm</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -2267,7 +2074,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBXE5AAA91EAE7D4ED28B5BC9347676B2B2">
+			<Item class="Part" referent="RBX33167F01FB474B4C948DB8A2CD5FB884">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -2296,12 +2103,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -2313,6 +2124,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Left Leg</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -2360,7 +2172,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBXD492BD6FD2514DDA85E7707EDD7390F6">
+			<Item class="Part" referent="RBXF31D44ED9F9544EDA681619A3A3E3854">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -2389,12 +2201,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -2406,6 +2222,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Right Arm</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -2453,7 +2270,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBX5EF005F94FBB4309852CDA258CF6D45F">
+			<Item class="Part" referent="RBX31BC674AA81B4F47A36AD11B3852C384">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -2482,12 +2299,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -2499,6 +2320,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Right Leg</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -2546,7 +2368,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBXFBECEC89B0C846B1B1DD9EF49EB4DD5D">
+			<Item class="Part" referent="RBX6ED92A44068C4CA48579BC8BB987DE9C">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -2572,15 +2394,19 @@
 						<R21>0</R21>
 						<R22>0.0398320146</R22>
 					</CoordinateFrame>
-					<bool name="CanCollide">false</bool>
+					<bool name="CanCollide">true</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -2592,6 +2418,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Torso</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -2638,14 +2465,16 @@
 						<Z>1</Z>
 					</Vector3>
 				</Properties>
-				<Item class="Decal" referent="RBXC9750F07D3744CB6AFEC23F30263EA98">
+				<Item class="Decal" referent="RBXE76287758ACC4E128D8D3B393A5B6A28">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
+						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">roblox</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -2655,7 +2484,7 @@
 						<int name="ZIndex">1</int>
 					</Properties>
 				</Item>
-				<Item class="Motor6D" referent="RBX457A3C06C9E8430AB726AE102F3D1FE8">
+				<Item class="Motor6D" referent="RBXD7B680A851C145729375EDE4DD0C72D0">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -2686,17 +2515,19 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">-0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.150000006</float>
 						<string name="Name">Right Shoulder</string>
-						<Ref name="Part0">RBXFBECEC89B0C846B1B1DD9EF49EB4DD5D</Ref>
-						<Ref name="Part1">RBXD492BD6FD2514DDA85E7707EDD7390F6</Ref>
+						<Ref name="Part0">RBX6ED92A44068C4CA48579BC8BB987DE9C</Ref>
+						<Ref name="Part1">RBXF31D44ED9F9544EDA681619A3A3E3854</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
-				<Item class="Motor6D" referent="RBXDF9353D6BE52475E84CCB05C95028D1F">
+				<Item class="Motor6D" referent="RBX3B2B6D6240CB4D1C9191F1C6B6EEF8AE">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -2727,17 +2558,19 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">-0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.150000006</float>
 						<string name="Name">Left Shoulder</string>
-						<Ref name="Part0">RBXFBECEC89B0C846B1B1DD9EF49EB4DD5D</Ref>
-						<Ref name="Part1">RBXA3806312435D418D84420179150EEB13</Ref>
+						<Ref name="Part0">RBX6ED92A44068C4CA48579BC8BB987DE9C</Ref>
+						<Ref name="Part1">RBXFA0874220CCF4E24B1E29D66963C0110</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
-				<Item class="Motor6D" referent="RBXC41008C16FD2431C9AD473BFCB8F0831">
+				<Item class="Motor6D" referent="RBX869F1421236D4BD39DBC134C86F70C5F">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -2768,17 +2601,19 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
 						<string name="Name">Right Hip</string>
-						<Ref name="Part0">RBXFBECEC89B0C846B1B1DD9EF49EB4DD5D</Ref>
-						<Ref name="Part1">RBX5EF005F94FBB4309852CDA258CF6D45F</Ref>
+						<Ref name="Part0">RBX6ED92A44068C4CA48579BC8BB987DE9C</Ref>
+						<Ref name="Part1">RBX31BC674AA81B4F47A36AD11B3852C384</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
-				<Item class="Motor6D" referent="RBX654DD2D5A86B4484A5C44394DC48AFE8">
+				<Item class="Motor6D" referent="RBXB50D5AAB41F8419B93DD0A65A5C55786">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -2809,17 +2644,19 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
 						<string name="Name">Left Hip</string>
-						<Ref name="Part0">RBXFBECEC89B0C846B1B1DD9EF49EB4DD5D</Ref>
-						<Ref name="Part1">RBXE5AAA91EAE7D4ED28B5BC9347676B2B2</Ref>
+						<Ref name="Part0">RBX6ED92A44068C4CA48579BC8BB987DE9C</Ref>
+						<Ref name="Part1">RBX33167F01FB474B4C948DB8A2CD5FB884</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
-				<Item class="Motor6D" referent="RBX2BC5E26FE2E3411683E7CD6493AA0AB1">
+				<Item class="Motor6D" referent="RBX3454530B22264DE0B863E3C01EC7522B">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -2850,27 +2687,32 @@
 							<R21>1</R21>
 							<R22>-0</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
 						<string name="Name">Neck</string>
-						<Ref name="Part0">RBXFBECEC89B0C846B1B1DD9EF49EB4DD5D</Ref>
-						<Ref name="Part1">RBX29007563C4204C9BA575F6746CEDA2EA</Ref>
+						<Ref name="Part0">RBX6ED92A44068C4CA48579BC8BB987DE9C</Ref>
+						<Ref name="Part1">RBX0E9E3E9227154F0BAE3CEE42CC70D503</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
 			</Item>
-			<Item class="Humanoid" referent="RBX1BA858D2796A446C849886A7074E1A06">
+			<Item class="Humanoid" referent="RBXE8FD395C734B44F5BF4272C05849997E">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<bool name="AutoJumpEnabled">true</bool>
 					<bool name="AutoRotate">true</bool>
 					<bool name="AutomaticScalingEnabled">true</bool>
 					<bool name="BreakJointsOnDeath">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<token name="CollisionType">0</token>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="DisplayDistanceType">2</token>
 					<string name="DisplayName"></string>
+					<bool name="EvaluateStateMachine">true</bool>
 					<float name="HealthDisplayDistance">0</float>
 					<token name="HealthDisplayType">0</token>
 					<float name="Health_XML">100</float>
@@ -2896,121 +2738,9 @@
 					<float name="WalkSpeed">16</float>
 				</Properties>
 			</Item>
-		</Item>
-		<Item class="Model" referent="RBXBBAF2816128945F098BF0157D77B336B">
-			<Properties>
-				<BinaryString name="AttributesSerialize"></BinaryString>
-				<token name="LevelOfDetail">0</token>
-				<CoordinateFrame name="ModelMeshCFrame">
-					<X>0</X>
-					<Y>0</Y>
-					<Z>0</Z>
-					<R00>1</R00>
-					<R01>0</R01>
-					<R02>0</R02>
-					<R10>0</R10>
-					<R11>1</R11>
-					<R12>0</R12>
-					<R20>0</R20>
-					<R21>0</R21>
-					<R22>1</R22>
-				</CoordinateFrame>
-				<SharedString name="ModelMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
-				<Vector3 name="ModelMeshSize">
-					<X>0</X>
-					<Y>0</Y>
-					<Z>0</Z>
-				</Vector3>
-				<string name="Name">Driver</string>
-				<bool name="NeedsPivotMigration">false</bool>
-				<Ref name="PrimaryPart">null</Ref>
-				<int64 name="SourceAssetId">-1</int64>
-				<BinaryString name="Tags"></BinaryString>
-				<OptionalCoordinateFrame name="WorldPivotData">
-					<CFrame>
-						<X>-69.917038</X>
-						<Y>4.82229996</Y>
-						<Z>-83.0796356</Z>
-						<R00>0.999962091</R00>
-						<R01>1.24134783e-06</R01>
-						<R02>-0.00871644821</R02>
-						<R10>-0.000484000047</R10>
-						<R11>0.998465121</R11>
-						<R12>-0.0553829074</R12>
-						<R20>0.00870300084</R20>
-						<R21>0.0553850196</R21>
-						<R22>0.998427212</R22>
-					</CFrame>
-				</OptionalCoordinateFrame>
-			</Properties>
-			<Item class="BodyColors" referent="RBX7DF5E9E542E54EBBA8324F071E8526B8">
+			<Item class="Accessory" referent="RBX9D37434B772B4F90AD4553CAFAB5203B">
 				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<Color3 name="HeadColor3">
-						<R>0.972549081</R>
-						<G>0.972549081</G>
-						<B>0.972549081</B>
-					</Color3>
-					<Color3 name="LeftArmColor3">
-						<R>0.854902029</R>
-						<G>0.521568656</G>
-						<B>0.254901975</B>
-					</Color3>
-					<Color3 name="LeftLegColor3">
-						<R>0.854902029</R>
-						<G>0.521568656</G>
-						<B>0.254901975</B>
-					</Color3>
-					<string name="Name">Body Colors</string>
-					<Color3 name="RightArmColor3">
-						<R>0.854902029</R>
-						<G>0.521568656</G>
-						<B>0.254901975</B>
-					</Color3>
-					<Color3 name="RightLegColor3">
-						<R>0.854902029</R>
-						<G>0.521568656</G>
-						<B>0.254901975</B>
-					</Color3>
-					<int64 name="SourceAssetId">-1</int64>
-					<BinaryString name="Tags"></BinaryString>
-					<Color3 name="TorsoColor3">
-						<R>0.854902029</R>
-						<G>0.521568656</G>
-						<B>0.254901975</B>
-					</Color3>
-				</Properties>
-			</Item>
-			<Item class="Pants" referent="RBXAC416009F2864097A076CB6D9E9B4EAF">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<Color3 name="Color3">
-						<R>1</R>
-						<G>1</G>
-						<B>1</B>
-					</Color3>
-					<string name="Name">Pants</string>
-					<Content name="PantsTemplate"><url>http://www.roblox.com/asset/?id=37566406</url></Content>
-					<int64 name="SourceAssetId">-1</int64>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-			<Item class="Shirt" referent="RBXDF789CE35A084661BBF9E540DB96A684">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<Color3 name="Color3">
-						<R>1</R>
-						<G>1</G>
-						<B>1</B>
-					</Color3>
-					<string name="Name">Shirt</string>
-					<Content name="ShirtTemplate"><url>http://www.roblox.com/asset/?id=15557308</url></Content>
-					<int64 name="SourceAssetId">-1</int64>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-			<Item class="Hat" referent="RBXF17968932CA94C78B5349C31A8B71F4B">
-				<Properties>
+					<token name="AccessoryType">0</token>
 					<CoordinateFrame name="AttachmentPoint">
 						<X>0</X>
 						<Y>0.649999976</Y>
@@ -3026,11 +2756,13 @@
 						<R22>1</R22>
 					</CoordinateFrame>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
 					<string name="Name">Clown</string>
 					<int64 name="SourceAssetId">-1</int64>
 					<BinaryString name="Tags"></BinaryString>
 				</Properties>
-				<Item class="Part" referent="RBX1A7194550BA9435A8916AD122B3DB19B">
+				<Item class="Part" referent="RBXA7CC1D741D8A40DE987BEFC70A61ABAE">
 					<Properties>
 						<bool name="Anchored">true</bool>
 						<BinaryString name="AttributesSerialize"></BinaryString>
@@ -3043,28 +2775,32 @@
 						<token name="BottomSurface">0</token>
 						<token name="BottomSurfaceInput">0</token>
 						<CoordinateFrame name="CFrame">
-							<X>73.4751892</X>
-							<Y>5.88738823</Y>
-							<Z>-39.7942848</Z>
-							<R00>0.999962091</R00>
-							<R01>1.24134783e-06</R01>
-							<R02>-0.00871644821</R02>
-							<R10>-0.000484000047</R10>
-							<R11>0.998465121</R11>
-							<R12>-0.0553829074</R12>
-							<R20>0.00870300084</R20>
-							<R21>0.0553850196</R21>
-							<R22>0.998427212</R22>
+							<X>72.9555664</X>
+							<Y>6.9507761</Y>
+							<Z>-32.5984383</Z>
+							<R00>0.0398320146</R00>
+							<R01>0</R01>
+							<R02>-0.999206364</R02>
+							<R10>0</R10>
+							<R11>1</R11>
+							<R12>0</R12>
+							<R20>0.999206364</R20>
+							<R21>0</R21>
+							<R22>0.0398320146</R22>
 						</CoordinateFrame>
 						<bool name="CanCollide">false</bool>
 						<bool name="CanQuery">true</bool>
 						<bool name="CanTouch">true</bool>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<bool name="CastShadow">true</bool>
+						<string name="CollisionGroup">Default</string>
 						<int name="CollisionGroupId">0</int>
 						<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 						<PhysicalProperties name="CustomPhysicalProperties">
 							<CustomPhysics>false</CustomPhysics>
 						</PhysicalProperties>
+						<bool name="DefinesCapabilities">false</bool>
+						<bool name="EnableFluidForces">true</bool>
 						<float name="FrontParamA">-0.5</float>
 						<float name="FrontParamB">0.5</float>
 						<token name="FrontSurface">0</token>
@@ -3076,6 +2812,7 @@
 						<bool name="Locked">false</bool>
 						<bool name="Massless">false</bool>
 						<token name="Material">256</token>
+						<string name="MaterialVariantSerialized"></string>
 						<string name="Name">Handle</string>
 						<CoordinateFrame name="PivotOffset">
 							<X>0</X>
@@ -3122,11 +2859,11 @@
 							<Z>2</Z>
 						</Vector3>
 					</Properties>
-					<Item class="SpecialMesh" referent="RBX16999721781E46FE8EA5B7E705732171">
+					<Item class="SpecialMesh" referent="RBXA015ED06CC9245AB9DA76885BF1F6810">
 						<Properties>
 							<BinaryString name="AttributesSerialize"></BinaryString>
-							<token name="LODX">2</token>
-							<token name="LODY">2</token>
+							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+							<bool name="DefinesCapabilities">false</bool>
 							<Content name="MeshId"><url>http://www.roblox.com/asset/?id=15393031</url></Content>
 							<token name="MeshType">5</token>
 							<string name="Name">Mesh</string>
@@ -3150,9 +2887,147 @@
 							</Vector3>
 						</Properties>
 					</Item>
+					<Item class="Vector3Value" referent="RBX15E7893ECF914144AA0CF429B5FAFC8B">
+						<Properties>
+							<BinaryString name="AttributesSerialize"></BinaryString>
+							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+							<bool name="DefinesCapabilities">false</bool>
+							<string name="Name">OriginalSize</string>
+							<int64 name="SourceAssetId">-1</int64>
+							<BinaryString name="Tags"></BinaryString>
+							<Vector3 name="Value">
+								<X>2</X>
+								<Y>2</Y>
+								<Z>2</Z>
+							</Vector3>
+						</Properties>
+					</Item>
 				</Item>
 			</Item>
-			<Item class="Part" referent="RBX104573DF37A44A8DA5F099B31581F021">
+		</Item>
+		<Item class="Model" referent="RBXC3672997144F43D895FCEAECF25EF4DE">
+			<Properties>
+				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
+				<token name="LevelOfDetail">0</token>
+				<CoordinateFrame name="ModelMeshCFrame">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+					<R00>1</R00>
+					<R01>0</R01>
+					<R02>0</R02>
+					<R10>0</R10>
+					<R11>1</R11>
+					<R12>0</R12>
+					<R20>0</R20>
+					<R21>0</R21>
+					<R22>1</R22>
+				</CoordinateFrame>
+				<SharedString name="ModelMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+				<Vector3 name="ModelMeshSize">
+					<X>0</X>
+					<Y>0</Y>
+					<Z>0</Z>
+				</Vector3>
+				<token name="ModelStreamingMode">0</token>
+				<string name="Name">Driver</string>
+				<bool name="NeedsPivotMigration">false</bool>
+				<Ref name="PrimaryPart">null</Ref>
+				<float name="ScaleFactor">1</float>
+				<int64 name="SourceAssetId">-1</int64>
+				<BinaryString name="Tags"></BinaryString>
+				<OptionalCoordinateFrame name="WorldPivotData">
+					<CFrame>
+						<X>-69.917038</X>
+						<Y>4.82229996</Y>
+						<Z>-83.0796356</Z>
+						<R00>0.999962091</R00>
+						<R01>1.24134783e-06</R01>
+						<R02>-0.00871644821</R02>
+						<R10>-0.000484000047</R10>
+						<R11>0.998465121</R11>
+						<R12>-0.0553829074</R12>
+						<R20>0.00870300084</R20>
+						<R21>0.0553850196</R21>
+						<R22>0.998427212</R22>
+					</CFrame>
+				</OptionalCoordinateFrame>
+			</Properties>
+			<Item class="BodyColors" referent="RBX8AE58D799F8B4F8FBA19B6C1547F62F8">
+				<Properties>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
+					<Color3 name="HeadColor3">
+						<R>0.972549081</R>
+						<G>0.972549081</G>
+						<B>0.972549081</B>
+					</Color3>
+					<Color3 name="LeftArmColor3">
+						<R>0.854902029</R>
+						<G>0.521568656</G>
+						<B>0.254901975</B>
+					</Color3>
+					<Color3 name="LeftLegColor3">
+						<R>0.854902029</R>
+						<G>0.521568656</G>
+						<B>0.254901975</B>
+					</Color3>
+					<string name="Name">Body Colors</string>
+					<Color3 name="RightArmColor3">
+						<R>0.854902029</R>
+						<G>0.521568656</G>
+						<B>0.254901975</B>
+					</Color3>
+					<Color3 name="RightLegColor3">
+						<R>0.854902029</R>
+						<G>0.521568656</G>
+						<B>0.254901975</B>
+					</Color3>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+					<Color3 name="TorsoColor3">
+						<R>0.854902029</R>
+						<G>0.521568656</G>
+						<B>0.254901975</B>
+					</Color3>
+				</Properties>
+			</Item>
+			<Item class="Pants" referent="RBX44565AE1C06A40B589C65A823E677B61">
+				<Properties>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<Color3 name="Color3">
+						<R>1</R>
+						<G>1</G>
+						<B>1</B>
+					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
+					<string name="Name">Pants</string>
+					<Content name="PantsTemplate"><url>http://www.roblox.com/asset/?id=37566406</url></Content>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+				</Properties>
+			</Item>
+			<Item class="Shirt" referent="RBXDF85B59B8C384FC392BF0076940734D8">
+				<Properties>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<Color3 name="Color3">
+						<R>1</R>
+						<G>1</G>
+						<B>1</B>
+					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
+					<string name="Name">Shirt</string>
+					<Content name="ShirtTemplate"><url>http://www.roblox.com/asset/?id=15557308</url></Content>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+				</Properties>
+			</Item>
+			<Item class="Part" referent="RBX99A8D1AC505C43F5A3777CFDE9F6F1AD">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -3181,12 +3056,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4294506744</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -3198,6 +3077,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Head</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -3244,11 +3124,11 @@
 						<Z>1</Z>
 					</Vector3>
 				</Properties>
-				<Item class="SpecialMesh" referent="RBX8DC637010B104F0282D4B5B0F6615AEF">
+				<Item class="SpecialMesh" referent="RBX1137DD53ED66482B8133F90C6FEB9985">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
-						<token name="LODX">2</token>
-						<token name="LODY">2</token>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<Content name="MeshId"><null></null></Content>
 						<token name="MeshType">0</token>
 						<string name="Name">Mesh</string>
@@ -3272,14 +3152,16 @@
 						</Vector3>
 					</Properties>
 				</Item>
-				<Item class="Decal" referent="RBX44149B026FFC4634B95C07B77AABE400">
+				<Item class="Decal" referent="RBX649FF30726BA4417B145DD91D6FC0E5F">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
+						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">face</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -3289,7 +3171,7 @@
 						<int name="ZIndex">1</int>
 					</Properties>
 				</Item>
-				<Item class="Weld" referent="RBX28101C7A173C4E7A925160875C5241F9">
+				<Item class="Weld" referent="RBX6E648F4A1DEE46899923323E3FDB4E3A">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -3320,16 +3202,18 @@
 							<R21>0</R21>
 							<R22>1</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<bool name="Enabled">true</bool>
 						<string name="Name">HeadWeld</string>
-						<Ref name="Part0">RBX104573DF37A44A8DA5F099B31581F021</Ref>
-						<Ref name="Part1">RBX1A7194550BA9435A8916AD122B3DB19B</Ref>
+						<Ref name="Part0">RBX99A8D1AC505C43F5A3777CFDE9F6F1AD</Ref>
+						<Ref name="Part1">RBXDAFECB9069B44490B21B81679DD239F7</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
 			</Item>
-			<Item class="Part" referent="RBXB387C1F6A6E34CD1A82360331E08543D">
+			<Item class="Part" referent="RBX2019B356E6734BC8ABCE9867A7FF4B69">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -3358,12 +3242,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -3375,6 +3263,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Left Arm</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -3422,7 +3311,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBXDF8478A536AD43CA8978C6E7FDD8A270">
+			<Item class="Part" referent="RBXD434135E0A0747DDBC5EDFCA8B7CF00C">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -3451,12 +3340,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -3468,6 +3361,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Left Leg</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -3515,7 +3409,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBX9B2580B94BBC414AB5404A6824F7D6E0">
+			<Item class="Part" referent="RBX91284B54CEE54DFAABD036D636A44528">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -3544,12 +3438,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -3561,6 +3459,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Right Arm</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -3608,7 +3507,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBXC09F8831F6AB4C2AAD789FD458EA05EF">
+			<Item class="Part" referent="RBXB67D7A258EFC46EE8B7473F4744454E0">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -3637,12 +3536,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -3654,6 +3557,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Right Leg</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -3701,7 +3605,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBXD8D3325465E744389E6E859119758C60">
+			<Item class="Part" referent="RBXAFEE3B5098564ED294475A7D5BBD056A">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -3727,15 +3631,19 @@
 						<R21>0.0553850196</R21>
 						<R22>0.998427212</R22>
 					</CoordinateFrame>
-					<bool name="CanCollide">false</bool>
+					<bool name="CanCollide">true</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4292511041</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -3747,6 +3655,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Torso</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -3793,14 +3702,16 @@
 						<Z>1</Z>
 					</Vector3>
 				</Properties>
-				<Item class="Decal" referent="RBX6D6C873EC217492FB115AF9AB5B57C1F">
+				<Item class="Decal" referent="RBXF320A1B0C19D447795D1DCA676E6676F">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 						<Color3 name="Color3">
 							<R>1</R>
 							<G>1</G>
 							<B>1</B>
 						</Color3>
+						<bool name="DefinesCapabilities">false</bool>
 						<token name="Face">5</token>
 						<string name="Name">roblox</string>
 						<int64 name="SourceAssetId">-1</int64>
@@ -3810,7 +3721,7 @@
 						<int name="ZIndex">1</int>
 					</Properties>
 				</Item>
-				<Item class="Motor6D" referent="RBX2C7C40F393624043BE64579AB791559A">
+				<Item class="Motor6D" referent="RBX1CEC12367225462BA3B50E3FE99DA327">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -3841,17 +3752,19 @@
 							<R21>0</R21>
 							<R22>0</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">-0.0620252751</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.150000006</float>
 						<string name="Name">Left Shoulder</string>
-						<Ref name="Part0">RBXD8D3325465E744389E6E859119758C60</Ref>
-						<Ref name="Part1">RBXB387C1F6A6E34CD1A82360331E08543D</Ref>
+						<Ref name="Part0">RBXAFEE3B5098564ED294475A7D5BBD056A</Ref>
+						<Ref name="Part1">RBX2019B356E6734BC8ABCE9867A7FF4B69</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
-				<Item class="Motor6D" referent="RBX61E845B6CF3648EF8E956159E6FA1690">
+				<Item class="Motor6D" referent="RBX3580F122772747D883FADA54E3DB2A29">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<CoordinateFrame name="C0">
@@ -3882,27 +3795,32 @@
 							<R21>1</R21>
 							<R22>-0</R22>
 						</CoordinateFrame>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="DefinesCapabilities">false</bool>
 						<float name="DesiredAngle">0</float>
 						<bool name="Enabled">true</bool>
 						<float name="MaxVelocity">0.100000001</float>
 						<string name="Name">Neck</string>
-						<Ref name="Part0">RBXD8D3325465E744389E6E859119758C60</Ref>
-						<Ref name="Part1">RBX104573DF37A44A8DA5F099B31581F021</Ref>
+						<Ref name="Part0">RBXAFEE3B5098564ED294475A7D5BBD056A</Ref>
+						<Ref name="Part1">RBX99A8D1AC505C43F5A3777CFDE9F6F1AD</Ref>
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
 			</Item>
-			<Item class="Humanoid" referent="RBXD6E353E7AEC14A959A4B1AC07AC3DFA5">
+			<Item class="Humanoid" referent="RBX90AF4FA2FC18426FAEEDA814728373ED">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<bool name="AutoJumpEnabled">true</bool>
 					<bool name="AutoRotate">true</bool>
 					<bool name="AutomaticScalingEnabled">true</bool>
 					<bool name="BreakJointsOnDeath">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<token name="CollisionType">0</token>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="DisplayDistanceType">2</token>
 					<string name="DisplayName"></string>
+					<bool name="EvaluateStateMachine">true</bool>
 					<float name="HealthDisplayDistance">0</float>
 					<token name="HealthDisplayType">0</token>
 					<float name="Health_XML">100</float>
@@ -3928,10 +3846,178 @@
 					<float name="WalkSpeed">16</float>
 				</Properties>
 			</Item>
+			<Item class="Accessory" referent="RBX90C534EDC6C248BB9768EB8ED4F61FC0">
+				<Properties>
+					<token name="AccessoryType">0</token>
+					<CoordinateFrame name="AttachmentPoint">
+						<X>0</X>
+						<Y>0.649999976</Y>
+						<Z>0</Z>
+						<R00>1</R00>
+						<R01>0</R01>
+						<R02>0</R02>
+						<R10>0</R10>
+						<R11>1</R11>
+						<R12>0</R12>
+						<R20>0</R20>
+						<R21>0</R21>
+						<R22>1</R22>
+					</CoordinateFrame>
+					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+					<bool name="DefinesCapabilities">false</bool>
+					<string name="Name">Clown</string>
+					<int64 name="SourceAssetId">-1</int64>
+					<BinaryString name="Tags"></BinaryString>
+				</Properties>
+				<Item class="Part" referent="RBXDAFECB9069B44490B21B81679DD239F7">
+					<Properties>
+						<bool name="Anchored">true</bool>
+						<BinaryString name="AttributesSerialize"></BinaryString>
+						<float name="BackParamA">-0.5</float>
+						<float name="BackParamB">0.5</float>
+						<token name="BackSurface">0</token>
+						<token name="BackSurfaceInput">0</token>
+						<float name="BottomParamA">-0.5</float>
+						<float name="BottomParamB">0.5</float>
+						<token name="BottomSurface">0</token>
+						<token name="BottomSurfaceInput">0</token>
+						<CoordinateFrame name="CFrame">
+							<X>73.4751892</X>
+							<Y>5.88738823</Y>
+							<Z>-39.7942848</Z>
+							<R00>0.999962091</R00>
+							<R01>1.24134783e-06</R01>
+							<R02>-0.00871644821</R02>
+							<R10>-0.000484000047</R10>
+							<R11>0.998465121</R11>
+							<R12>-0.0553829074</R12>
+							<R20>0.00870300084</R20>
+							<R21>0.0553850196</R21>
+							<R22>0.998427212</R22>
+						</CoordinateFrame>
+						<bool name="CanCollide">false</bool>
+						<bool name="CanQuery">true</bool>
+						<bool name="CanTouch">true</bool>
+						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+						<bool name="CastShadow">true</bool>
+						<string name="CollisionGroup">Default</string>
+						<int name="CollisionGroupId">0</int>
+						<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
+						<PhysicalProperties name="CustomPhysicalProperties">
+							<CustomPhysics>false</CustomPhysics>
+						</PhysicalProperties>
+						<bool name="DefinesCapabilities">false</bool>
+						<bool name="EnableFluidForces">true</bool>
+						<float name="FrontParamA">-0.5</float>
+						<float name="FrontParamB">0.5</float>
+						<token name="FrontSurface">0</token>
+						<token name="FrontSurfaceInput">0</token>
+						<float name="LeftParamA">-0.5</float>
+						<float name="LeftParamB">0.5</float>
+						<token name="LeftSurface">0</token>
+						<token name="LeftSurfaceInput">0</token>
+						<bool name="Locked">false</bool>
+						<bool name="Massless">false</bool>
+						<token name="Material">256</token>
+						<string name="MaterialVariantSerialized"></string>
+						<string name="Name">Handle</string>
+						<CoordinateFrame name="PivotOffset">
+							<X>0</X>
+							<Y>0</Y>
+							<Z>0</Z>
+							<R00>1</R00>
+							<R01>0</R01>
+							<R02>0</R02>
+							<R10>0</R10>
+							<R11>1</R11>
+							<R12>0</R12>
+							<R20>0</R20>
+							<R21>0</R21>
+							<R22>1</R22>
+						</CoordinateFrame>
+						<float name="Reflectance">0</float>
+						<float name="RightParamA">-0.5</float>
+						<float name="RightParamB">0.5</float>
+						<token name="RightSurface">0</token>
+						<token name="RightSurfaceInput">0</token>
+						<int name="RootPriority">0</int>
+						<Vector3 name="RotVelocity">
+							<X>0</X>
+							<Y>0</Y>
+							<Z>0</Z>
+						</Vector3>
+						<int64 name="SourceAssetId">-1</int64>
+						<BinaryString name="Tags"></BinaryString>
+						<float name="TopParamA">-0.5</float>
+						<float name="TopParamB">0.5</float>
+						<token name="TopSurface">0</token>
+						<token name="TopSurfaceInput">0</token>
+						<float name="Transparency">0</float>
+						<Vector3 name="Velocity">
+							<X>0</X>
+							<Y>0</Y>
+							<Z>0</Z>
+						</Vector3>
+						<token name="formFactorRaw">0</token>
+						<token name="shape">1</token>
+						<Vector3 name="size">
+							<X>2</X>
+							<Y>2</Y>
+							<Z>2</Z>
+						</Vector3>
+					</Properties>
+					<Item class="SpecialMesh" referent="RBXC546F605C3D5445D919560016F61834D">
+						<Properties>
+							<BinaryString name="AttributesSerialize"></BinaryString>
+							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+							<bool name="DefinesCapabilities">false</bool>
+							<Content name="MeshId"><url>http://www.roblox.com/asset/?id=15393031</url></Content>
+							<token name="MeshType">5</token>
+							<string name="Name">Mesh</string>
+							<Vector3 name="Offset">
+								<X>0</X>
+								<Y>0</Y>
+								<Z>0</Z>
+							</Vector3>
+							<Vector3 name="Scale">
+								<X>1</X>
+								<Y>1</Y>
+								<Z>1</Z>
+							</Vector3>
+							<int64 name="SourceAssetId">-1</int64>
+							<BinaryString name="Tags"></BinaryString>
+							<Content name="TextureId"><url>http://www.roblox.com/asset/?id=15393013</url></Content>
+							<Vector3 name="VertexColor">
+								<X>1</X>
+								<Y>1</Y>
+								<Z>1</Z>
+							</Vector3>
+						</Properties>
+					</Item>
+					<Item class="Vector3Value" referent="RBX9E05A6B9846A4A959A8E70BCA0E07CF1">
+						<Properties>
+							<BinaryString name="AttributesSerialize"></BinaryString>
+							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+							<bool name="DefinesCapabilities">false</bool>
+							<string name="Name">OriginalSize</string>
+							<int64 name="SourceAssetId">-1</int64>
+							<BinaryString name="Tags"></BinaryString>
+							<Vector3 name="Value">
+								<X>2</X>
+								<Y>2</Y>
+								<Z>2</Z>
+							</Vector3>
+						</Properties>
+					</Item>
+				</Item>
+			</Item>
 		</Item>
-		<Item class="Model" referent="RBXA4D7D14C664241A382867F258A3EDD8F">
+		<Item class="Model" referent="RBX96FA9876B4334B4EBF8F883CC87256D4">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+				<bool name="DefinesCapabilities">false</bool>
 				<token name="LevelOfDetail">0</token>
 				<CoordinateFrame name="ModelMeshCFrame">
 					<X>0</X>
@@ -3953,9 +4039,11 @@
 					<Y>0</Y>
 					<Z>0</Z>
 				</Vector3>
+				<token name="ModelStreamingMode">0</token>
 				<string name="Name">Model</string>
 				<bool name="NeedsPivotMigration">false</bool>
 				<Ref name="PrimaryPart">null</Ref>
+				<float name="ScaleFactor">1</float>
 				<int64 name="SourceAssetId">-1</int64>
 				<BinaryString name="Tags"></BinaryString>
 				<OptionalCoordinateFrame name="WorldPivotData">
@@ -3975,7 +4063,7 @@
 					</CFrame>
 				</OptionalCoordinateFrame>
 			</Properties>
-			<Item class="Part" referent="RBX916E45FD387E4135B8DC6001F996B5B6">
+			<Item class="Part" referent="RBX9878B914F48C47F58E634465D140ABA1">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4004,12 +4092,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -4021,6 +4113,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Part</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -4067,49 +4160,8 @@
 						<Z>0.459999919</Z>
 					</Vector3>
 				</Properties>
-				<Item class="ManualWeld" referent="RBX194B381CAA7B46189003CF2A7C867497">
-					<Properties>
-						<BinaryString name="AttributesSerialize"></BinaryString>
-						<CoordinateFrame name="C0">
-							<X>3.46000004</X>
-							<Y>-1.02999997</Y>
-							<Z>0.229999959</Z>
-							<R00>1</R00>
-							<R01>0</R01>
-							<R02>0</R02>
-							<R10>0</R10>
-							<R11>0</R11>
-							<R12>-1</R12>
-							<R20>0</R20>
-							<R21>1</R21>
-							<R22>0</R22>
-						</CoordinateFrame>
-						<CoordinateFrame name="C1">
-							<X>3.5</X>
-							<Y>0.105405569</Y>
-							<Z>0.0400009155</Z>
-							<R00>1</R00>
-							<R01>0</R01>
-							<R02>0</R02>
-							<R10>0</R10>
-							<R11>0</R11>
-							<R12>-1</R12>
-							<R20>0</R20>
-							<R21>1</R21>
-							<R22>0</R22>
-						</CoordinateFrame>
-						<bool name="Enabled">true</bool>
-						<string name="Name">Part-to-Part Strong Joint</string>
-						<Ref name="Part0">RBX916E45FD387E4135B8DC6001F996B5B6</Ref>
-						<Ref name="Part1">RBX2FAD7A9A92404EB2A59FD78D219BBC50</Ref>
-						<int64 name="SourceAssetId">-1</int64>
-						<int name="Surface0">4</int>
-						<int name="Surface1">1</int>
-						<BinaryString name="Tags"></BinaryString>
-					</Properties>
-				</Item>
 			</Item>
-			<Item class="Part" referent="RBXA6CDC0F95C5743E1958F7BDB86263B19">
+			<Item class="Part" referent="RBX92628EC7167749F6AE8913CF27FFED4A">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4138,12 +4190,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -4155,6 +4211,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Part</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -4201,49 +4258,8 @@
 						<Z>0.459999919</Z>
 					</Vector3>
 				</Properties>
-				<Item class="ManualWeld" referent="RBXEFB16A0C0C8C4E10A5AFD8072F4383ED">
-					<Properties>
-						<BinaryString name="AttributesSerialize"></BinaryString>
-						<CoordinateFrame name="C0">
-							<X>0.360000223</X>
-							<Y>-2.43000007</Y>
-							<Z>0.229999959</Z>
-							<R00>1</R00>
-							<R01>0</R01>
-							<R02>0</R02>
-							<R10>0</R10>
-							<R11>0</R11>
-							<R12>-1</R12>
-							<R20>0</R20>
-							<R21>1</R21>
-							<R22>0</R22>
-						</CoordinateFrame>
-						<CoordinateFrame name="C1">
-							<X>-2.69999695</X>
-							<Y>0.105397463</Y>
-							<Z>0.0400009155</Z>
-							<R00>1</R00>
-							<R01>0</R01>
-							<R02>0</R02>
-							<R10>0</R10>
-							<R11>0</R11>
-							<R12>-1</R12>
-							<R20>0</R20>
-							<R21>1</R21>
-							<R22>0</R22>
-						</CoordinateFrame>
-						<bool name="Enabled">true</bool>
-						<string name="Name">Part-to-Part Strong Joint</string>
-						<Ref name="Part0">RBXA6CDC0F95C5743E1958F7BDB86263B19</Ref>
-						<Ref name="Part1">RBX2FAD7A9A92404EB2A59FD78D219BBC50</Ref>
-						<int64 name="SourceAssetId">-1</int64>
-						<int name="Surface0">4</int>
-						<int name="Surface1">1</int>
-						<BinaryString name="Tags"></BinaryString>
-					</Properties>
-				</Item>
 			</Item>
-			<Item class="Part" referent="RBX8DFAFFA544F6441E9BBB4B4FF94456AE">
+			<Item class="Part" referent="RBX22CD6FC77F944AB8A9F37EC3D2C7063B">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4272,12 +4288,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -4289,6 +4309,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Part</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -4336,7 +4357,7 @@
 					</Vector3>
 				</Properties>
 			</Item>
-			<Item class="Part" referent="RBX014C4A1B3BF84473970F6AC8BED97469">
+			<Item class="Part" referent="RBX464141B0FF364C68ADE7C872A8DB394D">
 				<Properties>
 					<bool name="Anchored">true</bool>
 					<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4365,12 +4386,16 @@
 					<bool name="CanCollide">false</bool>
 					<bool name="CanQuery">true</bool>
 					<bool name="CanTouch">true</bool>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<bool name="CastShadow">true</bool>
+					<string name="CollisionGroup">Default</string>
 					<int name="CollisionGroupId">0</int>
 					<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 					<PhysicalProperties name="CustomPhysicalProperties">
 						<CustomPhysics>false</CustomPhysics>
 					</PhysicalProperties>
+					<bool name="DefinesCapabilities">false</bool>
+					<bool name="EnableFluidForces">true</bool>
 					<float name="FrontParamA">-0.5</float>
 					<float name="FrontParamB">0.5</float>
 					<token name="FrontSurface">0</token>
@@ -4382,6 +4407,7 @@
 					<bool name="Locked">false</bool>
 					<bool name="Massless">false</bool>
 					<token name="Material">256</token>
+					<string name="MaterialVariantSerialized"></string>
 					<string name="Name">Part</string>
 					<CoordinateFrame name="PivotOffset">
 						<X>0</X>
@@ -4430,7 +4456,7 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="Part" referent="RBXE4FA40E571274F61A743C644D3B90F34">
+		<Item class="Part" referent="RBXCC57122C74D646858CD4061F2E46B776">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4459,12 +4485,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -4476,6 +4506,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -4523,7 +4554,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX8895E33A32E541499F741E394B98F9FA">
+		<Item class="Part" referent="RBXE45964D5433C40069C84EE088059507F">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4552,12 +4583,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -4569,6 +4604,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -4616,7 +4652,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXBD3687157C394F8D83038997CB59BC26">
+		<Item class="Part" referent="RBXFE1C8F901F6440C3836CF38597EE8340">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4645,12 +4681,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -4662,6 +4702,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Window</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -4708,14 +4749,16 @@
 					<Z>2.7300005</Z>
 				</Vector3>
 			</Properties>
-			<Item class="Texture" referent="RBXA9308FE1B457495B8B6761888C750539">
+			<Item class="Texture" referent="RBXD3E7DCA21C024270B9BBA61AAC508D8F">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">4</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -4729,14 +4772,16 @@
 					<int name="ZIndex">1</int>
 				</Properties>
 			</Item>
-			<Item class="Texture" referent="RBX63B003DF609244FBB078EDB76FF860EB">
+			<Item class="Texture" referent="RBX8946911272D346949F3FC9AD75FA8492">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">1</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -4751,7 +4796,7 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="Part" referent="RBX1B1C1E1B47C8445C84B3F495A43B5027">
+		<Item class="Part" referent="RBXAF66DF3A20B845B1BB2957E351F4C573">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4780,12 +4825,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -4797,6 +4846,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -4843,49 +4893,8 @@
 					<Z>15.8500004</Z>
 				</Vector3>
 			</Properties>
-			<Item class="ManualWeld" referent="RBXD7AAF53D72114CC88BC7436060CAB1CF">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>4.10000038</X>
-						<Y>-0.11499995</Y>
-						<Z>7.92500019</Z>
-						<R00>1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>-1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>0.970031738</X>
-						<Y>1.54460526</Y>
-						<Z>0.460002899</Z>
-						<R00>1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>-1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX1B1C1E1B47C8445C84B3F495A43B5027</Ref>
-					<Ref name="Part1">RBX014C4A1B3BF84473970F6AC8BED97469</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">4</int>
-					<int name="Surface1">1</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
 		</Item>
-		<Item class="Part" referent="RBXB7973101E95A46B49F609AA8FE26F09C">
+		<Item class="Part" referent="RBX4AD2DC097F044A9597D2F32EE7194754">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -4914,12 +4923,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -4931,6 +4944,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -4978,7 +4992,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX7748619AAF274AE8B7F433BABB0203B1">
+		<Item class="Part" referent="RBX1DBF40AB2140444ABCE664E6AA1A7131">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5007,12 +5021,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5024,6 +5042,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5070,49 +5089,8 @@
 					<Z>0.76000005</Z>
 				</Vector3>
 			</Properties>
-			<Item class="ManualWeld" referent="RBXE0E80275E39F4D2B8A9FCDAE75B26C5C">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>-4.1500001</X>
-						<Y>0.254999965</Y>
-						<Z>0.380000025</Z>
-						<R00>-1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>-0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>-4.1199646</X>
-						<Y>-0.124997377</Y>
-						<Z>0.520000458</Z>
-						<R00>-1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>-0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX7748619AAF274AE8B7F433BABB0203B1</Ref>
-					<Ref name="Part1">RBX2FAD7A9A92404EB2A59FD78D219BBC50</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">1</int>
-					<int name="Surface1">4</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
 		</Item>
-		<Item class="Part" referent="RBX6EC577EF3DC64071B86F62A328614336">
+		<Item class="Part" referent="RBXB2BA21C3008F4C35BA6C67B5DA85301F">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5141,12 +5119,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5158,6 +5140,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5205,7 +5188,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX6530E66B9CFC451B889DAF881EC3628A">
+		<Item class="Part" referent="RBX67D6B07A6DAE47BCAE9761303F1E02DB">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5234,12 +5217,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5251,6 +5238,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5298,7 +5286,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXEA730227BAE34FADB2EB0C1B6C9689C4">
+		<Item class="Part" referent="RBX99000BD6307E4E8794AAEDD88E282A58">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5327,12 +5315,16 @@
 				<bool name="CanCollide">true</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5344,6 +5336,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5391,7 +5384,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX047E0E335F1D44BAB552CCC54343C1A7">
+		<Item class="Part" referent="RBX7E78B151732D4E5E981F807BC65564B0">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5420,12 +5413,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5437,6 +5434,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5484,7 +5482,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXCB094EC1B4D04CBD86C83282F479373E">
+		<Item class="Part" referent="RBX23F5770C03484DA4BFF240F382EF02B9">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5513,12 +5511,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5530,6 +5532,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5577,7 +5580,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX079B0D298B744EC798A178DEA06D487E">
+		<Item class="Part" referent="RBX219E5559DB0749FCBB1CC2E18F2931F0">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5606,12 +5609,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4284702562</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5623,6 +5630,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5670,7 +5678,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXA53AC304EA9641EBADC3B3BB6EB11A4B">
+		<Item class="Part" referent="RBX679DE66E64C44EBE9E4D6AA73DA0CB2E">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5699,12 +5707,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5716,6 +5728,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5763,7 +5776,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXE59327B7E7044148955A7EE7CCD5A796">
+		<Item class="Part" referent="RBX51E3AE631FCB4108BCC8B16D46AD551F">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5792,12 +5805,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5809,6 +5826,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5856,7 +5874,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX2FAD7A9A92404EB2A59FD78D219BBC50">
+		<Item class="Part" referent="RBX88FD018FE5B34780AA5EEE811413EA62">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5885,12 +5903,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5902,6 +5924,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -5949,7 +5972,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX3CAA328B31D2411C95E5B685039A2C9F">
+		<Item class="Part" referent="RBX05EF940F8819424FBDBA41C9E6BD53B8">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -5978,12 +6001,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -5995,6 +6022,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6042,7 +6070,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX6405D4EFCF424DE49289DF2624BD76E2">
+		<Item class="Part" referent="RBX163AAAE4677A443C811DAD05B88E7FDA">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6071,12 +6099,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6088,6 +6120,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6134,90 +6167,8 @@
 					<Z>5.54999828</Z>
 				</Vector3>
 			</Properties>
-			<Item class="ManualWeld" referent="RBXC48BE56FCD4D4F0C93745AFE4037B084">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-2.53500009</Y>
-						<Z>2.77499914</Z>
-						<R00>1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>-1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>4.12001038</X>
-						<Y>0.11500144</Y>
-						<Z>0.259998322</Z>
-						<R00>1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>0</R11>
-						<R12>-1</R12>
-						<R20>0</R20>
-						<R21>1</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX6405D4EFCF424DE49289DF2624BD76E2</Ref>
-					<Ref name="Part1">RBX2FAD7A9A92404EB2A59FD78D219BBC50</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">4</int>
-					<int name="Surface1">1</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-			<Item class="ManualWeld" referent="RBX2787479EFC5F4CB0A6EC559A33CE8002">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-2.53500009</Y>
-						<Z>-2.77499914</Z>
-						<R00>-1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>0</R12>
-						<R20>0</R20>
-						<R21>0</R21>
-						<R22>-1</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>0.330001831</X>
-						<Y>-2.53500009</Y>
-						<Z>2.79501724</Z>
-						<R00>-1</R00>
-						<R01>0</R01>
-						<R02>0</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>0</R12>
-						<R20>0</R20>
-						<R21>0</R21>
-						<R22>-1</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Door Strong Joint</string>
-					<Ref name="Part0">RBX6405D4EFCF424DE49289DF2624BD76E2</Ref>
-					<Ref name="Part1">RBX99339A76E6CF4B608910DBE9D062A23A</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">5</int>
-					<int name="Surface1">2</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
 		</Item>
-		<Item class="Part" referent="RBXD81165C595104DDBB14B96B098DCE5A8">
+		<Item class="Part" referent="RBXBE47D0F98DCC4E9A939316C712FF02D9">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6246,12 +6197,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6263,6 +6218,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6310,7 +6266,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBXA131AC4F81CA41F49DBA28F26C57A3D5">
+		<Item class="Part" referent="RBX8C04C211A0B44C49A35647602CB4E0FC">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6339,12 +6295,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6356,6 +6316,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6403,7 +6364,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX10CF77A9D2BE4A919CE93466AE0D8221">
+		<Item class="Part" referent="RBX24F9AD8D7D2345D48F453B6A315A1578">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6432,12 +6393,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6449,6 +6414,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6496,7 +6462,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX9540B3F4461E4BC49A815E813E2A2B13">
+		<Item class="Part" referent="RBX8317D288D34945A7B0E3B7C57CD14296">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6525,12 +6491,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6542,6 +6512,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6589,7 +6560,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX0663CB343EBC49BE897D390A217F4E66">
+		<Item class="Part" referent="RBX6C93C5D9778A43AEB3244FD111218E44">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6618,12 +6589,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6635,6 +6610,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6682,7 +6658,7 @@
 				</Vector3>
 			</Properties>
 		</Item>
-		<Item class="Part" referent="RBX0AC00C031417437D8F8B2AE3B2367AA3">
+		<Item class="Part" referent="RBXE088E62E04DB40BFAB047B8A57CD92C2">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6711,12 +6687,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6728,6 +6708,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Part</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6774,90 +6755,8 @@
 					<Z>19.9799976</Z>
 				</Vector3>
 			</Properties>
-			<Item class="ManualWeld" referent="RBXD0818652A8644C988BC7FED6DA9655DB">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-0.394999951</Y>
-						<Z>9.98999882</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>-0.359970093</X>
-						<Y>-3.10039568</Y>
-						<Z>0.419998169</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX0AC00C031417437D8F8B2AE3B2367AA3</Ref>
-					<Ref name="Part1">RBXA6CDC0F95C5743E1958F7BDB86263B19</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">0</int>
-					<int name="Surface1">3</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
-			<Item class="ManualWeld" referent="RBXD5E9A347BBDB4E85855B5F4C84E5ED59">
-				<Properties>
-					<BinaryString name="AttributesSerialize"></BinaryString>
-					<CoordinateFrame name="C0">
-						<X>0.329999983</X>
-						<Y>-0.394999951</Y>
-						<Z>9.98999882</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<CoordinateFrame name="C1">
-						<X>-3.45996094</X>
-						<Y>-1.70040369</Y>
-						<Z>0.419998169</Z>
-						<R00>0</R00>
-						<R01>0</R01>
-						<R02>1</R02>
-						<R10>0</R10>
-						<R11>1</R11>
-						<R12>-0</R12>
-						<R20>-1</R20>
-						<R21>0</R21>
-						<R22>0</R22>
-					</CoordinateFrame>
-					<bool name="Enabled">true</bool>
-					<string name="Name">Part-to-Part Strong Joint</string>
-					<Ref name="Part0">RBX0AC00C031417437D8F8B2AE3B2367AA3</Ref>
-					<Ref name="Part1">RBX916E45FD387E4135B8DC6001F996B5B6</Ref>
-					<int64 name="SourceAssetId">-1</int64>
-					<int name="Surface0">0</int>
-					<int name="Surface1">3</int>
-					<BinaryString name="Tags"></BinaryString>
-				</Properties>
-			</Item>
 		</Item>
-		<Item class="Part" referent="RBX65ECC5C0E36D4C3E854D4147010E1BE0">
+		<Item class="Part" referent="RBX79E2B16ECDDC46CD954F60E9707255A6">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -6886,12 +6785,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -6903,6 +6806,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Window</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -6949,14 +6853,16 @@
 					<Z>3.62000036</Z>
 				</Vector3>
 			</Properties>
-			<Item class="Texture" referent="RBX8CCB22F4B35C4E608BCE6C573ACD6E13">
+			<Item class="Texture" referent="RBX870602AC75964EFEBAF62317277D1949">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">4</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -6970,14 +6876,16 @@
 					<int name="ZIndex">1</int>
 				</Properties>
 			</Item>
-			<Item class="Texture" referent="RBX0670E6B5EC414F029CBA1CF10D4B4CEF">
+			<Item class="Texture" referent="RBXE8273AD79599449395BF0620224D9981">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">1</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -6992,8 +6900,9 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="UnionOperation" referent="RBX74FB940A39E14B56874C543E4B4798E6">
+		<Item class="UnionOperation" referent="RBXF6F04FEAE4B74DEB85BFAC8DB5944026">
 			<Properties>
+				<SharedString name="AeroMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
 				<bool name="Anchored">true</bool>
 				<Content name="AssetId"><url>http://www.roblox.com//asset/?id=531394419</url></Content>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -7022,14 +6931,19 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<BinaryString name="ChildData"></BinaryString>
 				<SharedString name="ChildData2">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
+				<token name="FluidFidelityInternal">0</token>
 				<token name="FormFactor">3</token>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -7040,7 +6954,6 @@
 					<Y>3.92315292</Y>
 					<Z>3.10763836</Z>
 				</Vector3>
-				<BinaryString name="LODData"></BinaryString>
 				<float name="LeftParamA">-0.5</float>
 				<float name="LeftParamB">0.5</float>
 				<token name="LeftSurface">0</token>
@@ -7048,6 +6961,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<BinaryString name="MeshData"></BinaryString>
 				<SharedString name="MeshData2">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
 				<string name="Name">Union</string>
@@ -7099,14 +7013,16 @@
 					<Z>3.10763836</Z>
 				</Vector3>
 			</Properties>
-			<Item class="Texture" referent="RBXDC51E0FE08844A67AB37DB1199087F89">
+			<Item class="Texture" referent="RBX96AA0EEDBB774A3F9817515506EF9C42">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">3</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7120,14 +7036,16 @@
 					<int name="ZIndex">1</int>
 				</Properties>
 			</Item>
-			<Item class="Texture" referent="RBX0B8FC04417B04A739BFC9F67D3A8C135">
+			<Item class="Texture" referent="RBX4B69116C3E3943EA88DB11247832D6C9">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">0</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7142,8 +7060,9 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="UnionOperation" referent="RBX425CBEEB1A40405EB0C629559BBB0B41">
+		<Item class="UnionOperation" referent="RBXA5484BA33CAB4B27AFEEB6106E5FEEBC">
 			<Properties>
+				<SharedString name="AeroMeshData">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
 				<bool name="Anchored">true</bool>
 				<Content name="AssetId"><url>http://www.roblox.com//asset/?id=531394419</url></Content>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -7172,14 +7091,19 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
 				<BinaryString name="ChildData"></BinaryString>
 				<SharedString name="ChildData2">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4279308561</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
+				<token name="FluidFidelityInternal">0</token>
 				<token name="FormFactor">3</token>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
@@ -7190,7 +7114,6 @@
 					<Y>3.92315292</Y>
 					<Z>3.10763836</Z>
 				</Vector3>
-				<BinaryString name="LODData"></BinaryString>
 				<float name="LeftParamA">-0.5</float>
 				<float name="LeftParamB">0.5</float>
 				<token name="LeftSurface">0</token>
@@ -7198,6 +7121,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<BinaryString name="MeshData"></BinaryString>
 				<SharedString name="MeshData2">yuZpQdnvvUBOTYh1jqZ2cA==</SharedString>
 				<string name="Name">Union</string>
@@ -7249,14 +7173,16 @@
 					<Z>3.10763836</Z>
 				</Vector3>
 			</Properties>
-			<Item class="Texture" referent="RBXDE551F768DFF4169BC46A4741936E62D">
+			<Item class="Texture" referent="RBXB6878F75460141348F17EB3B71ABE231">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">3</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7270,14 +7196,16 @@
 					<int name="ZIndex">1</int>
 				</Properties>
 			</Item>
-			<Item class="Texture" referent="RBX11887857821643998CE19CD63A1A1E73">
+			<Item class="Texture" referent="RBXAA06DF0B0D674AA0AE40BCB78EA90F1F">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">0</token>
 					<string name="Name">Texture</string>
 					<float name="OffsetStudsU">0</float>
@@ -7292,7 +7220,7 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="Part" referent="RBX9FD0BAEB664E4812B7422E446CA53E58">
+		<Item class="Part" referent="RBXEF0822E48F294D3BB211DA9034FA6721">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -7321,12 +7249,16 @@
 				<bool name="CanCollide">true</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -7338,6 +7270,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">256</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">EpixInc</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -7384,14 +7317,16 @@
 					<Z>1</Z>
 				</Vector3>
 			</Properties>
-			<Item class="Decal" referent="RBX7F02A190B4CE4A4A9B508B9433E3A287">
+			<Item class="Decal" referent="RBX7C301C66F97347E69E2005FB739D1E3A">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color3">
 						<R>1</R>
 						<G>1</G>
 						<B>1</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<token name="Face">0</token>
 					<string name="Name">Decal</string>
 					<int64 name="SourceAssetId">-1</int64>
@@ -7402,7 +7337,7 @@
 				</Properties>
 			</Item>
 		</Item>
-		<Item class="Part" referent="RBXD1D70280C7CC4984A0BF9453FF524823">
+		<Item class="Part" referent="RBX7AE72F190AB8472BAB8A913ADF8B44AA">
 			<Properties>
 				<bool name="Anchored">true</bool>
 				<BinaryString name="AttributesSerialize"></BinaryString>
@@ -7431,12 +7366,16 @@
 				<bool name="CanCollide">false</bool>
 				<bool name="CanQuery">true</bool>
 				<bool name="CanTouch">true</bool>
+				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 				<bool name="CastShadow">true</bool>
+				<string name="CollisionGroup">Default</string>
 				<int name="CollisionGroupId">0</int>
 				<Color3uint8 name="Color3uint8">4294901760</Color3uint8>
 				<PhysicalProperties name="CustomPhysicalProperties">
 					<CustomPhysics>false</CustomPhysics>
 				</PhysicalProperties>
+				<bool name="DefinesCapabilities">false</bool>
+				<bool name="EnableFluidForces">true</bool>
 				<float name="FrontParamA">-0.5</float>
 				<float name="FrontParamB">0.5</float>
 				<token name="FrontSurface">0</token>
@@ -7448,6 +7387,7 @@
 				<bool name="Locked">false</bool>
 				<bool name="Massless">false</bool>
 				<token name="Material">288</token>
+				<string name="MaterialVariantSerialized"></string>
 				<string name="Name">Light1</string>
 				<CoordinateFrame name="PivotOffset">
 					<X>0</X>
@@ -7494,16 +7434,18 @@
 					<Z>0.200000003</Z>
 				</Vector3>
 			</Properties>
-			<Item class="SpotLight" referent="RBXD90398EC98DB431FB16CF8B332194DA3">
+			<Item class="SpotLight" referent="RBXC3F6990D2D204ABB8B8CAD885A0B31C9">
 				<Properties>
 					<float name="Angle">85</float>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<float name="Brightness">20</float>
+					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 					<Color3 name="Color">
 						<R>1</R>
 						<G>0</G>
 						<B>0</B>
 					</Color3>
+					<bool name="DefinesCapabilities">false</bool>
 					<bool name="Enabled">true</bool>
 					<token name="Face">5</token>
 					<string name="Name">SpotLight</string>

--- a/MainModule/Server/Plugins/Anti_Cheat.lua
+++ b/MainModule/Server/Plugins/Anti_Cheat.lua
@@ -142,7 +142,7 @@ return function(Vargs, GetEnv)
 
 			for _, v in ipairs(character:GetChildren()) do
 				if v:IsA("Accoutrement") and Settings.ProtectHats == true and game.PlaceId < 13308063561 then -- // Enable workspace.RejectCharacterDeletions instead
-					coroutine.wrap(protectHat)(v)
+					task.spawn(protectHat, v)
 				end
 			end
 
@@ -267,7 +267,7 @@ return function(Vargs, GetEnv)
 		end
 
 		if player.Character then
-			coroutine.wrap(onCharacterAdded)(player.Character)
+			task.spawn(onCharacterAdded, player.Character)
 		end
 
 		player.CharacterRemoving:Connect(onCharacterRemoving)

--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -540,7 +540,7 @@ Main = (function()
 		caller(function() if not getfenv(2).zin then incompatibleMessage("RERU WILL BE FILING A LAWSUIT AGAINST YOU SOON") end end)
 		
 		local second = false
-		coroutine.wrap(function() local start = tick() wait(5) if tick() - start < 0.1 or not second then incompatibleMessage("SKIDDED YIELDING") end end)()
+		task.spawn(function() local start = tick() wait(5) if tick() - start < 0.1 or not second then incompatibleMessage("SKIDDED YIELDING") end end)
 		second = true
 	end
 	]]
@@ -1100,10 +1100,10 @@ Main = (function()
 		if not val then
 			local startTime = tick()
 			Main.MainGuiCloseTime = startTime
-			coroutine.wrap(function()
+			task.spawn(function()
 				Lib.FastWait(0.2)
 				if not Main.MainGuiOpen and startTime == Main.MainGuiCloseTime then Main.MainGui.OpenButton.MainFrame.Visible = false end
-			end)()
+			end)
 		else
 			Main.MainGuiMouseEvent = service.UserInputService.InputBegan:Connect(function(input)
 				if input.UserInputType == Enum.UserInputType.MouseButton1 and not Lib.CheckMouseInGui(Main.MainGui.OpenButton) and not Lib.CheckMouseInGui(Main.MainGui.OpenButton.MainFrame) then
@@ -1263,10 +1263,10 @@ Main = (function()
 
 		-- Done
 		intro.SetProgress("Complete",1)
-		coroutine.wrap(function()
+		task.spawn(function()
 			Lib.FastWait(1.25)
 			intro.Close()
-		end)()
+		end)
 
 		-- Init window system, create main menu, show explorer and properties
 		Lib.Window.Init()
@@ -2134,7 +2134,7 @@ local function main()
 		end
 
 		if hasExpanded and not updateDebounce then
-			coroutine.wrap(Explorer.PerformUpdate)(true)
+			task.spawn(Explorer.PerformUpdate, true)
 		end
 	end
 
@@ -2649,7 +2649,7 @@ local function main()
 		table.clear(nilCons)
 
 		for i = 1,#nilNode do
-			coroutine.wrap(removeObject)(nilNode[i].Obj)
+			task.spawn(removeObject, nilNode[i].Obj)
 		end
 
 		Explorer.Update()
@@ -2687,7 +2687,7 @@ local function main()
 			local node = nilNode[i]
 			if not newNilMap[node.Obj] then
 				nilMap[node.Obj] = nil
-				coroutine.wrap(removeObject)(node)
+				task.spawn(removeObject, node)
 			end
 		end]]
 
@@ -2696,7 +2696,7 @@ local function main()
 		for i = 1,#nilInsts do
 			local obj = nilInsts[i]
 			local node = nodes[obj]
-			if not node then coroutine.wrap(addObject)(obj) end
+			if not node then task.spawn(addObject, obj) end
 		end
 
 		--[[
@@ -3326,7 +3326,7 @@ return search]==]
 	end
 
 	Explorer.InitDelCleaner = function()
-		coroutine.wrap(function()
+		task.spawn(function()
 			local fw = Lib.FastWait
 			while true do
 				local processed = false
@@ -3365,7 +3365,7 @@ return search]==]
 				if processed and not refreshDebounce then Explorer.PerformRefresh() end
 				fw(0.5)
 			end
-		end)()
+		end)
 	end
 
 	Explorer.UpdateSelectionVisuals = function()
@@ -4082,7 +4082,7 @@ local function main()
 
 		funcs.Fire = function(self,...)
 			for i,v in next,self.Connections do
-				xpcall(coroutine.wrap(v.Func),function(e) warn(e.."\n"..debug.traceback()) end,...)
+				task.spawn(xpcall, v.Func, function(e) warn(e.."\n"..debug.traceback()) end, ...)
 			end
 		end
 
@@ -6645,7 +6645,7 @@ local function main()
 			lineTweens.Vis:Cancel()
 			cursor.BackgroundTransparency = 0
 			
-			coroutine.wrap(function()
+			task.spawn(function()
 				while self.Editable do
 					Lib.FastWait(0.5)
 					if self.LastAnimTime ~= animTime then return end
@@ -6655,7 +6655,7 @@ local function main()
 					lineTweens.Vis:Play()
 					Lib.FastWait(0.2)
 				end
-			end)()
+			end)
 		end
 		
 		funcs.MoveCursor = function(self,x,y)
@@ -10289,7 +10289,7 @@ local function main()
 			if newId then sound.TimePosition = 0 end
 			if not noplay then sound:Resume() end
 
-			coroutine.wrap(function()
+			task.spawn(function()
 				local previewTime = tick()
 				Properties.SoundPreviewTime = previewTime
 				while previewTime == Properties.SoundPreviewTime and sound.Playing do
@@ -10301,7 +10301,7 @@ local function main()
 					end
 					Lib.FastWait()
 				end
-			end)()
+			end)
 			Properties.Refresh()
 		end
 	end

--- a/MainModule/Server/Plugins/Urgent_Messages.lua
+++ b/MainModule/Server/Plugins/Urgent_Messages.lua
@@ -52,7 +52,7 @@ return function(Vargs, GetEnv)
 				local data = Core.GetPlayer(p);
 				if checkDoNotify(p, data) then
 					data.LastUrgentMessage = MessageVersion;
-					task.delay(0.5, Functions.Notification, "Urgent Message!", "Click to view messages", {p}, 20, "MatIcon://Announcement", {xpcall(Core.Bytecode("client.Remote.Send('ProcessCommand',':adonisalerts')"))}[2])
+					task.delay(0.5, xpcall, Functions.Notification, warn, "Urgent Message!", "Click to view messages", {p}, 20, "MatIcon://Announcement", {xpcall(Core.Bytecode("client.Remote.Send('ProcessCommand',':adonisalerts')"))}[2])
 				end
 			end
 		end

--- a/MainModule/Server/Plugins/Urgent_Messages.lua
+++ b/MainModule/Server/Plugins/Urgent_Messages.lua
@@ -52,7 +52,7 @@ return function(Vargs, GetEnv)
 				local data = Core.GetPlayer(p);
 				if checkDoNotify(p, data) then
 					data.LastUrgentMessage = MessageVersion;
-					task.delay(0.5, xpcall, Functions.Notification, warn, "Urgent Message!", "Click to view messages", {p}, 20, "MatIcon://Announcement", {xpcall(Core.Bytecode("client.Remote.Send('ProcessCommand',':adonisalerts')"))}[2])
+					task.delay(0.5, Functions.Notification, "Urgent Message!", "Click to view messages", {p}, 20, "MatIcon://Announcement", Core.Bytecode("client.Remote.Send('ProcessCommand',':adonisalerts')"))
 				end
 			end
 		end

--- a/MainModule/Server/Plugins/Urgent_Messages.lua
+++ b/MainModule/Server/Plugins/Urgent_Messages.lua
@@ -29,10 +29,6 @@ return function(Vargs, GetEnv)
 		LastDateTime = Alerts.LastDateTime;						--// Last message date and time
 		Messages = Alerts.Messages;								--// List of alert messages/lines
 
-		local function doNotify(p)
-			Functions.Notification("Urgent Message!", "Click to view messages", {p}, 20, "MatIcon://Announcement", Core.Bytecode("client.Remote.Send('ProcessCommand',':adonisalerts')"))
-		end
-
 		local function checkDoNotify(p, data)
 			local lastMessage = data.LastUrgentMessage or 0;
 
@@ -56,7 +52,7 @@ return function(Vargs, GetEnv)
 				local data = Core.GetPlayer(p);
 				if checkDoNotify(p, data) then
 					data.LastUrgentMessage = MessageVersion;
-					task.delay(0.5, doNotify, p)
+					task.delay(0.5, Functions.Notification, "Urgent Message!", "Click to view messages", {p}, 20, "MatIcon://Announcement", {xpcall(Core.Bytecode("client.Remote.Send('ProcessCommand',':adonisalerts')"))}[2])
 				end
 			end
 		end


### PR DESCRIPTION
- Fix `:BuyItem` being broken due to legacy setting and a typo
- Fixed anti cheat misdetecting if a player has a lag spike in which rendering doesn't happen for over minute. Now it is changed to 1.5 minutes. (A single frame should never take 1.5 minutes, if this is too low then it can be changed to 2.5 minutes/150 seconds)
- `coroutine.wrap` 2 `task.spawn` (Fixes a part of tornado code not working)
- `.Velocity` to `.AssemblyLinearVelocity`
- `Hat` to `Accessory`
- `tick()` to `os.clock()` or `os.time`
- Removed `ManualWeld` studio joint artifacts generated by a weird Roblox feature from `Van.rbxmx`
- Cleaned up some code
- Fix `:slippery` & `:unslippery`