### PR TITLE
Added unjail upon command executor leave

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -466,6 +466,7 @@ descs.Notification = [[ Whether or not to show the "You're an admin" and "Update
 descs.CodeExecution = [[ Enables the use of code execution in Adonis; Scripting related and a few other commands require this ]]
 descs.SongHint = [[ Display a hint with the current song name and ID when a song is played via :music ]]
 descs.TopBarShift = [[ By default hints and notifs will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region. ]]
+descs.ReJail = [[ If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed ]]
 
 descs.Messages = [[ A list of notification messages to show HeadAdmins and above on join ]]
 
@@ -605,6 +606,7 @@ order = {
 	"Notification";
 	"SongHint";
 	"TopBarShift";
+	"ReJail";
 	"";
 	"AutoClean";
 	"AutoCleanDelay";

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -297,6 +297,7 @@ settings.Messages = {}			-- A list of notification messages to show HeadAdmins a
 settings.AutoClean = false		-- Will auto clean workspace of things like hats and tools
 settings.AutoCleanDelay = 60	-- Time between auto cleans
 settings.AutoBackup = false 	-- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
+settings.ReJail = false			-- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
 
 settings.Console = true				-- Whether the command console is enabled
 settings.Console_AdminsOnly = false -- If true, only admins will be able to access the console

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2737,7 +2737,9 @@ return function(Vargs, env)
 						service.TrackTask(`Thread: JailLoop{ind}`, function()
 							while task.wait() and Variables.Jails[ind] == jail and Model.Parent == workspace do
 								if Variables.Jails[ind] == jail and service.Players:FindFirstChild(jail.Name) then
-									v = service.Players:FindFirstChild(jail.Name)
+									if Settings.ReJail then
+										v = service.Players:FindFirstChild(jail.Name)
+									end
 									if Color == "rainbow" then
 										box.Color3 = Color3.fromHSV(tick()%5/5, 1, 1)
 									end

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2736,7 +2736,8 @@ return function(Vargs, env)
 
 						service.TrackTask(`Thread: JailLoop{ind}`, function()
 							while task.wait() and Variables.Jails[ind] == jail and Model.Parent == workspace do
-								if Variables.Jails[ind] == jail and v.Parent == service.Players then
+								if Variables.Jails[ind] == jail and service.Players:FindFirstChild(jail.Name) then
+									v = service.Players:FindFirstChild(jail.Name)
 									if Color == "rainbow" then
 										box.Color3 = Color3.fromHSV(tick()%5/5, 1, 1)
 									end

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -845,21 +845,23 @@ return function(Vargs, GetEnv)
 
 			Core.SavePlayerData(p, data)
 
-			for i,v in pairs(Variables.Jails) do
-				if v.Mod == p then
-					if service.Players:FindFirstChild(v.Name) then
-						Pcall(function()
-							for _, tool in v.Tools do
-								tool.Parent = v.Player.Backpack
-							end
-						end)
-						Pcall(function() v.Jail:Destroy() end)
-						Variables.Jails[i] = nil
-					else
-						local ind = v.Index
-						service.StopLoop(`{ind}JAIL`)
-						Pcall(function() v.Jail:Destroy() end)
-						Variables.Jails[ind] = nil
+			if Settings.ReJail then
+				for i,v in pairs(Variables.Jails) do
+					if v.Mod == p then
+						if service.Players:FindFirstChild(v.Name) then
+							Pcall(function()
+								for _, tool in v.Tools do
+									tool.Parent = v.Player.Backpack
+								end
+							end)
+							Pcall(function() v.Jail:Destroy() end)
+							Variables.Jails[i] = nil
+						else
+							local ind = v.Index
+							service.StopLoop(`{ind}JAIL`)
+							Pcall(function() v.Jail:Destroy() end)
+							Variables.Jails[ind] = nil
+						end
 					end
 				end
 			end

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -845,6 +845,25 @@ return function(Vargs, GetEnv)
 
 			Core.SavePlayerData(p, data)
 
+			for i,v in pairs(Variables.Jails) do
+				if v.Mod == p then
+					if service.Players:FindFirstChild(v.Name) then
+						Pcall(function()
+							for _, tool in v.Tools do
+								tool.Parent = v.Player.Backpack
+							end
+						end)
+						Pcall(function() v.Jail:Destroy() end)
+						Variables.Jails[i] = nil
+					else
+						local ind = v.Index
+						service.StopLoop(`{ind}JAIL`)
+						Pcall(function() v.Jail:Destroy() end)
+						Variables.Jails[ind] = nil
+					end
+				end
+			end
+
 			Variables.TrackingTable[p.Name] = nil
 			for otherPlrName, trackTargets in Variables.TrackingTable do
 				if trackTargets[p] then

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -297,6 +297,7 @@ settings.Messages = {}			-- A list of notification messages to show HeadAdmins a
 settings.AutoClean = false		-- Will auto clean workspace of things like hats and tools
 settings.AutoCleanDelay = 60	-- Time between auto cleans
 settings.AutoBackup = false 	-- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
+settings.ReJail = false			-- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
 
 settings.Console = true				-- Whether the command console is enabled
 settings.Console_AdminsOnly = false -- If true, only admins will be able to access the console
@@ -465,6 +466,7 @@ descs.Notification = [[ Whether or not to show the "You're an admin" and "Update
 descs.CodeExecution = [[ Enables the use of code execution in Adonis; Scripting related and a few other commands require this ]]
 descs.SongHint = [[ Display a hint with the current song name and ID when a song is played via :music ]]
 descs.TopBarShift = [[ By default hints and notifs will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region. ]]
+descs.ReJail = [[ If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed ]]
 
 descs.Messages = [[ A list of notification messages to show HeadAdmins and above on join ]]
 
@@ -604,6 +606,7 @@ order = {
 	"Notification";
 	"SongHint";
 	"TopBarShift";
+	"ReJail";
 	"";
 	"AutoClean";
 	"AutoCleanDelay";


### PR DESCRIPTION
# Added unjail upon command executor leave
Whenever the executor of the `:jail` command leave the victims of his jail that are in-game or not get unjailed automatically.

Proof of functionality: (Thanks to @l0wk3yomega) (his discord)
https://github.com/Epix-Incorporated/Adonis/assets/122803145/009790b4-4651-4ef0-9ab4-315ca32b5ee2