### PR TITLE
Fix arguments for NoYield function; fix :sing command MeshID

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -5061,7 +5061,7 @@ return function(Vargs, env)
 						head.face:Destroy()
 					end
 
-					if head:IsA("MeshPart") and table.find(Variables.AnimatedFaces, tonumber(head.TextureID:match("%d%d%d+"))) then
+					if head:IsA("MeshPart") and table.find(Variables.AnimatedFaces, tonumber(head.MeshId:match("%d%d%d+"))) then
 						head.TextureID = ""
 						if head:FindFirstChildOfClass("SurfaceAppearance") then
 							head:FindFirstChildOfClass("SurfaceAppearance"):Destroy()

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -1219,9 +1219,9 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 
 
 			if noYield then
-				service.TrackTask(`Thread: Loop: {name}`, false, loop)
+				service.TrackTask(`Thread: Loop: {name}`, loop, false)
 			else
-				service.TrackTask(`Loop: {name}`, false, loop)
+				service.TrackTask(`Loop: {name}`, loop, false)
 			end
 
 			--[[local task = service.Threads.RunTask(`LOOP:{name}`, loop)


### PR DESCRIPTION
- Fixes typo in sing creating a double face
- Fixes the accidental mixing up of arguments from #1216. This fixes many things not working at all: capes, datastores, trello, _G API, SetFPS, ClientCheck, Hint counter, Loopkill, loopfling, loopheal, Anti Cheat, Dizzy, Disco, Autoclean, Musicshuffle, hint counter