### PR TITLE
Fixed SaveCommandLogs

### DIFF
--- a/MainModule/Server/Commands/Creators.lua
+++ b/MainModule/Server/Commands/Creators.lua
@@ -303,6 +303,27 @@ return function(Vargs, env)
 					end)
 				end
 			end,
+		};
+
+		ClearOldLogs = {
+			Prefix = Settings.Prefix;
+			Commands = {"clearoldlogs","flusholdlogs"};
+			Description = "Clears old logs";
+			AdminLevel = "Creators";
+			Function = function(plr: Player)
+				local ans = Remote.GetGui(plr, "YesNoPrompt", {
+					Question = `Are you sure you want to clear old logs (this will be saved in old logs)`;
+					Title = `Clear Old Logs`;
+					Icon = server.MatIcons.Info;
+					Size = {300, 200};
+				})
+				if ans == "Yes" then
+					Core.RemoveData("OldCommandLogs")
+					Functions.Hint("Old Logs Cleared (this will be saved in old logs)", {plr})
+				else
+					Functions.Hint("Operation cancelled", {plr})
+				end
+			end,
 		}
 
 		--[[

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6682,7 +6682,7 @@ return function(Vargs, env)
 					local tab = table.create(1000)
 					local data = Core.GetData("OldCommandLogs")
 					if data then
-						for i, v in data do
+						for i, v in service.HttpService:JSONDecode(data) do
 							table.insert(tab, i, {
 								Time = v.Time,
 								Text = `{v.Text}: {v.Desc}`,

--- a/MainModule/Server/Core/Logs.lua
+++ b/MainModule/Server/Core/Logs.lua
@@ -123,7 +123,7 @@ return function(Vargs, GetEnv)
 			--	table.insert(logsToSave, Logs.Commands[i]);
 			--end
 
-			Core.UpdateData("OldCommandLogs", function(oldLogs) oldLogs = service.HttpService:JSONDecode(oldLogs)
+			Core.UpdateData("OldCommandLogs", function(oldLogs) if typeof(oldLogs) ~= "table" then oldLogs = service.HttpService:JSONDecode(oldLogs) end
 				local temp = {}
 
 				for _, m in logsToSave do


### PR DESCRIPTION
# Fixed SaveCommandLogs
I made it work with DLL and normal tables, and fix how it trims logs from the oldest. I also made it JSONEncode while in the datastore to stop an error, and have better storage so we could have more logs in there.

(Because there might be oldlogs that aren't strings we check for them and encode them while saving to allow old games to keep their logs)

PoF:
![image](https://github.com/Epix-Incorporated/Adonis/assets/122803145/d36850a0-4799-4f5e-97fd-962d81a06715)