### PR TITLE
Fix "radius-{num}" for games with custom player/character loading systems

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -374,7 +374,10 @@ return function(Vargs, GetEnv)
 
 						for _,v in parent:GetChildren() do
 							local p = getplr(v)
-							if p and p ~= plr and plr:DistanceFromCharacter(p.Character.Head.Position) <= num then
+							local character = p.Character
+							local Head = character and character:FindFirstChild("Head")
+							
+							if Head and p and p ~= plr and plr:DistanceFromCharacter(Head.Position) <= num then
 								table.insert(players,p)
 								plus()
 							end


### PR DESCRIPTION
Games with custom loading systems are completely unable to use the radius command as it can error due to one of two things.

1) Player has no character
2) Players characters head is replaced after loading

This will simply return a standard Adonis error and the command will not run at all if any of the two above scenarios occur, rendering the Radius command completely unusable in these scenarios.