### PR TITLE
Update !playerinfo command - Get Render Resolution

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -1778,6 +1778,7 @@ return function(Vargs, GetEnv)
 			for _, p in props do
 				data[p] = service.UserInputService[p]
 			end
+			data["Resolution"] = workspace.CurrentCamera.ViewportSize.X.." x "..workspace.CurrentCamera.ViewportSize.Y
 			return data
 		end;
 	};

--- a/MainModule/Client/UI/Default/Profile.lua
+++ b/MainModule/Client/UI/Default/Profile.lua
@@ -388,6 +388,7 @@ return function(data, env)
 			{"Mouse Delta Sensitivity", data.GameData.MouseDeltaSensitivity, "The scale of the delta (change) output of the user’s Mouse"},
 			{"Mouse Enabled", boolToStr(data.GameData.MouseEnabled), "Whether the user’s device has a mouse available"},
 			-- NEEDS REFRESHABILITY {"OnScreenKeyboardVisible", data.GameData.OnScreenKeyboardVisible, "Whether an on-screen keyboard is currently visible on the user’s screen"},
+			{"Render Resolution", data.GameData.Resolution, "The render resolution on user's current device. May not reflect real resolution on high-DPI devices."},
 			{"Touch Enabled", boolToStr(data.GameData.TouchEnabled), "Whether the user’s current device has a touch-screen available"},
 			{"VR Enabled", boolToStr(data.GameData.VREnabled), "Whether the user is using a virtual reality headset"},
 			{"Source Place ID", data.GameData.SourcePlaceId, "The ID of the place from which the player was teleported to this game, if applicable"},


### PR DESCRIPTION
Uses `workspace.CurrentCamera.ViewportSize` from mentioned player's client to get the rendered resolution.
Useful for evaluating player's response if they're talking about your UI for their own devices.

Viewing my own resolution:
![image](https://github.com/Epix-Incorporated/Adonis/assets/54766538/afc87ee9-0e13-44fe-a9d5-8c7ef2661c4a)

Viewing another player with a mobile device (Xiaomi Redmi 10C, 1560 x 720, not mine):
![image](https://github.com/Epix-Incorporated/Adonis/assets/54766538/50c49436-b076-445b-8d11-25609ca3fb7e)
(Horizontal resolution is a bit less than said real render resolution as ViewportSize does account for screen "notches")

Note that High-DPI displays will have their resolution lower than the real ones. Additionally, on desktop OSes and Android, they can still run Roblox in windowed mode thus the resolution will be different than actual device resolution.