### PR TITLE
Update command desc for `:flyclip` to show it doesn't allow noclipping

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2538,7 +2538,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"flyclip"};
 			Args = {"player", "speed"};
-			Description = "Flying noclip";
+			Description = "Lets the target player(s) fly but does not allow them to go through walls";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local newArgs = { "me", args[2] or "2", "false" }


### PR DESCRIPTION
`:flyclip` doesn't grant noclipping, this fixes a small oversight when the command was changed from `:flynoclip` 

![image](https://github.com/Epix-Incorporated/Adonis/assets/77434904/200d53da-1ce7-48a3-97ae-ecfb900b6ee5)
