### PR TITLE
Remove linkedlist toggle in userfacing settings

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -290,7 +290,6 @@ settings.SystemTitle = "System Message"		-- Title to display in :sm and :bc
 
 settings.MaxLogs = 5000			-- Maximum logs to save before deleting the oldest
 settings.SaveCommandLogs = true	-- If command logs are saved to the datastores
-settings.UseLinkedListsInLogs = true -- If true then log system uses a linked-list system to store logs instead of tables - severely improves server performance & allows for large logs with little to no impact except slightly increased memory usage
 settings.Notification = true	-- Whether or not to show the "You're an admin" and "Updated" notifications
 settings.SongHint = true		-- Display a hint with the current song name and ID when a song is played via :music
 settings.TopBarShift = false	-- By default hints and notifications will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region.
@@ -462,7 +461,6 @@ descs.SystemTitle = [[ Title to display in :sm ]]
 descs.CreatorPowers = [[ Gives me creator-level admin; This is strictly used for debugging; I can't debug without access to the script and specific owner commands ]]
 descs.MaxLogs = [[ Maximum logs to save before deleting the oldest; Too high can lag the game ]]
 descs.SaveCommandLogs = [[ If command logs are saved to the datastores ]]
-descs.UseLinkedListsInLogs = [[ If true then log system uses a linked-list system to store logs instead of tables - severely improves server performance & allows for large logs with little to no impact except slightly increased memory usage ]]
 descs.Notification = [[ Whether or not to show the "You're an admin" and "Updated" notifications ]]
 descs.CodeExecution = [[ Enables the use of code execution in Adonis; Scripting related and a few other commands require this ]]
 descs.SongHint = [[ Display a hint with the current song name and ID when a song is played via :music ]]
@@ -603,7 +601,6 @@ order = {
 	" ";
 	"MaxLogs";
 	"SaveCommandLogs";
-	"UseLinkedListsInLogs";
 	"Notification";
 	"SongHint";
 	"TopBarShift";

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -34,9 +34,9 @@ return function(Vargs, GetEnv)
 		Logs.Init = nil;
 		Logs:AddLog("Script", "Logging Module Initialized");
 	end;
-	
-	local UseDLL = server.Settings.UseLinkedListsInLogs == true
-	
+
+	local UseDLL = server.Settings.UseLinkedListsInLogs == true or server.Settings.UseLinkedListsInLogs == nil
+
 	server.Logs = {
 		Init = Init;
 		Chats = if UseDLL then DLL.new() else {};


### PR DESCRIPTION
It really just doesn't make sense to have this in the settings. If someone really wants to disable it they can just add `settings.UseLinkedListsInLogs = false` anywhere in their settings file.

It just otherwise bloats up the settings file with no real meaningful substance. The only reason someone would ever want to do this is 1 if they have some bug (which is highly unlikely) or they want to save memory (the overhead is neglible). And if so they can just add the false toggle in their settings file.

Yes this still exists in the `DefaultSettings.lua` file as `true`. Just from the userfacing settings is this removed from.

(Yes there are other settings too that are missing from the setting file in Adonis that Adonis listens too so this isn't the first 1)