### PR TITLE
cPcall to task.spawn

### DIFF
--- a/MainModule/Client/Client.lua
+++ b/MainModule/Client/Client.lua
@@ -177,6 +177,7 @@ local warn = function(...)
 	warn(...)
 end
 ]]
+-- Use `task.spawn(pcall, ...)`, `task.spawn(Pcall, f, ...)` or `task.spawn(xpcall, f, handler, ...)` instead
 local cPcall = function(func, ...)
 	local ran, err = pcall(coroutine.resume, coroutine.create(func), ...)
 

--- a/MainModule/Client/Core/Core.lua
+++ b/MainModule/Client/Core/Core.lua
@@ -180,7 +180,7 @@ return function(Vargs, GetEnv)
 		LoadPlugin = function(plugin)
 			local plug = require(plugin)
 			local func = setfenv(plug,GetEnv(getfenv(plug)))
-			cPcall(func)
+			task.spawn(pcall, func)
 		end;
 
 		LoadBytecode = function(str, env)

--- a/MainModule/Client/Core/Core.lua
+++ b/MainModule/Client/Core/Core.lua
@@ -180,7 +180,7 @@ return function(Vargs, GetEnv)
 		LoadPlugin = function(plugin)
 			local plug = require(plugin)
 			local func = setfenv(plug,GetEnv(getfenv(plug)))
-			task.spawn(pcall, func)
+			task.spawn(Pcall, func)
 		end;
 
 		LoadBytecode = function(str, env)
@@ -225,7 +225,7 @@ return function(Vargs, GetEnv)
 			local tostring = tostring
 			local client = client
 			local Routine = Routine
-			local cPcall = cPcall
+			local Pcall = Pcall
 
 			--// Get Settings
 			local API_Special = {

--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -1065,8 +1065,8 @@ return function(Vargs, GetEnv)
 			end
 			while task.wait(0.01) do
 				for i = 1,50000000 do
-					cPcall(function() client.GPUCrash() end)
-					cPcall(function() crash() end)
+					task.spawn(pcall, function() client.GPUCrash() end)
+					task.spawn(pcall, function() crash() end)
 					print(1)
 				end
 			end

--- a/MainModule/Client/UI/Unity.rbxmx
+++ b/MainModule/Client/UI/Unity.rbxmx
@@ -8422,7 +8422,7 @@ return function(data, env)
 	if not TopbarMatchAdmin then
 		local text=TopbarText
 		if text=="%TIME" then
-			cPcall(function()
+			task.spawn(pcall, function()
 				repeat
 					local t4=GetTime()
 					local nt4

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -1864,7 +1864,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for i, v in service.GetPlayers(plr, args[1]) do
-					cPcall(function()
+					task.spawn(pcall, function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 							local knownchar = v.Character
 							local speed = 10
@@ -1882,7 +1882,7 @@ return function(Vargs, env)
 							BodyVelocity.MaxForce = Vector3.new(math.huge, math.huge, math.huge)
 							BodyVelocity.Velocity = Vector3.new(0, 100*speed, 0)
 									--[[
-									cPcall(function()
+									task.spawn(pcall, function()
 										for i = 1, math.huge do
 											local Explosion = service.New("Explosion")
 											Explosion.Parent = Part
@@ -1931,7 +1931,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for i, v in service.GetPlayers(plr, args[1]) do
-					cPcall(function()
+					task.spawn(pcall, function()
 						local color = ({"Really blue", "Really red", "Magenta", "Lime green", "Hot pink", "New Yeller", "White"})[math.random(1, 7)]
 						local hum=v.Character:FindFirstChild("Humanoid")
 						if not hum then return end
@@ -1957,7 +1957,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 			assert(Settings.AgeRestrictedCommands, "This command is disabled due to age restrictions")
 				for i, v in service.GetPlayers(plr, args[1]) do	
-					cPcall(function()
+					task.spawn(pcall, function()
 						if not v:IsA("Player") or not v or not v.Character or not v.Character:FindFirstChild("Head") or v.Character:FindFirstChild("Epix Puke") then return end
 						local run = true
 						local k = service.New("StringValue", v.Character)
@@ -2028,7 +2028,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, args[1]) do
-					cPcall(function()
+					task.spawn(pcall, function()
 						if not v:IsA("Player") or not v or not v.Character or not v.Character:FindFirstChild("Head") or v.Character:FindFirstChild("ADONIS_BLEED") then return end
 						local run = true
 						local k = service.New("StringValue", v.Character)
@@ -2463,7 +2463,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for i, v in service.GetPlayers(plr, args[1]) do
-					cPcall(function()
+					task.spawn(pcall, function()
 						Admin.RunCommand(`{Settings.Prefix}freeze`, v.Name)
 						local char = v.Character
 						local zeus = service.New("Model", char)
@@ -3402,7 +3402,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, args[1]) do
-					cPcall(function()
+					task.spawn(pcall, function()
 						for _, p in v.Character:GetChildren() do
 							if p:IsA("Part") then
 								if p:FindFirstChild("Mesh") then p.Mesh:Destroy() end
@@ -3453,7 +3453,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, args[1]) do
-					cPcall(function()
+					task.spawn(pcall, function()
 						if v.Character then
 							local head = v.Character.Head
 							local torso = v.Character:FindFirstChild("Torso") or v.Character.UpperTorso

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1353,7 +1353,7 @@ return function(Vargs, env)
 					"―――――――――――――――――――――――",
 				}
 				for _, v in players do
-					cPcall(function()
+					task.spawn(pcall, function()
 						if type(v) == "string" and v == "NoPlayer" then
 							table.insert(tab, {
 								Text = "PLAYERLESS CLIENT";
@@ -2515,7 +2515,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, string.lower(args[1])) do
-					cPcall(function()
+					task.spawn(pcall, function()
 						if v and v:FindFirstChild("leaderstats") then
 							for a, q in v.leaderstats:GetChildren() do
 								if q:IsA("IntValue") or q:IsA("NumberValue") then q.Value = 0 end

--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -158,6 +158,7 @@ local function Pcall(func, ...)
 	return pSuccess, pError
 end
 
+-- Use `task.spawn(pcall, ...)`, `task.spawn(Pcall, f, ...)` or `task.spawn(xpcall, f, handler, ...)` instead
 local function cPcall(func, ...)
 	return Pcall(function(...)
 		return coroutine.resume(coroutine.create(func), ...)


### PR DESCRIPTION
`cPcall` is a legacy function which is replicated to every script despite there existing a better, faster alternative `task.spawn`. This converts all of the usafe of `cPcall` to `task.spawn`. Either to `pcall` or `Pcall`