### PR TITLE
Allow Performance Stats window to be resized

### DIFF
--- a/MainModule/Client/UI/Default/PerfStats.lua
+++ b/MainModule/Client/UI/Default/PerfStats.lua
@@ -1,38 +1,37 @@
-client,service = nil,nil
+client, service = nil, nil
 
-return function(data,env)
+return function(data, env)
 	if env then
 		setfenv(1, env)
 	end
-	
+
 	local gfps = true
 	local gTable
-	
+
 	--warn(math.floor(1/game:GetService("RunService").RenderStepped:Wait()))
-	
-	local window = client.UI.Make("Window",{
-		Name  = "Performance stats";
-		Title = "Stats";
-		Icon = client.MatIcons.Leaderboard;
-		Size  = {150, 90};
-		Position = UDim2.new(0, 10, 1, -100);
-		AllowMultiple = false;
-		NoHide = true;
-		Walls = true;
-		SizeLocked = true;
-		CanKeepAlive = true;
+
+	local window = client.UI.Make("Window", {
+		Name = "Performance stats",
+		Title = "Stats",
+		Icon = client.MatIcons.Leaderboard,
+		Size = { 150, 90 },
+		Position = UDim2.new(0, 10, 1, -100),
+		AllowMultiple = false,
+		NoHide = true,
+		Walls = true,
+		CanKeepAlive = true,
 		OnClose = function()
 			gfps = false
-		end
+		end,
 	})
-	
+
 	if window then
-		local label = window:Add("TextLabel",{
-			Text = "...";
-			BackgroundTransparency = 1;
-			TextSize = 20;
-			Size = UDim2.new(1, 0, 1, 0);
-			Position = UDim2.new(0, 0, 0, 0);
+		local label = window:Add("TextLabel", {
+			Text = "...",
+			BackgroundTransparency = 1,
+			TextSize = 20,
+			Size = UDim2.new(1, 0, 1, 0),
+			Position = UDim2.new(0, 0, 0, 0),
 			--TextScaled = true;
 			--TextWrapped = true;
 		})
@@ -41,7 +40,12 @@ return function(data,env)
 		window:Ready()
 
 		repeat
-			label.Text = string.format("Render: %.1f fps\nPhysics: %.1f fps\nPing: %d ms", 1/service["RunService"].RenderStepped:Wait(), workspace:GetRealPhysicsFPS(), service.Players.LocalPlayer:GetNetworkPing())
+			label.Text = string.format(
+				"Render: %.1f fps\nPhysics: %.1f fps\nPing: %d ms",
+				1 / service["RunService"].RenderStepped:Wait(),
+				workspace:GetRealPhysicsFPS(),
+				service.Players.LocalPlayer:GetNetworkPing()
+			)
 			task.wait(1)
 		until not gfps or not gTable.Active
 	end


### PR DESCRIPTION
Before it would make it so all useful data is cut off due to the window being too small and being unable to resize.

Since the !ping command was merged with the !fps command, it made being able to view your ping impossible due to the window being too small.


The only change I made besides the formatting updates to fix it was to remove the 
`SizeLocked = true;`
Code in the window