### PR TITLE
Add NoLog option to Commands

### DIFF
--- a/MainModule/Server/Core/Commands.lua
+++ b/MainModule/Server/Core/Commands.lua
@@ -42,6 +42,7 @@ return function(Vargs, GetEnv)
 			Hidden = t.boolean,
 			Disabled = t.boolean,
 			NoStudio = t.boolean,
+			NoLog = t.boolean,
 			NonChattable = t.boolean,
 			AllowDonors = t.boolean,
 			Donors = t.boolean,
@@ -70,6 +71,7 @@ return function(Vargs, GetEnv)
 				Hidden = false;
 				Disabled = false;
 				NoStudio = false;
+				NoLog = false;
 				NonChattable = false;
 				AllowDonors = false;
 				Donors = false;

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -460,7 +460,7 @@ return function(Vargs, GetEnv)
 					end
 				end
 
-				if opts.CrossServer or (not isSystem and not opts.DontLog) then
+				if (opts.CrossServer or (not isSystem and not opts.DontLog)) and not command.NoLog then
 					local noSave = command.AdminLevel == "Player" or command.Donors or command.AdminLevel == 0
 					AddLog("Commands", {
 						Text = `{((opts.CrossServer and "[CRS_SERVER] ") or "")}{p.Name}`;


### PR DESCRIPTION
The reason for this commit is that there is no way for Commands to opt out of logging on a per-command basis, as far as I am aware. This can be useful in instances where you might not want a command to be logged for whatever reason.

I acknowledge that there's likely a better way to write the conditional statement, so I'm open to suggestions.