### PR TITLE
Adding BanMenu UI & adding functions+data models to the window code

### DIFF
--- a/MainModule/Client/UI/Default/BanMenu.lua
+++ b/MainModule/Client/UI/Default/BanMenu.lua
@@ -1,0 +1,434 @@
+client,service = nil,nil
+
+return function(data, env)
+	if env then
+		setfenv(1, env)
+	end
+	
+	local AdminLevel = data.AdminLevel
+	local CanBan = data.CanBan
+	local CanTimeBan = data.CanTimeBan
+	local CanPermBan = data.CanPermBan
+	local Tabbed
+	local gTable
+	
+	local window = client.UI.Make("Window", {
+		Name  = "Ban Menu";
+		Title = "Ban Menu";
+		Size  = {267, 250};
+		Position = UDim2.new(0.5, -125, 0.5, -125);
+		Icon = client.MatIcons["Gavel"];
+		MinSize = {267,250};
+		AllowMultiple = false;
+		Walls = true;
+		NoHide = true;
+		NoClose = false;
+		CanKeepAlive = true;
+		SizeLocked = false;
+		NoDrag = false
+	})
+	
+	if window then
+		local tabFrame = window:Add("TabFrame",{
+			Size = UDim2.new(1, -10, 1, -10);
+			Position = UDim2.new(0, 5, 0, 5)
+		})
+		
+		--// Server Ban
+		do
+			if CanBan then
+				local tab,button = tabFrame:NewTab("Server Ban",{
+					Text = "Server Ban"
+				})
+
+				local searchBar: TextBox = tab:Add("TextBox",{
+					Size = UDim2.new(1, -10, 0, 20);
+					Position = UDim2.new(0, 5, 0, 5);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+					BorderColor3 = Color3.new(0,0,0);
+					TextColor3 = Color3.new(1, 1, 1);
+					Text = "";
+					PlaceholderText = `Search player`;
+					TextStrokeTransparency = 0.8;
+					ClearTextOnFocus = false;
+				})
+				
+				local PossiblePlayers = tab:Add("ScrollingFrame",{
+					Size = UDim2.new(1, -10, 0, 85);
+					Position = UDim2.new(0, 5, 0, 27);
+					BackgroundColor3 = Color3.new(20/255, 20/255, 20/255);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+					BorderColor3 = Color3.new(0,0,0);
+					ZIndex = 5
+				})
+				
+				local reasonFrame = tab:Add("Frame",{
+					Size = UDim2.new(1, -10, 1, -65);
+					Position = UDim2.new(0, 5, 0, 30);
+					BackgroundColor3 = Color3.new(20/255, 20/255, 20/255);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+				})
+				
+				local reason = reasonFrame:Add("TextBox",{
+					Size = UDim2.new(1, -10, 1, -10);
+					Position = UDim2.new(0, 5, 0, 5);
+					BackgroundTransparency = 1;
+					BorderSizePixel = 0;
+					TextColor3 = Color3.new(1, 1, 1);
+					Text = "";
+					PlaceholderText = `Reason`;
+					TextXAlignment = Enum.TextXAlignment.Left;
+					TextYAlignment = Enum.TextYAlignment.Top;
+					TextWrapped = true;
+				})
+				
+				local unbanButton = tab:Add("TextButton",{
+					Size = UDim2.new(.5, -10, 0, 25);
+					Position = UDim2.new(0, 5, 1, -30);
+					Text = "Unban";
+					OnClick = function()
+						client.Remote.Send("ProcessCommand",`{data.Prefix}unban {searchBar.Text}`)
+					end,
+				})
+				
+				local banButton = tab:Add("TextButton",{
+					Size = UDim2.new(.5, -10, 0, 25);
+					Position = UDim2.new(1, -5, 1, -30);
+					Text = "Ban";
+					AnchorPoint = Vector2.new(1,0);
+					OnClick = function()
+						client.Remote.Send("ProcessCommand",`{data.Prefix}ban {searchBar.Text} {reason.Text}`)
+					end,
+				})
+				
+				local function getPlayers()
+					PossiblePlayers:ClearAllChildren()
+					local ind = 0
+					for i,v in pairs(game.Players:GetPlayers()) do
+						local button:TextButton = PossiblePlayers:Add("TextButton",{
+							Text = `{v.DisplayName} (@{v.Name})`;
+							Size = UDim2.new(1, 0, 0, 25);
+							Position = UDim2.new(0, 0, 0, 25*ind);
+							ZIndex = 5
+						})
+						
+						button.MouseButton1Down:Connect(function()
+							searchBar.Text = v.Name
+							searchBar:ReleaseFocus()
+						end)
+						
+						ind += 1
+					end
+					PossiblePlayers:ResizeCanvas(false,true)
+				end
+				
+				PossiblePlayers.Visible = false
+				
+				searchBar.Focused:Connect(function() PossiblePlayers.Visible = true; searchBar.BorderSizePixel = 2; PossiblePlayers.BorderSizePixel = 2 end)
+				searchBar.FocusLost:Connect(function() task.wait(); PossiblePlayers.Visible = false; searchBar.BorderSizePixel = 0; PossiblePlayers.BorderSizePixel = 0 end)
+				
+				searchBar:GetPropertyChangedSignal("Text"):Connect(function()
+					if searchBar.Text ~= "" then
+						local ind = 0
+						for i,v in pairs(PossiblePlayers:GetChildren()) do
+							if v.Text:find(searchBar.Text) ~= nil then
+								v.Visible = true
+								v.Position = UDim2.new(0, 0, 0, 25*ind)
+								ind += 1
+							else
+								v.Visible = false
+							end
+						end
+						PossiblePlayers:ResizeCanvas(false,true)
+					else
+						getPlayers()
+					end
+				end)
+				
+				button.MouseButton1Click:Connect(function()
+					getPlayers()
+				end)
+				
+				getPlayers()
+			end
+		end
+		
+		--// Perm Ban
+		do
+			if CanPermBan then
+				local tab,button = tabFrame:NewTab("Perm Ban",{
+					Text = "Perm Ban"
+				})
+				
+				local searchBar: TextBox = tab:Add("TextBox",{
+					Size = UDim2.new(1, -10, 0, 20);
+					Position = UDim2.new(0, 5, 0, 5);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+					BorderColor3 = Color3.new(0,0,0);
+					TextColor3 = Color3.new(1, 1, 1);
+					Text = "";
+					PlaceholderText = `Search player`;
+					TextStrokeTransparency = 0.8;
+					ClearTextOnFocus = false;
+				})
+
+				local PossiblePlayers = tab:Add("ScrollingFrame",{
+					Size = UDim2.new(1, -10, 0, 85);
+					Position = UDim2.new(0, 5, 0, 27);
+					BackgroundColor3 = Color3.new(20/255, 20/255, 20/255);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+					BorderColor3 = Color3.new(0,0,0);
+					ZIndex = 5
+				})
+
+				local reasonFrame = tab:Add("Frame",{
+					Size = UDim2.new(1, -10, 1, -65);
+					Position = UDim2.new(0, 5, 0, 30);
+					BackgroundColor3 = Color3.new(20/255, 20/255, 20/255);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+				})
+
+				local reason = reasonFrame:Add("TextBox",{
+					Size = UDim2.new(1, -10, 1, -10);
+					Position = UDim2.new(0, 5, 0, 5);
+					BackgroundTransparency = 1;
+					BorderSizePixel = 0;
+					TextColor3 = Color3.new(1, 1, 1);
+					Text = "";
+					PlaceholderText = `Reason`;
+					TextXAlignment = Enum.TextXAlignment.Left;
+					TextYAlignment = Enum.TextYAlignment.Top;
+					TextWrapped = true;
+				})
+
+				local unbanButton = tab:Add("TextButton",{
+					Size = UDim2.new(.5, -10, 0, 25);
+					Position = UDim2.new(0, 5, 1, -30);
+					Text = "Unban";
+					OnClick = function()
+						client.Remote.Send("ProcessCommand",`{data.Prefix}unpermban {searchBar.Text}`)
+					end,
+				})
+
+				local banButton = tab:Add("TextButton",{
+					Size = UDim2.new(.5, -10, 0, 25);
+					Position = UDim2.new(1, -5, 1, -30);
+					Text = "Ban";
+					AnchorPoint = Vector2.new(1,0);
+					OnClick = function()
+						client.Remote.Send("ProcessCommand",`{data.Prefix}permban {searchBar.Text} {reason.Text}`)
+					end,
+				})
+
+				local function getPlayers()
+					PossiblePlayers:ClearAllChildren()
+					local ind = 0
+					for i,v in pairs(game.Players:GetPlayers()) do
+						local button:TextButton = PossiblePlayers:Add("TextButton",{
+							Text = `{v.DisplayName} (@{v.Name})`;
+							Size = UDim2.new(1, 0, 0, 25);
+							Position = UDim2.new(0, 0, 0, 25*ind);
+							ZIndex = 5
+						})
+
+						button.MouseButton1Down:Connect(function()
+							searchBar.Text = v.Name
+							searchBar:ReleaseFocus()
+						end)
+
+						ind += 1
+					end
+					PossiblePlayers:ResizeCanvas(false,true)
+				end
+
+				PossiblePlayers.Visible = false
+
+				searchBar.Focused:Connect(function() PossiblePlayers.Visible = true; searchBar.BorderSizePixel = 2; PossiblePlayers.BorderSizePixel = 2 end)
+				searchBar.FocusLost:Connect(function() task.wait(); PossiblePlayers.Visible = false; searchBar.BorderSizePixel = 0; PossiblePlayers.BorderSizePixel = 0 end)
+
+				searchBar:GetPropertyChangedSignal("Text"):Connect(function()
+					if searchBar.Text ~= "" then
+						local ind = 0
+						for i,v in pairs(PossiblePlayers:GetChildren()) do
+							if v.Text:find(searchBar.Text) ~= nil then
+								v.Visible = true
+								v.Position = UDim2.new(0, 0, 0, 25*ind)
+								ind += 1
+							else
+								v.Visible = false
+							end
+						end
+						PossiblePlayers:ResizeCanvas(false,true)
+					else
+						getPlayers()
+					end
+				end)
+				
+				button.MouseButton1Click:Connect(function()
+					getPlayers()
+				end)
+
+				getPlayers()
+			end
+		end
+		
+		--// Time Ban
+		do
+			if CanTimeBan then
+				local tab,button = tabFrame:NewTab("Time Ban",{
+					Text = "Time Ban"
+				})
+				
+				button:GetPropertyChangedSignal("BackgroundTransparency"):Connect(function()
+					local AbsolutePosition = window:GetPosition()
+					local AbsoluteSize = window:GetSize()
+					if button.BackgroundTransparency == 0 then
+						window:SetPosition(UDim2.new(0, AbsolutePosition.X, 0, AbsolutePosition.Y-(15/2)))
+						window:SetSize({AbsoluteSize.X,AbsoluteSize.Y+15})
+						window:SetMinSize({AbsoluteSize.X,AbsoluteSize.Y+15})
+					else
+						window:SetPosition(UDim2.new(0, AbsolutePosition.X, 0, AbsolutePosition.Y+(15/2)))
+						window:SetSize({AbsoluteSize.X,AbsoluteSize.Y-15})
+						window:SetMinSize({AbsoluteSize.X,AbsoluteSize.Y-15})
+					end
+				end)
+
+				local searchBar: TextBox = tab:Add("TextBox",{
+					Size = UDim2.new(1, -10, 0, 20);
+					Position = UDim2.new(0, 5, 0, 5);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+					BorderColor3 = Color3.new(0,0,0);
+					TextColor3 = Color3.new(1, 1, 1);
+					Text = "";
+					PlaceholderText = `Search player`;
+					TextStrokeTransparency = 0.8;
+					ClearTextOnFocus = false;
+				})
+
+				local PossiblePlayers = tab:Add("ScrollingFrame",{
+					Size = UDim2.new(1, -10, 0, 85);
+					Position = UDim2.new(0, 5, 0, 27);
+					BackgroundColor3 = Color3.new(20/255, 20/255, 20/255);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+					BorderColor3 = Color3.new(0,0,0);
+					ZIndex = 5
+				})
+				
+				local duration = tab:Add("TextBox",{
+					Size = UDim2.new(1, -10, 0, 20);
+					Position = UDim2.new(0, 5, 0, 30);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+					TextColor3 = Color3.new(1, 1, 1);
+					Text = "";
+					PlaceholderText = `Duration (example: 1h)`;
+				})
+
+				local reasonFrame = tab:Add("Frame",{
+					Size = UDim2.new(1, -10, 1, -90);
+					Position = UDim2.new(0, 5, 0, 55);
+					BackgroundColor3 = Color3.new(20/255, 20/255, 20/255);
+					BackgroundTransparency = 0;
+					BorderSizePixel = 0;
+				})
+
+				local reason = reasonFrame:Add("TextBox",{
+					Size = UDim2.new(1, -10, 1, -10);
+					Position = UDim2.new(0, 5, 0, 5);
+					BackgroundTransparency = 1;
+					BorderSizePixel = 0;
+					TextColor3 = Color3.new(1, 1, 1);
+					Text = "";
+					PlaceholderText = `Reason`;
+					TextXAlignment = Enum.TextXAlignment.Left;
+					TextYAlignment = Enum.TextYAlignment.Top;
+					TextWrapped = true;
+				})
+
+				local unbanButton = tab:Add("TextButton",{
+					Size = UDim2.new(.5, -10, 0, 25);
+					Position = UDim2.new(0, 5, 1, -30);
+					Text = "Unban";
+					OnClick = function()
+						client.Remote.Send("ProcessCommand",`{data.Prefix}untimeban {searchBar.Text}`)
+					end,
+				})
+
+				local banButton = tab:Add("TextButton",{
+					Size = UDim2.new(.5, -10, 0, 25);
+					Position = UDim2.new(1, -5, 1, -30);
+					Text = "Ban";
+					AnchorPoint = Vector2.new(1,0);
+					OnClick = function()
+						client.Remote.Send("ProcessCommand",`{data.Prefix}timeban {searchBar.Text} {duration.Text or "1h"} {reason.Text}`)
+					end,
+				})
+
+				local function getPlayers()
+					PossiblePlayers:ClearAllChildren()
+					local ind = 0
+					for i,v in pairs(game.Players:GetPlayers()) do
+						local button:TextButton = PossiblePlayers:Add("TextButton",{
+							Text = `{v.DisplayName} (@{v.Name})`;
+							Size = UDim2.new(1, 0, 0, 25);
+							Position = UDim2.new(0, 0, 0, 25*ind);
+							ZIndex = 5
+						})
+
+						button.MouseButton1Down:Connect(function()
+							searchBar.Text = v.Name
+							searchBar:ReleaseFocus()
+						end)
+
+						ind += 1
+					end
+					PossiblePlayers:ResizeCanvas(false,true)
+				end
+
+				PossiblePlayers.Visible = false
+
+				searchBar.Focused:Connect(function() PossiblePlayers.Visible = true; searchBar.BorderSizePixel = 2; PossiblePlayers.BorderSizePixel = 2 end)
+				searchBar.FocusLost:Connect(function() task.wait(); PossiblePlayers.Visible = false; searchBar.BorderSizePixel = 0; PossiblePlayers.BorderSizePixel = 0 end)
+
+				searchBar:GetPropertyChangedSignal("Text"):Connect(function()
+					if searchBar.Text ~= "" then
+						local ind = 0
+						for i,v in pairs(PossiblePlayers:GetChildren()) do
+							if v.Text:find(searchBar.Text) ~= nil then
+								v.Visible = true
+								v.Position = UDim2.new(0, 0, 0, 25*ind)
+								ind += 1
+							else
+								v.Visible = false
+							end
+						end
+						PossiblePlayers:ResizeCanvas(false,true)
+					else
+						getPlayers()
+					end
+				end)
+				
+				button.MouseButton1Click:Connect(function()
+					getPlayers()
+					
+					if searchBar.Text ~= "" then
+						
+					end
+				end)
+
+				getPlayers()
+			end
+		end
+	end
+	
+	gTable = window.gTable
+	window:Ready()
+end

