### PR TITLE
Fix !rejoin regarding max player server count

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -289,16 +289,17 @@ settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is :slocked
 settings.SystemTitle = "System Message"		-- Title to display in :sm and :bc
 
-settings.MaxLogs = 5000			-- Maximum logs to save before deleting the oldest
-settings.SaveCommandLogs = true	-- If command logs are saved to the datastores
-settings.Notification = true	-- Whether or not to show the "You're an admin" and "Updated" notifications
-settings.SongHint = true		-- Display a hint with the current song name and ID when a song is played via :music
-settings.TopBarShift = false	-- By default hints and notifications will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region.
-settings.Messages = {}			-- A list of notification messages to show HeadAdmins and above on join
-settings.AutoClean = false		-- Will auto clean workspace of things like hats and tools
-settings.AutoCleanDelay = 60	-- Time between auto cleans
-settings.AutoBackup = false 	-- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
-settings.ReJail = false			-- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
+settings.MaxLogs = 5000			           -- Maximum logs to save before deleting the oldest
+settings.SaveCommandLogs = true	           -- If command logs are saved to the datastores
+settings.Notification = true	           -- Whether or not to show the "You're an admin" and "Updated" notifications
+settings.SongHint = true		           -- Display a hint with the current song name and ID when a song is played via :music
+settings.TopBarShift = false	           -- By default hints and notifications will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region.
+settings.Messages = {}			           -- A list of notification messages to show HeadAdmins and above on join
+settings.AutoClean = false		           -- Will auto clean workspace of things like hats and tools
+settings.AutoCleanDelay = 60	           -- Time between auto cleans
+settings.AutoBackup = false 	           -- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
+settings.ReJail = false			           -- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
+settings.DisableRejoinAtMaxPlayers = false -- If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount.
 
 settings.Console = true				-- Whether the command console is enabled
 settings.Console_AdminsOnly = false -- If true, only admins will be able to access the console

--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -470,6 +470,7 @@ descs.CodeExecution = [[ Enables the use of code execution in Adonis; Scripting 
 descs.SongHint = [[ Display a hint with the current song name and ID when a song is played via :music ]]
 descs.TopBarShift = [[ By default hints and notifs will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region. ]]
 descs.ReJail = [[ If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed ]]
+descs.DisableRejoinAtMaxPlayers =  [[ If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount. ]]
 
 descs.Messages = [[ A list of notification messages to show HeadAdmins and above on join ]]
 
@@ -611,6 +612,7 @@ order = {
 	"SongHint";
 	"TopBarShift";
 	"ReJail";
+	"DisableRejoinAtMaxPlayers";
 	"";
 	"AutoClean";
 	"AutoCleanDelay";

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -432,7 +432,7 @@ return function(Vargs, env)
 			NoStudio = true; -- Commands which cannot be used in Roblox Studio (e.g. commands which use TeleportService)
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				assert(#(service.Players:GetPlayers()) < service.Players.MaxPlayers, "Cannot rejoin while server is at max capacity.")
+				assert(#(service.Players:GetPlayers()) < service.Players.MaxPlayers or not Settings.DisableRejoinAtMaxPlayers, "Cannot rejoin while server is at max capacity.")
 				service.TeleportService:TeleportAsync(game.PlaceId, {plr}, service.New("TeleportOptions", {
 					ServerInstanceId = game.JobId
 				}))

--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -432,6 +432,7 @@ return function(Vargs, env)
 			NoStudio = true; -- Commands which cannot be used in Roblox Studio (e.g. commands which use TeleportService)
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
+				assert(#(service.Players:GetPlayers()) < service.Players.MaxPlayers, "Cannot rejoin while server is at max capacity.")
 				service.TeleportService:TeleportAsync(game.PlaceId, {plr}, service.New("TeleportOptions", {
 					ServerInstanceId = game.JobId
 				}))

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -299,6 +299,7 @@ settings.AutoClean = false		-- Will auto clean workspace of things like hats and
 settings.AutoCleanDelay = 60	-- Time between auto cleans
 settings.AutoBackup = false 	-- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
 settings.ReJail = false			-- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
+settings.DisableRejoinAtMaxPlayers = false -- If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount.
 
 settings.Console = true				-- Whether the command console is enabled
 settings.Console_AdminsOnly = false -- If true, only admins will be able to access the console

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -470,6 +470,7 @@ descs.CodeExecution = [[ Enables the use of code execution in Adonis; Scripting 
 descs.SongHint = [[ Display a hint with the current song name and ID when a song is played via :music ]]
 descs.TopBarShift = [[ By default hints and notifs will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region. ]]
 descs.ReJail = [[ If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed ]]
+descs.DisableRejoinAtMaxPlayers = [[ If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount. ]]
 
 descs.Messages = [[ A list of notification messages to show HeadAdmins and above on join ]]
 
@@ -611,6 +612,7 @@ order = {
 	"SongHint";
 	"TopBarShift";
 	"ReJail";
+	"DisableRejoinAtMaxPlayers";
 	"";
 	"AutoClean";
 	"AutoCleanDelay";

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -289,16 +289,16 @@ settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is :slocked
 settings.SystemTitle = "System Message"		-- Title to display in :sm and :bc
 
-settings.MaxLogs = 5000			-- Maximum logs to save before deleting the oldest
-settings.SaveCommandLogs = true	-- If command logs are saved to the datastores
-settings.Notification = true	-- Whether or not to show the "You're an admin" and "Updated" notifications
-settings.SongHint = true		-- Display a hint with the current song name and ID when a song is played via :music
-settings.TopBarShift = false	-- By default hints and notifications will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region.
-settings.Messages = {}			-- A list of notification messages to show HeadAdmins and above on join
-settings.AutoClean = false		-- Will auto clean workspace of things like hats and tools
-settings.AutoCleanDelay = 60	-- Time between auto cleans
-settings.AutoBackup = false 	-- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
-settings.ReJail = false			-- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
+settings.MaxLogs = 5000			           -- Maximum logs to save before deleting the oldest
+settings.SaveCommandLogs = true	           -- If command logs are saved to the datastores
+settings.Notification = true	           -- Whether or not to show the "You're an admin" and "Updated" notifications
+settings.SongHint = true		           -- Display a hint with the current song name and ID when a song is played via :music
+settings.TopBarShift = false	           -- By default hints and notifications will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region.
+settings.Messages = {}			           -- A list of notification messages to show HeadAdmins and above on join
+settings.AutoClean = false		           -- Will auto clean workspace of things like hats and tools
+settings.AutoCleanDelay = 60	           -- Time between auto cleans
+settings.AutoBackup = false 	           -- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
+settings.ReJail = false			           -- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
 settings.DisableRejoinAtMaxPlayers = false -- If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount.
 
 settings.Console = true				-- Whether the command console is enabled


### PR DESCRIPTION
closes #1416 
This is to patch a bug inside roblox where players can have way too many players in it.
![image](https://github.com/Epix-Incorporated/Adonis/assets/69520693/3ea7fc49-de89-4395-b477-07695cbcfccb)
![image](https://github.com/Epix-Incorporated/Adonis/assets/69520693/7a7b2519-47ce-4c6a-84e5-d8fb69e508d3)
![image](https://github.com/Epix-Incorporated/Adonis/assets/69520693/42977a83-f92e-4508-a360-7ee13040ef0b)
This has become apparent to me from users abusing !rejoin to do such things, and instead of out right disabling !rejoin, this should be a good compromise.