### PR TITLE
Fix Duplicate Display of Reason in Kick Message

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -1014,7 +1014,7 @@ return function(Vargs, GetEnv)
 					if ban.EndTime-os.time() <= 0 then
 						table.remove(Core.Variables.TimeBans, ind)
 					else
-						return true, `\n Reason: {ban.Reason or "(No reason provided.)"}\n Banned until {service.FormatTime(ban.EndTime, {WithWrittenDate = true})}`
+						return true, `\n {ban.Reason or "(No reason provided.)"}\n | Banned until {service.FormatTime(ban.EndTime, {WithWrittenDate = true})}`
 					end
 				end
 			end


### PR DESCRIPTION
The current implementation of CheckBan results in the timeban "Reason:" text being displayed twice. This pull request addresses this issue by removing the duplication.
This also fixes [this](https://discord.com/channels/81902207070380032/1195434999235760168) bug report.
@h0nzzz helped with the Fix. I had a stroke the moment i opened Process.lua