### PR TITLE
Add Setting "ChatCreateRobloxCommands" to configure whether or not one wants Roblox Chat Commands to be generated

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -285,6 +285,7 @@ settings.CreatorPowers = true			-- Gives me creator-level admin; This is strictl
 settings.CodeExecution = true			-- Enables the use of code execution in Adonis; Scripting related (such as :s) and a few other commands require this
 settings.SilentCommandDenials = false	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
 settings.OverrideChatCallbacks = true	-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
+settings.ChatCreateRobloxCommands = true	-- Whether "/" commands for Roblox should get created in new Chat
 
 settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is :slocked
@@ -458,6 +459,7 @@ descs.CrossServerCommands = [[ Are commands which affect more than one server en
 descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands ]]
 descs.SilentCommandDenials = [[ If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command ]]
 descs.OverrideChatCallbacks = [[ If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for muting ]]
+descs.ChatCreateRobloxCommands = [[ Whether "/" commands for Roblox should get created in new Chat ]]
 
 
 descs.BanMessage = [[ Message shown to banned users ]]
@@ -605,6 +607,7 @@ order = {
 	"";
 	"SilentCommandDenials";
 	"OverrideChatCallbacks";
+	"ChatCreateRobloxCommands";
 	" ";
 	"BanMessage";
 	"LockMessage";

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -1273,61 +1273,63 @@ return function(Vargs, GetEnv)
 			Admin.PrefixCache = tempPrefix
 			Admin.CommandCache = tempTable
 
-			-- // Support for commands to be ran via TextChat
-			task.spawn(function()
-				local container = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.TextChatService:WaitForChild("TextChatCommands", 9e9)
+			if (Settings.ChatCreateRobloxCommands) then
+				-- // Support for commands to be ran via TextChat
+				task.spawn(function()
+					local container = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.TextChatService:WaitForChild("TextChatCommands", 9e9)
 
-				if container then
-					for _, v in container:GetChildren() do
-						if string.sub(v.Name, 1, 7) == "Adonis_" then
-							v:Destroy()
-						end
-					end
-
-					local blacklistedCommands = {}
-
-					for _, v in container:GetDescendants() do
-						if v:IsA("TextChatCommand") then
-							blacklistedCommands[v.PrimaryAlias] = true
-							blacklistedCommands[v.SecondaryAlias] = true
-						end
-					end
-
-					for name, data in Commands do
-						local command1, command2 = nil, nil
-
-						if type(data) ~= "table" or data.Hidden then
-							continue
-						end
-
-						for _, v in data.Commands do
-							if not blacklistedCommands["/"..data.Prefix..v] then
-								if not command1 then
-									command1 = "/"..data.Prefix..v
-								else
-									command2 = "/"..data.Prefix..v
-								end
+					if container then
+						for _, v in container:GetChildren() do
+							if string.sub(v.Name, 1, 7) == "Adonis_" then
+								v:Destroy()
 							end
 						end
 
-						if command1 then
-							local command = Instance.new("TextChatCommand")
+						local blacklistedCommands = {}
 
-							command.Name = "Adonis_"..name
-							command.PrimaryAlias = command1
-							command.SecondaryAlias = command2 or ""
-							command.Parent = container
-							command.Triggered:Connect(function(textSource, text)
-								local player = service.Players:GetPlayerByUserId(textSource.UserId)
+						for _, v in container:GetDescendants() do
+							if v:IsA("TextChatCommand") then
+								blacklistedCommands[v.PrimaryAlias] = true
+								blacklistedCommands[v.SecondaryAlias] = true
+							end
+						end
 
-								if player then
-									Process.Command(player, string.sub(text, 2))
+						for name, data in Commands do
+							local command1, command2 = nil, nil
+
+							if type(data) ~= "table" or data.Hidden then
+								continue
+							end
+
+							for _, v in data.Commands do
+								if not blacklistedCommands["/"..data.Prefix..v] then
+									if not command1 then
+										command1 = "/"..data.Prefix..v
+									else
+										command2 = "/"..data.Prefix..v
+									end
 								end
-							end)
+							end
+
+							if command1 then
+								local command = Instance.new("TextChatCommand")
+
+								command.Name = "Adonis_"..name
+								command.PrimaryAlias = command1
+								command.SecondaryAlias = command2 or ""
+								command.Parent = container
+								command.Triggered:Connect(function(textSource, text)
+									local player = service.Players:GetPlayerByUserId(textSource.UserId)
+
+									if player then
+										Process.Command(player, string.sub(text, 2))
+									end
+								end)
+							end
 						end
 					end
-				end
-			end)
+				end)
+			end
 		end;
 
 		GetCommand = function(Command)

--- a/MainModule/Server/Core/Admin.lua
+++ b/MainModule/Server/Core/Admin.lua
@@ -1273,7 +1273,7 @@ return function(Vargs, GetEnv)
 			Admin.PrefixCache = tempPrefix
 			Admin.CommandCache = tempTable
 
-			if (Settings.ChatCreateRobloxCommands) then
+			if Settings.ChatCreateRobloxCommands then
 				-- // Support for commands to be ran via TextChat
 				task.spawn(function()
 					local container = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.TextChatService:WaitForChild("TextChatCommands", 9e9)

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -285,6 +285,7 @@ settings.CreatorPowers = true			-- Gives me creator-level admin; This is strictl
 settings.CodeExecution = true			-- Enables the use of code execution in Adonis; Scripting related (such as :s) and a few other commands require this
 settings.SilentCommandDenials = false	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
 settings.OverrideChatCallbacks = true		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
+settings.ChatCreateRobloxCommands = true	-- Whether "/" commands for Roblox should get created in new Chat
 
 settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is :slocked
@@ -458,6 +459,7 @@ descs.CrossServerCommands = [[ Are commands which affect more than one server en
 descs.ChatCommands = [[ If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands ]]
 descs.SilentCommandDenials = [[ If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command ]]
 descs.OverrideChatCallbacks = [[ If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for muting ]]
+descs.ChatCreateRobloxCommands = [[ Whether "/" commands for Roblox should get created in new Chat ]]
 
 
 descs.BanMessage = [[ Message shown to banned users ]]
@@ -605,6 +607,7 @@ order = {
 	"";
 	"SilentCommandDenials";
 	"OverrideChatCallbacks";
+	"ChatCreateRobloxCommands";
 	" ";
 	"BanMessage";
 	"LockMessage";


### PR DESCRIPTION
In the current version, the new chat gets clogged up with these ``/`` commands. Ruining the experience from eventually adding _your own_ vanilla based Chat Commands while also using Adonis. Creating the need to modify Adonis.

![image](https://github.com/Epix-Incorporated/Adonis/assets/12023782/c8610bd0-428a-4944-b287-f46213eeab0b)


Therefore, I've added this setting ``ChatCreateRobloxCommands`` allowing people to now be able to configure whether this should happen or not. By default I've kept this on ``true``.