### PR TITLE
Update description of `:nil` command.

### DIFF
--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1424,7 +1424,7 @@ return function(Vargs, env)
 			Commands = {"nil"};
 			Args = {"player"};
 			Hidden = true;
-			Description = "Sends the target player(s) to nil, where they will not show up on the player list and not normally be able to interact with the game";
+			Description = "[DEPRECATED] Sends the target player(s) to nil, kicks them to unexpected client behavior.";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, args[1]) do

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -1424,7 +1424,7 @@ return function(Vargs, env)
 			Commands = {"nil"};
 			Args = {"player"};
 			Hidden = true;
-			Description = "[DEPRECATED] Sends the target player(s) to nil, kicks them to unexpected client behavior.";
+			Description = `Deletes the player forcefully, causing them to be kicked for "unexpected client behaviour"`;
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, args[1]) do


### PR DESCRIPTION
The behaviour of the `:nil` command has changed throughout the roblox updates and now it's sadly time to deprecate it as it no longer serves it's intended purpose.