### PR TITLE
Added old name command with fix to CameraSubject

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -1317,6 +1317,10 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
+		FixCameraSubject = function()
+			workspace.Camera.CameraSubject = service.Players.LocalPlayer.Character.Humanoid
+		end,
+
 		FadeAudio = function(audioId,inVol,pitch,looped,incWait)
 			if not inVol then
 				local sound = Variables.localSounds[tostring(audioId)]


### PR DESCRIPTION
# Added old name command
I added the old name command back because, the new one if people have custom name tags it ceases to work unlike the old one. The way I fixed the old one is so simple, I just added a remote that changes the camera subject back.

Proof of it working: (By: me)
https://github.com/Epix-Incorporated/Adonis/assets/122803145/3f7d5d18-9311-4860-aab2-e2e1cd34055a

# Added new remote function
The new remote function is called "FixCameraSubject" it just resets the camera subject back to the regular humanoid (used as a fix to the old name command.)
