### PR TITLE
Implemented way to monitor Adonis Teleport status via a Character Attribute named "ADONIS_isTeleporting"

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -4661,6 +4661,7 @@ return function(Vargs, env)
 			Description = "Teleport player1(s) to player2, a waypoint, or specific coords, use :tp player1 waypoint-WAYPOINTNAME to use waypoints, x,y,z for coords";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
+				
 				if args[2] and (string.match(args[2], "^waypoint%-(.*)") or string.match(args[2], "wp%-(.*)")) then
 					local m = string.match(args[2], "^waypoint%-(.*)") or string.match(args[2], "wp%-(.*)")
 					local point
@@ -4670,19 +4671,27 @@ return function(Vargs, env)
 							point=v
 						end
 					end
-
+					
 					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 						if point then
-							if not v.Character then
+							local Character = v.Character
+
+							if not Character then
 								continue
 							end
+
+							Character:SetAttribute("ADONIS_isTeleporting", true)
+							task.delay(0.5, function() if Character then Character:SetAttribute("ADONIS_isTeleporting", nil) end end)
+
 							if workspace.StreamingEnabled == true then
 								v:RequestStreamAroundAsync(point)
 							end
-							local Humanoid = v.Character:FindFirstChildOfClass("Humanoid")
-							local root = (Humanoid and Humanoid.RootPart or v.Character.PrimaryPart or v.Character:FindFirstChild("HumanoidRootPart"))
+
+							local Humanoid = Character:FindFirstChildOfClass("Humanoid")
+							local root = (Humanoid and Humanoid.RootPart or Character.PrimaryPart or Character:FindFirstChild("HumanoidRootPart"))
 							local FlightPos = root:FindFirstChild("ADONIS_FLIGHT_POSITION")
 							local FlightGyro = root:FindFirstChild("ADONIS_FLIGHT_GYRO")
+
 							if Humanoid then
 								if Humanoid.SeatPart~=nil then
 									Functions.RemoveSeatWelds(Humanoid.SeatPart)
@@ -4692,12 +4701,14 @@ return function(Vargs, env)
 									Humanoid.Jump = true
 								end
 							end
+
 							if FlightPos and FlightGyro then
 								FlightPos.Position = root.Position
 								FlightGyro.CFrame = root.CFrame
 							end
 
-							wait()
+							task.wait()
+
 							if root then
 								root.CFrame = CFrame.new(point)
 								if FlightPos and FlightGyro then
@@ -4712,15 +4723,22 @@ return function(Vargs, env)
 				elseif args[2] and string.find(args[2], ",") then
 					local x, y, z = string.match(args[2], "(.*),(.*),(.*)")
 					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
-						if not v.Character or not v.Character:FindFirstChild("HumanoidRootPart") then continue end
+						local Character = v.Character
+						local root = Character and Character:FindFirstChild('HumanoidRootPart')
+
+						if not root then continue end
+
+						Character:SetAttribute("ADONIS_isTeleporting", true)
+						task.delay(0.5, function() if Character then Character:SetAttribute("ADONIS_isTeleporting", nil) end end)
 
 						if workspace.StreamingEnabled == true then
 							v:RequestStreamAroundAsync(Vector3.new(x,y,z))
 						end
-						local Humanoid = v.Character:FindFirstChildOfClass("Humanoid")
-						local root = v.Character:FindFirstChild('HumanoidRootPart')
+
+						local Humanoid = Character:FindFirstChildOfClass("Humanoid")
 						local FlightPos = root:FindFirstChild("ADONIS_FLIGHT_POSITION")
 						local FlightGyro = root:FindFirstChild("ADONIS_FLIGHT_GYRO")
+
 						if Humanoid then
 							if Humanoid.SeatPart~=nil then
 								Functions.RemoveSeatWelds(Humanoid.SeatPart)
@@ -4730,12 +4748,16 @@ return function(Vargs, env)
 								Humanoid.Jump = true
 							end
 						end
+
 						if FlightPos and FlightGyro then
 							FlightPos.Position = root.Position
 							FlightGyro.CFrame = root.CFrame
 						end
-						wait()
+
+						task.wait()
+
 						root.CFrame = CFrame.new(Vector3.new(tonumber(x), tonumber(y), tonumber(z)))
+
 						if FlightPos and FlightGyro then
 							FlightPos.Position = root.Position
 							FlightGyro.CFrame = root.CFrame
@@ -4745,15 +4767,20 @@ return function(Vargs, env)
 					local target = service.GetPlayers(plr, args[2], { NoFakePlayer = true })[1]
 					local players = service.GetPlayers(plr, args[1], { NoFakePlayer = true })
 					if #players == 1 and players[1] == target then
-						local n = players[1]
-						if n.Character:FindFirstChild("HumanoidRootPart") and target.Character:FindFirstChild("HumanoidRootPart") then
-							local Humanoid = n.Character:FindFirstChildOfClass("Humanoid")
-							local root = n.Character:FindFirstChild('HumanoidRootPart')
+						local v = players[1]
+						local Character = v.Character
+						local root = Character and Character:FindFirstChild('HumanoidRootPart')
+
+						if root and target.Character:FindFirstChild("HumanoidRootPart") then
+							local Humanoid = Character:FindFirstChildOfClass("Humanoid")
 							local FlightPos = root:FindFirstChild("ADONIS_FLIGHT_POSITION")
 							local FlightGyro = root:FindFirstChild("ADONIS_FLIGHT_GYRO")
 
