### PR TITLE
Removed the random warn in the Window Code

### DIFF
--- a/MainModule/Client/UI/Default/Window.rbxmx
+++ b/MainModule/Client/UI/Default/Window.rbxmx
@@ -983,7 +983,6 @@ return function(data, env)
 	local InputService = service.UserInputService
 	local gIndex = data.gIndex
 	local gTable = data.gTable
-	warn(gTable.BindEvent)
 
 	local Event = gTable.BindEvent
 	local GUI = gTable.Object


### PR DESCRIPTION
# Removed the random warn in the Window Code
I removed the warn(gTable.BindEvent)

I don't need before and after.