### PR TITLE
Modification of user name filling when tab is pressed in the default console

### DIFF
--- a/MainModule/Client/UI/Default/Console.rbxmx
+++ b/MainModule/Client/UI/Default/Console.rbxmx
@@ -721,7 +721,10 @@ return function(data, env)
 		if text.Text ~= "" and openConsole then
 			if string.sub(text.Text, string.len(text.Text)) == "	" then
 				if players:FindFirstChild("Entry 0") then
-					text.Text = `{string.sub(text.Text, 1, (string.len(text.Text) - 1))}{players["Entry 0"].Text} `
+					local args = string.split(tostring(text.Text), " ") -- Get command args
+					local textWithoutLastArg = string.sub(text.Text, 1, string.len(text.Text) - string.len(args[#args])) -- Remove the last arg
+					
+					text.Text = `{textWithoutLastArg}{players["Entry 0"].Text} ` -- Combine the text witout the last arg and the player name
 				elseif scroll:FindFirstChild("Entry 0") then
 					text.Text = string.split(scroll["Entry 0"].Text, "<")[1]
 				else


### PR DESCRIPTION
Added some code to complete username correctly

Previously: when you wrote the beginning of the user name and pressed the Tab key, the entire username was added to what you had written.

Let's take the example that the username is: "anUser". Before pressing tab : 
":kick anU"
After pressing tab: 
":kick anUanUser"

Now, the username is correctly filled in, if we use the previous example, if we press tab:  ":kick anUser"

## Notice
Please make sure you read the Contributing Guidelines before submitting a pull request. https://github.com/Epix-Incorporated/Adonis/blob/master/CONTRIBUTING.md