### PR TITLE
Fixed malformed group inputs giving everybody a rank

### DIFF
--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -648,11 +648,12 @@ return function(Vargs, GetEnv)
 					local groupId = tonumber((string.match(filterData, "^%d+")))
 					if groupId then
 						local plrRank = Admin.GetGroupLevel(plr.UserId, groupId)
-						local requiredRank = tonumber((string.match(filterData, "^%d+:(.+)$")))
+						local requiredRank,noRank = tonumber((string.match(filterData, "^%d+:(.+)$"))), string.match(filterData,"^%d+$")
 						if requiredRank then
-							return plrRank == requiredRank or (requiredRank < 0 and plrRank >= math.abs(requiredRank))
+							return plrRank >= math.abs(requiredRank)
+						elseif noRank then
+							return plrRank > 0
 						end
-						return plrRank > 0
 					end
 					return false
 				elseif filterName == "item" then

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -650,7 +650,11 @@ return function(Vargs, GetEnv)
 						local plrRank = Admin.GetGroupLevel(plr.UserId, groupId)
 						local requiredRank,noRank = tonumber((string.match(filterData, "^%d+:(.+)$"))), string.match(filterData,"^%d+$")
 						if requiredRank then
-							return plrRank >= math.abs(requiredRank)
+							if requiredRank < 0 then
+								return plrRank >= math.abs(requiredRank)
+							else
+								return plrRank == requiredRank
+							end
 						elseif noRank then
 							return plrRank > 0
 						end


### PR DESCRIPTION
# Fixed malformed group inputs giving everybody a rank
I fixed a new bug that showed up that dealt with if group rank inputs were malformed.
This is what it does:
It first checks if a rank was provided, if it returns with a rank that isn't malformed then it checks the persons rank in the group with the rank provided, but if the rank is malformed it'll return false, but if no rank is provided it'll rank them based off if they're in the group.
