### PR TITLE
Fix RefreshGui not giving a theme over to Client

### DIFF
--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -1295,7 +1295,7 @@ return function(Vargs, GetEnv)
 			if not p then return end
 			local theme = {Desktop = Settings.Theme; Mobile = Settings.MobileTheme}
 			if themeData then for ind,dat in themeData do theme[ind] = dat end end
-			Remote.Send(p,"RefreshUI",name,ignore,themeData,data or {})
+			Remote.Send(p,"RefreshUI",name,ignore,themeData or theme,data or {})
 		end;
 
 		NewParticle = function(p: Player, target: Instance, class: string, properties: { [string]: any })


### PR DESCRIPTION
# Fixed RefreshGui not giving a theme over to Client
I fixed a bug that has gone unnoticed for some time (mainly because barley anything uses `Remote.RefreshGui`) but I found a fix for the issue but handing either `themeData` if there, but if it isn't then we'll send the normal `theme` that would be sent in `Remote.MakeGui`