### PR TITLE
String Match Fix (That works)

### DIFF
--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1316,7 +1316,16 @@ return function(Vargs, GetEnv)
 		end;
 
 		Trim = function(str)
-			return string.match(str, "^%s*(.-)%s*$")
+			local Split = str:split(" ")
+			if #Split > 1 then
+				if string.match(Split[2],"^%s*(%.-)%s*$") then
+					return str:gsub(".","")
+				else
+					return string.match(str,"^%s*(.-)%s*$")
+				end
+			else
+				return string.match(str,"^%s*(.-)%s*$")
+			end
 		end;
 
 		RoundToPlace = function(num, places)


### PR DESCRIPTION
# I fixed the string match issue (for real)
I managed to find a fix that doesn't break Adonis

How it works:
1. It splits the string by spaces (so we can get the 2nd argument which would normally be a player argument)
2. It checks to see if it's not the command by itself if it's my itself it'll do a normal trim
3. If the command is not by itself it checks the 2nd argument (mostly player argument)
4. If it detects only periods it filters the periods out if there's not only periods it'll do the normal trim

Proof of functionality:
https://cdn.discordapp.com/attachments/861902305715421185/1196537317427511467/2024-01-15_13-25-07.mp4?ex=65b7fd37&is=65a58837&hm=585f3fa50b56f784c0a86349e2193a4f93f692e53c4f39ac0be38fd596e565ef&