--- a/MainModule/Client/UI/Default/BanMenu.lua
+++ b/MainModule/Client/UI/Default/BanMenu.lua
@@ -25,7 +25,7 @@ return function(data, env)
 		NoClose = false;
 		CanKeepAlive = true;
 		SizeLocked = false;
-		NoDrag = false
+		NoDrag = false;
 	})
 	
 	if window then
@@ -291,11 +291,11 @@ return function(data, env)
 					if button.BackgroundTransparency == 0 then
 						window:SetPosition(UDim2.new(0, AbsolutePosition.X, 0, AbsolutePosition.Y-(15/2)))
 						window:SetSize({AbsoluteSize.X,AbsoluteSize.Y+15})
-						window:SetMinSize({AbsoluteSize.X,AbsoluteSize.Y+15})
+						window:SetMinSize({267,265})
 					else
 						window:SetPosition(UDim2.new(0, AbsolutePosition.X, 0, AbsolutePosition.Y+(15/2)))
 						window:SetSize({AbsoluteSize.X,AbsoluteSize.Y-15})
-						window:SetMinSize({AbsoluteSize.X,AbsoluteSize.Y-15})
+						window:SetMinSize({267,250})
 					end
 				end)
 
@@ -418,10 +418,6 @@ return function(data, env)
 				
 				button.MouseButton1Click:Connect(function()
 					getPlayers()
-					
-					if searchBar.Text ~= "" then
-						
-					end
 				end)
 
 				getPlayers()

