### PR TITLE
Fix slowmode logging

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -463,6 +463,14 @@ return function(Vargs, GetEnv)
 		--// How long admin levels will be cached (unless forcibly updated via something like :admin user)
 		AdminLevelCacheTimeout = 30;
 
+		CheckSlowMode = function(p: Player)
+			if Admin.SlowMode and Admin.SlowCache[p] and os.time() - Admin.SlowCache[p] < Admin.SlowMode then
+				return true
+			else
+				return false
+			end
+		end,
+		
 		DoHideChatCmd = function(p: Player, message: string, data: {[string]: any}?)
 			local pData = data or Core.GetPlayer(p)
 			if pData.Client.HideChatCommands then

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -604,33 +604,47 @@ return function(Vargs, GetEnv)
 				if utf8.len(utf8.nfcnormalize(msg)) > Process.MaxChatCharacterLimit and not Admin.CheckAdmin(p) then
 					Anti.Detected(p, "Kick", "Chatted message over the maximum character limit")
 				elseif not isMuted then
-					local msg = string.sub(msg, 1, Process.MsgStringLimit)
-					local filtered = service.LaxFilter(msg, p)
+					local Slowmode = Admin.CheckSlowMode(p)
+					if not Slowmode then
+						local msg = string.sub(msg, 1, Process.MsgStringLimit)
+						local filtered = service.LaxFilter(msg, p)
 
-					AddLog(Logs.Chats, {
-						Text = `{p.Name}: {filtered}`;
-						Desc = tostring(filtered);
-						Player = p;
-					})
+						AddLog(Logs.Chats, {
+							Text = `{p.Name}: {filtered}`;
+							Desc = tostring(filtered);
+							Player = p;
+						})
 
-					if Settings.ChatCommands then
-						if Admin.DoHideChatCmd(p, msg) then
-							Remote.Send(p,"Function","ChatMessage",`> {msg}`,Color3.new(1, 1, 1))
-							Process.Command(p, msg, {Chat = true;})
-						elseif string.sub(msg, 1, 3) == "/e " then
-							service.Events.PlayerChatted:Fire(p, msg)
-							msg = string.sub(msg, 4)
-							Process.Command(p, msg, {Chat = true;})
-						elseif string.sub(msg, 1, 8) == "/system " then
-							service.Events.PlayerChatted:Fire(p, msg)
-							msg = string.sub(msg, 9)
-							Process.Command(p, msg, {Chat = true;})
+						if Settings.ChatCommands then
+							if Admin.DoHideChatCmd(p, msg) then
+								Remote.Send(p,"Function","ChatMessage",`> {msg}`,Color3.new(1, 1, 1))
+								Process.Command(p, msg, {Chat = true;})
+							elseif string.sub(msg, 1, 3) == "/e " then
+								service.Events.PlayerChatted:Fire(p, msg)
+								msg = string.sub(msg, 4)
+								Process.Command(p, msg, {Chat = true;})
+							elseif string.sub(msg, 1, 8) == "/system " then
+								service.Events.PlayerChatted:Fire(p, msg)
+								msg = string.sub(msg, 9)
+								Process.Command(p, msg, {Chat = true;})
+							else
+								service.Events.PlayerChatted:Fire(p, msg)
+								Process.Command(p, msg, {Chat = true;})
+							end
 						else
 							service.Events.PlayerChatted:Fire(p, msg)
-							Process.Command(p, msg, {Chat = true;})
 						end
-					else
-						service.Events.PlayerChatted:Fire(p, msg)
+					elseif Slowmode then
+						local msg = string.sub(msg, 1, Process.MsgStringLimit)
+						
+						if Settings.ChatCommands then
+							if Admin.DoHideChatCmd(p, msg) then
+								Remote.Send(p,"Function","ChatMessage",`> {msg}`,Color3.new(1, 1, 1))
+								Process.Command(p, msg, {Chat = true;})
+							else
+								Process.Command(p, msg, {Chat = true;})
+							end
+						end
 					end
 				elseif isMuted then
 					local msg = string.sub(msg, 1, Process.MsgStringLimit);


### PR DESCRIPTION
# Fixed slowmode logging chats
I made it where when on slowmode it no longer logs it (might make it log but with an identifier saying it was sent on slowmode)

PoF:
![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/6a842c28-87fa-44f4-85d2-c460fdf33acf)