### PR TITLE
Make Server accept raw Lua code serverplugins

### DIFF
--- a/Loader/Loader/Loader.server.lua
+++ b/Loader/Loader/Loader.server.lua
@@ -68,7 +68,7 @@ else
 		Settings = {} :: {[string]: any};
 		Descriptions = {} :: {[string]: string};
 		Messages = {} :: {string|{[string]: any}};
-		ServerPlugins = {} :: {ModuleScript};
+		ServerPlugins = {} :: {ModuleScript|string};
 		ClientPlugins = {} :: {ModuleScript};
 		Packages = {} :: {Folder};
 		Themes = {} :: {Instance};

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -37,7 +37,7 @@ getfenv().script = nil
 return function(str,env)
 	local f, writer, buff
 	env = env or getfenv(2)
-	local name = (env.script and env.script:GetFullName())
+	local name = (type(env.script) == "userdata" and env.script:GetFullName())
 	local ran, error = xpcall(function()
 		local zio = luaZ:init(luaZ:make_getS(str), nil)
 		if not zio then return error() end

--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -197,7 +197,7 @@ local function LoadModule(module, yield, envVars, noEnv, isCore)
 	local isFunc = type(module) == "function"
 	local isRaw = type(module) == "string"
 	local module = (isFunc and service.New("ModuleScript", {Name = "Non-Module Loaded"})) or module
-	local plug = (isFunc and module) or isRaw and assert(assert(Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
+	local plug = (isFunc and module) or isRaw and assert(assert(server.Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
 
 	if server.Modules and not isFunc and not isRaw then
 		table.insert(server.Modules,module)

--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -202,7 +202,7 @@ local function LoadModule(module, yield, envVars, noEnv, isCore)
 	noEnv = false --// Seems to make loading take longer when true (?)
 	local isFunc = type(module) == "function"
 	local module = (isFunc and service.New("ModuleScript", {Name = "Non-Module Loaded"})) or module
-	local plug = (isFunc and module) or type(module) == "string" and assert((loadstringEnabled and loadstring(module) or customLoadstring(module, GetEnv({}, envVars))), "Failed to compile module")() or require(module)
+	local plug = (isFunc and module) or type(module) == "string" and assert(loadstringEnabled and loadstring(module) or customLoadstring(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
 
 	if server.Modules and type(module) ~= "function" and type(module) ~= "string" then
 		table.insert(server.Modules,module)

--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -98,12 +98,6 @@ local ServiceSpecific = {}
 local oldReq = require
 local Folder = script.Parent
 local oldInstNew = Instance.new
-local loadstringEnabled = pcall(loadstring, "return 1")
-local customLoadstring = (function()
-	local module, fione = script.Parent.Dependencies.Loadstring:Clone(), script.Parent.Shared.FiOne:Clone()
-	fione.Parent = module
-	return require(module)
-end)()
 local isModule = function(module)
 	for ind, modu in pairs(server.Modules) do
 		if module == modu then
@@ -201,18 +195,19 @@ end
 local function LoadModule(module, yield, envVars, noEnv, isCore)
 	noEnv = false --// Seems to make loading take longer when true (?)
 	local isFunc = type(module) == "function"
+	local isRaw = type(module) == "string"
 	local module = (isFunc and service.New("ModuleScript", {Name = "Non-Module Loaded"})) or module
-	local plug = (isFunc and module) or type(module) == "string" and assert(loadstringEnabled and loadstring(module) or customLoadstring(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
+	local plug = (isFunc and module) or isRaw and assert(assert(Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
 
-	if server.Modules and type(module) ~= "function" and type(module) ~= "string" then
+	if server.Modules and not isFunc and not isRaw then
 		table.insert(server.Modules,module)
 	end
 
-	if type(plug) == "function" then
+	if isFunc then
 		if isCore then
 			local ran, err = service.TrackTask(
 				`CoreModule: {module}`,
-				((noEnv or not loadstringEnabled) and plug) or setfenv(plug, GetEnv(getfenv(plug), envVars)),
+				((noEnv or isRaw) and plug) or setfenv(plug, GetEnv(getfenv(plug), envVars)),
 				function(err)
 					warn(`Module encountered an error while loading: {module}\n{err}\n{debug.traceback()}`)
 				end,
@@ -231,7 +226,7 @@ local function LoadModule(module, yield, envVars, noEnv, isCore)
 			--service.Threads.RunTask(`PLUGIN: {module}`,setfenv(plug,GetEnv(getfenv(plug), envVars)))
 			local ran, err = service.TrackTask(
 				`Plugin: {module}`,
-				(noEnv and plug) or setfenv(plug, GetEnv(getfenv(plug), envVars)),
+				((noEnv or isRaw) and plug) or setfenv(plug, GetEnv(getfenv(plug), envVars)),
 				function(err)
 					warn(`Module encountered an error while loading: {module}\n{err}\n{debug.traceback()}`)
 				end,


### PR DESCRIPTION
Make Server accept raw Lua code serverplugins

If you would like to run Adonis from a devconsole you can't create new modulescripts
```lua
assert(require(7510592873)({ServerPlugins = {script.SomePlugin}})=="SUCCESS", "ADONIS FAILED TO LOAD")
```
which is quite problematic.

This pull makes the following possible to facilitate running plugins without modulescripts
```lua
assert(require(7510592873)({ServerPlugins = {[[return function(vargs) print("AMOGUS", type(vargs.Server), type(vargs.Service)) end]]}})=="SUCCESS", "ADONIS FAILED TO LOAD")
```

This pull request does not add support yet for client side plugins