--- a/MainModule/Client/UI/Default/Window.rbxmx
+++ b/MainModule/Client/UI/Default/Window.rbxmx
@@ -1893,8 +1893,6 @@ return function(data, env)
 		gui:SetSpecial("Object", gui)
 		gui:SetSpecial("SetPosition", function(ignore, newPos) gui.Position = newPos end)
 		gui:SetSpecial("SetSize", function(ingore, newSize) gui.Size = newSize end)
-		gui:SetSpecial("SetMinSize",function(ignore, Table) setMinSize(Table) end)
-		gui:SetSpecial("SetMaxSize",function(ignore, Table) setMaxSize(Table) end)
 		gui:SetSpecial("Add", function(ignore, class, data)
 			if not data then data = class class = ignore end
 			local new = create(class,data);

--- a/MainModule/Client/UI/Default/Window.rbxmx
+++ b/MainModule/Client/UI/Default/Window.rbxmx
@@ -962,7 +962,6 @@ local setMaxSize
 local apiIfy
 
 client = nil
-cPcall = nil
 Pcall = nil
 Routine = nil
 service = nil

--- a/MainModule/Client/UI/Default/Window.rbxmx
+++ b/MainModule/Client/UI/Default/Window.rbxmx
@@ -837,7 +837,8 @@
 		[Bool] 		Walls		 - If true the window will be snapped back when dragged off the screen
 		[Bool] 		NoClose		 - If true the close button will be removed
 		[Bool]		CanKeepAlive - If false the window will be destroyed when the user respawns
-		[Bool]		SizeLocked	 - IF true the window cannot be resized
+		[Bool]		SizeLocked	 - If true the window cannot be resized
+		[Bool]		NoDrag		 - If true window can't be dragged
 		[Function]	OnClose		 - Called when the window closes
 		[Function]	OnResize	 - Called when the window is resized by the user
 		[Function]	OnReady		 - Called when window:Ready() is called
@@ -867,6 +868,8 @@
 		:Add(string Class, table Data)	- Adds a new object of Class to the window with properties specified by Data
 		:Hide(bool doHide)				- Forces the window to minimize or maximize
 		:SetTitle(string newTitle)		- Sets the window's title
+		:SetMinSize(table newMinSize)	- Sets the minimum allowed window size
+		:SetMaxSize(table newMaxSize)	- Sets the maximum allowed window size
 		:SetPosition(UDim2 newPos)		- Sets the window's position
 		:SetSize(table newSize)			- Sets the window's size; Must be a table containing X and Y absolute sizes
 		:GetPosition()					- Gets the window's position
@@ -954,9 +957,12 @@ local setPosition
 local checkMouse
 local isInFrame
 local setSize
+local setMinSize
+local setMaxSize
 local apiIfy
 
 client = nil
+cPcall = nil
 Pcall = nil
 Routine = nil
 service = nil
@@ -978,6 +984,7 @@ return function(data, env)
 	local InputService = service.UserInputService
 	local gIndex = data.gIndex
 	local gTable = data.gTable
+	warn(gTable.BindEvent)
 
 	local Event = gTable.BindEvent
 	local GUI = gTable.Object
@@ -990,6 +997,7 @@ return function(data, env)
 	local Walls = data.Walls
 	local noHide = data.NoHide
 	local noClose = data.NoClose
+	local noDrag = data.NoDrag
 	local onReady = data.OnReady
 	local onClose = data.OnClose
 	local onResize = data.OnResize
@@ -1009,7 +1017,6 @@ return function(data, env)
 	local isClosed = false
 	local Resizing = false
 	local Refreshing = false
-	local DragEnabled = true
 	local checkProperty = service.CheckProperty
 	local specialInsts = {}
 	local inExpandable
@@ -1886,6 +1893,8 @@ return function(data, env)
 		gui:SetSpecial("Object", gui)
 		gui:SetSpecial("SetPosition", function(ignore, newPos) gui.Position = newPos end)
 		gui:SetSpecial("SetSize", function(ingore, newSize) gui.Size = newSize end)
+		gui:SetSpecial("SetMinSize",function(ignore, Table) setMinSize(Table) end)
+		gui:SetSpecial("SetMaxSize",function(ignore, Table) setMaxSize(Table) end)
 		gui:SetSpecial("Add", function(ignore, class, data)
 			if not data then data = class class = ignore end
 			local new = create(class,data);
@@ -2023,6 +2032,18 @@ return function(data, env)
 			Drag.Position = UDim2.new(0, newPos[1], 0, newPos[2])
 		elseif Size and not newPos then
 			Drag.Position = UDim2.new(0.5, -Drag.AbsoluteSize.X/2, 0.5, -Main.AbsoluteSize.Y/2)
+		end
+	end
+	
+	function setMinSize(Table)
+		if Table and typeof(Table) == "table" then
+			MinSize = Table
+		end
+	end
+	
+	function setMaxSize(Table)
+		if Table and typeof(Table) == "table" then
+			MaxSize = Table
 		end
 	end
 
@@ -2436,9 +2457,11 @@ return function(data, env)
 
 		Event(InputService.InputBegan, function(input)
 			if inFrame and GUI.DisplayOrder == 101 and not dragDragging and (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch) then--isInFrame(input.Position.X, input.Position.Y, object) then
-				dragDragging = true
-				BringToFront()
-				dragOffset = Vector2.new(Drag.AbsolutePosition.X - input.Position.X, Drag.AbsolutePosition.Y - input.Position.Y)
+				if not noDrag then
+					dragDragging = true
+					BringToFront()
+					dragOffset = Vector2.new(Drag.AbsolutePosition.X - input.Position.X, Drag.AbsolutePosition.Y - input.Position.Y)
+				end
 			end
 		end)
 
@@ -2480,6 +2503,8 @@ return function(data, env)
 	api:SetSpecial("SetTitle", function(ignore, newTitle) Titlef.Text = newTitle end)
 	api:SetSpecial("SetPosition", function(ignore, newPos) setPosition(newPos) end)
 	api:SetSpecial("SetSize", function(ignore, newSize) setSize(newSize) end)
+	api:SetSpecial("SetMinSize",function(ignore, Table) setMinSize(Table) end)
+	api:SetSpecial("SetMaxSize",function(ignore, Table) setMaxSize(Table) end)
 	api:SetSpecial("GetPosition", function() return Drag.AbsolutePosition end)
 	api:SetSpecial("GetSize", function() return Main.AbsoluteSize end)
 	api:SetSpecial("IsVisible", isVisible)

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1333,6 +1333,23 @@ return function(Vargs, env)
 			end;
 		};
 
+		BanMenu = {
+			Prefix = Settings.Prefix;
+			Commands = {"banmenu"};
+			Args = {};
+			Description = "Opens the ban menu";
+			AdminLevel = "Admins";
+			Function = function(plr: Player, args: {string}, data: {any})
+				Remote.MakeGui(plr,"BanMenu",{
+					AdminLevel = Admin.GetLevel(plr);
+					CanBan = Admin.CheckComLevel(Admin.GetLevel(plr),Commands.ServerBan.AdminLevel);
+					CanTimeBan = Admin.CheckComLevel(Admin.GetLevel(plr),Commands.TimeBan.AdminLevel);
+					CanPermBan = Admin.CheckComLevel(Admin.GetLevel(plr),Commands.PermanentBan.AdminLevel);
+					Prefix = Settings.Prefix;
+				})
+			end,
+		};
+
 		CustomMessage = {
 			Prefix = Settings.Prefix;
 			Commands = {"cm", "custommessage"};


### PR DESCRIPTION
# New BanMenu UI
This ban menu UI aims to allow the admin the ability to open a menu using the command ":banmenu" this will then open a menu with 3 tabs which are:
- Server ban
- Perm ban
- Time ban

![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/777f9b16-f369-498a-855a-1c76fc2c7273)

# New functions & data models to window code
### While making this I've added three things that I've used in making my ban menu, the following items I've added are:
Data Model(s):
- NoDrag

Function(s):
- :SetMinSize()
- :SetMaxSize()

The following pictures shall now help you understand them:
![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/31298e3f-d1d1-4196-a5a8-757a0b6f8fed)

![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/66b9fa51-a823-4012-b0e6-84ebe1684ead)

Use cases for both of them are shown in the BanMenu.lua module