+							Character:SetAttribute("ADONIS_isTeleporting", true)
+							task.delay(0.5, function() if Character then Character:SetAttribute("ADONIS_isTeleporting", nil) end end)
+
 							if workspace.StreamingEnabled == true then
-								n:RequestStreamAroundAsync((target.Character.HumanoidRootPart.CFrame*CFrame.Angles(0, math.rad(90/#players*1), 0)*CFrame.new(5+.2*#players, 0, 0))*CFrame.Angles(0, math.rad(90), 0).Position)
+								v:RequestStreamAroundAsync((target.Character.HumanoidRootPart.CFrame*CFrame.Angles(0, math.rad(90/#players*1), 0)*CFrame.new(5+.2*#players, 0, 0))*CFrame.Angles(0, math.rad(90), 0).Position)
 							end
 
 							if Humanoid then
@@ -4769,8 +4796,11 @@ return function(Vargs, env)
 								FlightPos.Position = root.Position
 								FlightGyro.CFrame = root.CFrame
 							end
-							wait()
+
+							task.wait()
+
 							root.CFrame = (target.Character.HumanoidRootPart.CFrame*CFrame.Angles(0, math.rad(90/#players*1), 0)*CFrame.new(5+.2*#players, 0, 0))*CFrame.Angles(0, math.rad(90), 0)
+
 							if FlightPos and FlightGyro then
 								FlightPos.Position = root.Position
 								FlightGyro.CFrame = root.CFrame
@@ -4779,15 +4809,19 @@ return function(Vargs, env)
 					else
 						local targ_root = target.Character and target.Character:FindFirstChild("HumanoidRootPart")
 						if targ_root then
-							for k, n in players do
-								if n ~= target then
-									local Character = n.Character
+							for k, v in players do
+								if v ~= target then
+									local Character = v.Character
+
 									if not Character or not Character:FindFirstChild("HumanoidRootPart") then
 										continue
 									end
 
+									Character:SetAttribute("ADONIS_isTeleporting", true)
+									task.delay(0.5, function() if Character then Character:SetAttribute("ADONIS_isTeleporting", nil) end end)
+
 									if workspace.StreamingEnabled == true then
-										n:RequestStreamAroundAsync((targ_root.CFrame*CFrame.Angles(0, math.rad(90/#players*k), 0)*CFrame.new(5+.2*#players, 0, 0))*CFrame.Angles(0, math.rad(90), 0).Position)
+										v:RequestStreamAroundAsync((targ_root.CFrame*CFrame.Angles(0, math.rad(90/#players*k), 0)*CFrame.new(5+.2*#players, 0, 0))*CFrame.Angles(0, math.rad(90), 0).Position)
 									end
 
 									local Humanoid = Character:FindFirstChildOfClass("Humanoid")
@@ -4807,7 +4841,9 @@ return function(Vargs, env)
 										FlightPos.Position = root.Position
 										FlightGyro.CFrame = root.CFrame
 									end
-									wait()
+
+									task.wait()
+
 									if root and targ_root then
 										root.CFrame = (targ_root.CFrame*CFrame.Angles(0, math.rad(90/#players*k), 0)*CFrame.new(5+.2*#players, 0, 0))*CFrame.Angles(0, math.rad(90), 0)
 										if FlightPos and FlightGyro then
@@ -4882,6 +4918,9 @@ return function(Vargs, env)
 					for i = (l-1) * math.floor(numPlayers/lines) + 1, l * math.floor(numPlayers/lines) do
 						local char = players[i].Character
 						if not char then continue end
+						
+						char:SetAttribute("ADONIS_isTeleporting", true)
+						task.delay(0.5, function() if char then char:SetAttribute("ADONIS_isTeleporting", nil) end end)
 
 						local hum = char:FindFirstChildOfClass("Humanoid")
 						if hum then
@@ -4910,6 +4949,9 @@ return function(Vargs, env)
 					for i = lines*math.floor(numPlayers/lines)+1, lines*math.floor(numPlayers/lines) + numPlayers%lines do
 						local char = players[i].Character
 						if not char then continue end
+						
+						char:SetAttribute("ADONIS_isTeleporting", true)
+						task.delay(0.5, function() if char then char:SetAttribute("ADONIS_isTeleporting", nil) end end)
 
 						local r = i % (lines*math.floor(numPlayers/lines))
 						local offsetX = if r == 1 then 0


### PR DESCRIPTION
With Adonis it's currently incredibly painstaking implementing your own way of synergising your own anti-cheat with Adonis; it's possible to whitelist admins to negate it but what about actual players?

Teleport code was also changed to be more consistent, as there was many different uses of index instance, they've all been changed to use the character v for the player, aswell as swapping wait() out for the more efficient task library for consistancy.

I've changed the Teleport/MassBring code to enable a boolean attribute on the character named "ADONIS_isTeleporting", when it's active a player is/was teleporting.

This allows a custom external anti-cheat to then be capable of monitoring when Adonis is teleporting a player and allow the developer to program their own authorisation method capable of handling it.

Anti-Teleport Anti-Cheats are one of the most common form of anti-cheats and alot of games use them.

_The video below also includes a demonstration using my friends custom-anticheat BONK, which is now able to work with Adonis using this easy method._
**Video Demonstration:**
https://www.youtube.com/watch?v=-qs-e0OY9Xc