### PR TITLE
String Matching Fix

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1316,7 +1316,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		Trim = function(str)
-			return string.match(str, "^%s*(.-)%s*$")
+			return string.match(str, "^%s*([^%.]-)%s*$")
 		end;
 
 		RoundToPlace = function(num, places)


### PR DESCRIPTION
The current string matching for trimming matches `.`, causing issues when using plugins like [Player Selector Restrictor](https://github.com/Epix-Incorporated/Adonis-Plugins/blob/master/Server/Server-PlayerSelector_Restrictor.lua), as players are able to select everyone by using `.`, when they are restricted from doing so.

For example, when a player is unable to execute `:fly all` because they are restricted from doing so, they could execute `:fly .` to make every player in the server fly.

I have modified the string matching to exclude the `.`, which prevents players being able to select all players when they are not allowed to.