### PR TITLE
Fix :Smite freezing everyone

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -2497,8 +2497,8 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				for i, v in service.GetPlayers(plr, args[1]) do
 					task.spawn(pcall, function()
-						Admin.RunCommand(`{Settings.Prefix}freeze`, v.Name)
 						local char = v.Character
+						char.HumanoidRootPart.Anchored = true
 						local zeus = service.New("Model", char)
 						local cloud = service.New("Part", zeus)
 						cloud.Anchored = true


### PR DESCRIPTION
# Fixed smite freezing everyone
As the title says, I made it not freeze everyone by anchoring the humanoid root part.