### PR TITLE
Fixed Settings.Notification and tweaked something

### DIFF
--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -108,7 +108,7 @@ return function(Vargs, GetEnv)
 						return require(ChatSettings)
 					end)
 					if success then
-						local NewChatLimit = ChatSettingsModule.MaximumLength
+						local NewChatLimit = ChatSettingsModule.MaximumMessageLength
 						if NewChatLimit and type(NewChatLimit) == "number" then
 							Process.MaxChatCharacterLimit = NewChatLimit
 							AddLog("Script", `Chat Character Limit automatically set to {NewChatLimit}`)
@@ -285,8 +285,8 @@ return function(Vargs, GetEnv)
 		RunAfterPlugins = RunAfterPlugins;
 		RateLimit = RateLimit;
 		newRateLimit = newRateLimit;
-		MsgStringLimit = 500; --// Max  string length to prevent long length chat spam server crashing (chat & command bar); Anything over will be truncated;
-		MaxChatCharacterLimit = 250; --// Roblox chat character limit; The actual limit of the Roblox chat's textbox is 200 characters; I'm paranoid so I added 50 characters; Users should not be able to send a  larger than that;
+		MsgStringLimit = 500; --// Max message string length to prevent long length chat spam server crashing (chat & command bar); Anything over will be truncated;
+		MaxChatCharacterLimit = 250; --// Roblox chat character limit; The actual limit of the Roblox chat's textbox is 200 characters; I'm paranoid so I added 50 characters; Users should not be able to send a message larger than that;
 		RemoteMaxArgCount = 5; --// The maximum argument count Adonis will take from Remote (alter if your script requires more arguments)
 		RateLimits = {
 			Remote = 0.01;
@@ -405,7 +405,7 @@ return function(Vargs, GetEnv)
 					if opts.Check then
 						Remote.MakeGui(p, "Output", {
 							Title = "Output";
-							 = if Settings.SilentCommandDenials
+							Message = if Settings.SilentCommandDenials
 								then string.format("'%s' is either not a valid command, or you do not have permission to run it.", msg)
 								else string.format("'%s' is not a valid command.", msg);
 						})
@@ -413,7 +413,7 @@ return function(Vargs, GetEnv)
 					return
 				end
 
-				local allowed, denial = false, nil
+				local allowed, denialMessage = false, nil
 				local isSystem = false
 
 				local pDat = {
@@ -427,13 +427,13 @@ return function(Vargs, GetEnv)
 					allowed = not command.Disabled
 					p = p or "SYSTEM"
 				else
-					allowed, denial = Admin.CheckPermission(pDat, command, false, opts)
+					allowed, denialMessage = Admin.CheckPermission(pDat, command, false, opts)
 				end
 
 				if not allowed then
-					if not (isSystem or opts.NoOutput) and (denial or not Settings.SilentCommandDenials or opts.Check) then
+					if not (isSystem or opts.NoOutput) and (denialMessage or not Settings.SilentCommandDenials or opts.Check) then
 						Remote.MakeGui(p, "Output", {
-							 = denial or (if Settings.SilentCommandDenials
+							 Message = denialMessage or (if Settings.SilentCommandDenials
 								then string.format("'%s' is either not a valid command, or you do not have permission to run it.", msg)
 								else string.format("You do not have permission to run '%s'.", msg));
 						})
@@ -488,7 +488,7 @@ return function(Vargs, GetEnv)
 	
 							if not isSystem then
 								Remote.MakeGui(p, "Output", {
-									 = cmdError,
+									Message = cmdError,
 								})
 								warn(`Encountered an error while running a command: {msg}\n{cmdError}\n{debug.traceback()}`)
 							end

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -433,7 +433,7 @@ return function(Vargs, GetEnv)
 				if not allowed then
 					if not (isSystem or opts.NoOutput) and (denialMessage or not Settings.SilentCommandDenials or opts.Check) then
 						Remote.MakeGui(p, "Output", {
-							 Message = denialMessage or (if Settings.SilentCommandDenials
+							Message = denialMessage or (if Settings.SilentCommandDenials
 								then string.format("'%s' is either not a valid command, or you do not have permission to run it.", msg)
 								else string.format("You do not have permission to run '%s'.", msg));
 						})

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -108,7 +108,7 @@ return function(Vargs, GetEnv)
 						return require(ChatSettings)
 					end)
 					if success then
-						local NewChatLimit = ChatSettingsModule.MaximumMessageLength
+						local NewChatLimit = ChatSettingsModule.MaximumLength
 						if NewChatLimit and type(NewChatLimit) == "number" then
 							Process.MaxChatCharacterLimit = NewChatLimit
 							AddLog("Script", `Chat Character Limit automatically set to {NewChatLimit}`)
@@ -285,8 +285,8 @@ return function(Vargs, GetEnv)
 		RunAfterPlugins = RunAfterPlugins;
 		RateLimit = RateLimit;
 		newRateLimit = newRateLimit;
-		MsgStringLimit = 500; --// Max message string length to prevent long length chat spam server crashing (chat & command bar); Anything over will be truncated;
-		MaxChatCharacterLimit = 250; --// Roblox chat character limit; The actual limit of the Roblox chat's textbox is 200 characters; I'm paranoid so I added 50 characters; Users should not be able to send a message larger than that;
+		MsgStringLimit = 500; --// Max  string length to prevent long length chat spam server crashing (chat & command bar); Anything over will be truncated;
+		MaxChatCharacterLimit = 250; --// Roblox chat character limit; The actual limit of the Roblox chat's textbox is 200 characters; I'm paranoid so I added 50 characters; Users should not be able to send a  larger than that;
 		RemoteMaxArgCount = 5; --// The maximum argument count Adonis will take from Remote (alter if your script requires more arguments)
 		RateLimits = {
 			Remote = 0.01;
@@ -405,7 +405,7 @@ return function(Vargs, GetEnv)
 					if opts.Check then
 						Remote.MakeGui(p, "Output", {
 							Title = "Output";
-							Message = if Settings.SilentCommandDenials
+							 = if Settings.SilentCommandDenials
 								then string.format("'%s' is either not a valid command, or you do not have permission to run it.", msg)
 								else string.format("'%s' is not a valid command.", msg);
 						})
@@ -413,7 +413,7 @@ return function(Vargs, GetEnv)
 					return
 				end
 
-				local allowed, denialMessage = false, nil
+				local allowed, denial = false, nil
 				local isSystem = false
 
 				local pDat = {
@@ -427,13 +427,13 @@ return function(Vargs, GetEnv)
 					allowed = not command.Disabled
 					p = p or "SYSTEM"
 				else
-					allowed, denialMessage = Admin.CheckPermission(pDat, command, false, opts)
+					allowed, denial = Admin.CheckPermission(pDat, command, false, opts)
 				end
 
 				if not allowed then
-					if not (isSystem or opts.NoOutput) and (denialMessage or not Settings.SilentCommandDenials or opts.Check) then
+					if not (isSystem or opts.NoOutput) and (denial or not Settings.SilentCommandDenials or opts.Check) then
 						Remote.MakeGui(p, "Output", {
-							Message = denialMessage or (if Settings.SilentCommandDenials
+							 = denial or (if Settings.SilentCommandDenials
 								then string.format("'%s' is either not a valid command, or you do not have permission to run it.", msg)
 								else string.format("You do not have permission to run '%s'.", msg));
 						})
@@ -488,7 +488,7 @@ return function(Vargs, GetEnv)
 	
 							if not isSystem then
 								Remote.MakeGui(p, "Output", {
-									Message = cmdError,
+									 = cmdError,
 								})
 								warn(`Encountered an error while running a command: {msg}\n{cmdError}\n{debug.traceback()}`)
 							end
@@ -1007,7 +1007,7 @@ return function(Vargs, GetEnv)
 							task.wait(1)
 							for _,Message in pairs(Settings.Messages) do
 								Remote.MakeGui(p,"Notification",{
-									Title = "Message!";
+									Title = "Message";
 									Message = tostring(Message);
 									Time = math.round((#Message/19)+2.5);
 								})

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -950,22 +950,44 @@ return function(Vargs, GetEnv)
 					local newVer = (level > 300) and tonumber(string.match(server.Changelog[1], "Version: (.*)"))
 
 					if Settings.Notification then
-						Functions.Notification("Welcome.", "Click here for commands.", {p}, 15, "MatIcon://Verified user", Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.Prefix}cmds')`))
-
-						task.wait(1)
+						Remote.MakeGui(p, "Notification", {
+							Title = "Welcome.";
+							Message = "Click here for commands.";
+							Icon = server.MatIcons["Verified user"];
+							Time = 15;
+							OnClick = Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.Prefix}cmds')`);
+						})
 
 						if oldVer and newVer and newVer > oldVer then
-							Functions.Notification("Updated!", "Click to view the changelog.", {p}, 10, "MatIcon://Description", Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.Prefix}changelog')`))
+							task.wait(1)
+							Remote.MakeGui(p, "Notification", {
+								Title = "Updated!";
+								Message = "Click to view the changelog.";
+								Icon = server.MatIcons.Description;
+								Time = 10;
+								OnClick = Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.Prefix}changelog')`);
+							})
 						end
 
-						task.wait(1)
-
 						if level > 300 and Core.DebugMode == true then
-							Functions.Notification("Debug Mode Enabled", "Adonis is currently running in Debug Mode.", {p}, 10, "MatIcon://Bug report", Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.Prefix}debugcmds')`))
+							task.wait(1)
+							Remote.MakeGui(p, "Notification", {
+								Title = "Debug Mode Enabled";
+								Message = "Adonis is currently running in Debug Mode.";
+								Icon = server.MatIcons["Bug report"];
+								Time = 10;
+								OnClick = Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.Prefix}debugcmds')`);
+							})
 						end
 
 						if level > 300 and Settings.DataStoreKey == Defaults.Settings.DataStoreKey and Core.DebugMode == false then
-							Functions.Notification("Warning!", "Using default datastore key!", {p}, "MatIcon://Description", Core.Bytecode([[
+							task.wait(1)
+							Remote.MakeGui(p, "Notification", {
+								Title = "Warning!";
+								Message = "Using default datastore key!";
+								Icon = server.MatIcons.Description;
+								Time = 10;
+								OnClick = Core.Bytecode([[
 									local window = client.UI.Make("Window", {
 										Title = "How to change the DataStore key";
 										Size = {700,300};
@@ -977,8 +999,19 @@ return function(Vargs, GetEnv)
 									})
 
 									window:Ready()
-								]])
-							)
+								]]);
+							})
+						end
+						
+						if level >= 300 and #Settings.Messages > 0 then
+							task.wait(1)
+							for _,Message in pairs(Settings.Messages) do
+								Remote.MakeGui(p,"Notification",{
+									Title = "Message!";
+									Message = tostring(Message);
+									Time = math.round((#Message/19)+2.5);
+								})
+							end
 						end
 					end
 

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -1004,8 +1004,8 @@ return function(Vargs, GetEnv)
 						end
 						
 						if level >= 300 and #Settings.Messages > 0 then
-							task.wait(1)
 							for _,Message in pairs(Settings.Messages) do
+								task.wait(1)
 								Remote.MakeGui(p,"Notification",{
 									Title = "Message";
 									Message = tostring(Message);


### PR DESCRIPTION
# Fixed Settings.Notification
I fixed Settings.Notification before it used to not show any notification, but now it shows a notification

Before: (By: @astrohweston) That's their discord not github
![Medal_aFiDDIWYJC](https://github.com/Epix-Incorporated/Adonis/assets/122803145/6e9aa2e6-9337-4479-9e27-45ea42031254)

After: (By: me)
![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/76c361ab-68e6-49f2-af75-525c5617e9a6)

# Tweaked how the system waits before sending another default notification
Before the tweak, it used to wait after every if statement. But now, it waits after a successful if statement, so instead of waiting 2 seconds for the GUI if the first if statement failed, you're only waiting 1 seconds as I put the task.wait() inside the if statement if it was successful

[**Before**](https://github.com/Epix-Incorporated/Adonis/assets/122803145/7fecd49e-29c3-4ee8-b062-dc8c9e5e3c0e) (By: Me)

[**After**](https://github.com/Epix-Incorporated/Adonis/assets/122803145/1f6bd168-ba3b-4cd1-86f5-dd0a668410a2) (By: Me)

