### PR TITLE
Fixed Command Box

### DIFF
--- a/MainModule/Client/UI/Default/CommandBox.lua
+++ b/MainModule/Client/UI/Default/CommandBox.lua
@@ -1,0 +1,63 @@
+client,service = nil,nil
+
+return function(data,env)
+	if env then
+		setfenv(1, env)
+	end
+	
+	local window = client.UI.Make("Window",{
+		Title = "Command Box";
+		Name = "CommandBox";
+		Icon = client.MatIcons.Code;
+		Size  = {300, 250};
+	})
+	
+	local Frame: ScrollingFrame = window:Add("ScrollingFrame",{
+		Name = "ComFrame";
+		Size = UDim2.new(1, -10, 1, -45);
+		BackgroundTransparency = 0.5;
+	})
+	
+	local Text: TextLabel = Frame:Add("TextBox",{
+		Name = "ComText";
+		Size = UDim2.new(1, 0, 1, 0);
+		Position = UDim2.new(0, 0, 0, 0);
+		Text = "";
+		BackgroundTransparency = 0.5;
+		PlaceholderText = "Enter commands here";
+		TextYAlignment = "Top";
+		MultiLine = true;
+		ClearTextOnFocus = false;
+	})
+	
+	local Execute: TextButton = window:Add("TextButton",{
+		Name = "Execute";
+		Size = UDim2.new(1, -10, 0, 35);
+		Position = UDim2.new(0, 5, 1, -40);
+		Text = "Execute";
+		OnClick = function()
+			client.Remote.Send("ProcessCommand", Text.Text)
+		end,
+	})
+	
+	Text:GetPropertyChangedSignal("Text"):Connect(function()
+		if Text.TextBounds.Y > Frame.AbsoluteSize.Y then
+			Text:SetSize(UDim2.new(1, 0, 0, Text.TextBounds.Y+5))
+			Text:SetPosition(UDim2.new(0, 0, 0, 0))
+			Frame.CanvasSize = UDim2.new(0, 0, 0, Text.TextBounds.Y+5)
+			Frame.CanvasPosition = Vector2.new(0, Frame.CanvasPosition.Y+21)
+		else
+			Frame.CanvasSize = UDim2.new(0, 0, 0, 0)
+			Text:SetSize(UDim2.new(1, 0, 1, 0))
+		end
+	end)
+	
+	Frame:GetPropertyChangedSignal("AbsoluteSize"):Connect(function()
+		if Text.TextBounds.Y < Frame.AbsoluteSize.Y then
+			Frame.CanvasSize = UDim2.new(0, 0, 0, 0)
+			Text:SetSize(UDim2.new(1, 0, 1, 0))
+		end
+	end)
+	
+	window:Ready()
+end

--- a/MainModule/Client/UI/Default/CommandBox.lua
+++ b/MainModule/Client/UI/Default/CommandBox.lua
@@ -5,6 +5,8 @@ return function(data,env)
 		setfenv(1, env)
 	end
 	
+	local Enabled = false
+	
 	local window = client.UI.Make("Window",{
 		Title = "Command Box";
 		Name = "CommandBox";
@@ -15,17 +17,20 @@ return function(data,env)
 	local Frame: ScrollingFrame = window:Add("ScrollingFrame",{
 		Name = "ComFrame";
 		Size = UDim2.new(1, -10, 1, -45);
-		BackgroundTransparency = 0.5;
+		BackgroundTransparency = 1;
+		AutomaticCanvasSize = Enum.AutomaticSize.Y;
 	})
 	
-	local Text: TextLabel = Frame:Add("TextBox",{
+	local Text: TextBox = Frame:Add("TextBox",{
 		Name = "ComText";
 		Size = UDim2.new(1, 0, 1, 0);
 		Position = UDim2.new(0, 0, 0, 0);
+		BackgroundTransparency = 1;
 		Text = "";
-		BackgroundTransparency = 0.5;
 		PlaceholderText = "Enter commands here";
 		TextYAlignment = "Top";
+		TextWrapped = true;
+		TextScaled = false;
 		MultiLine = true;
 		ClearTextOnFocus = false;
 	})
@@ -40,7 +45,15 @@ return function(data,env)
 		end,
 	})
 	
-	Text:GetPropertyChangedSignal("Text"):Connect(function()
+	Text:GetPropertyChangedSignal("TextBounds"):Connect(function()
+		if Text.Text ~= "" then
+			Text.Size = UDim2.new(Text.Size.X.Scale, Text.Size.X.Offset, Text.Size.Y.Scale, Text.TextBounds.Y+16)
+		else
+			Text.Size = UDim2.new(1, 0, 1, 0)
+		end
+	end)
+	
+	--[[Text:GetPropertyChangedSignal("Text"):Connect(function()
 		if Text.TextBounds.Y > Frame.AbsoluteSize.Y then
 			Text:SetSize(UDim2.new(1, 0, 0, Text.TextBounds.Y+5))
 			Text:SetPosition(UDim2.new(0, 0, 0, 0))
@@ -57,7 +70,7 @@ return function(data,env)
 			Frame.CanvasSize = UDim2.new(0, 0, 0, 0)
 			Text:SetSize(UDim2.new(1, 0, 1, 0))
 		end
-	end)
+	end)]]
 	
 	window:Ready()
 end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1725,46 +1725,7 @@ return function(Vargs, env)
 			Description = "Command Box";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				Remote.MakeGui(plr, "Window", {
-					Title = "Command Box";
-					Name = "CommandBox";
-					Icon = server.MatIcons.Code;
-					Size  = {300, 250};
-					Ready = true;
-					Content = {
-						{
-							Class = "TextBox";
-							Name = "ComText";
-							Size = UDim2.new(1, -10, 1, -40);
-							Text = "";
-							BackgroundTransparency = 0.5;
-							PlaceholderText = "Enter commands here";
-							TextYAlignment = "Top";
-							MultiLine = true;
-							ClearTextOnFocus = false;
-							TextChanged = Core.Bytecode[[
-								if not Object.TextFits then
-									Object.TextYAlignment = "Bottom"
-								else
-									Object.TextYAlignment = "Top"
-								end
-							]]
-						};
-						{
-							Class = "TextButton";
-							Name = "Execute";
-							Size = UDim2.new(1, -10, 0, 35);
-							Position = UDim2.new(0, 5, 1, -40);
-							Text = "Execute";
-							OnClick = Core.Bytecode[[
-								local textBox = Object.Parent:FindFirstChild("ComText")
-								if textBox then
-									client.Remote.Send("ProcessCommand", textBox.Text)
-								end
-							]]
-						};
-					}
-				})
+				Remote.MakeGui(plr,"CommandBox")																																																																													
 			end;
 		};
 


### PR DESCRIPTION
# Fixed Command Box
The command box has been funky since it was added to adonis, but I fixed it.

What I fixed:
- The frame is now scrollable if the text goes off the frame
- The text wraps now so if you have one super long command it is able to be seen (shouldn't need to use it)

Before: (By: @legendary191)
![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/4a2439db-15ae-4381-b610-13b8defee368)

After: (By: Me)
![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/a5e872ec-98ac-44da-9d78-e973b8c476c2)
