### PR TITLE
Move the sword command into fun commands.

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -1071,6 +1071,28 @@ return function(Vargs, env)
 			end;
 		};
 
+		Sword = {
+			Prefix = Settings.Prefix;
+			Commands = {"sword", "givesword"};
+			Args = {"player", "allow teamkill (default: true)"};
+			Description = "Gives the target player(s) a sword";
+			AdminLevel = "Moderators";
+			Fun = true;
+			Function = function(plr: Player, args: {string})
+				local sword = service.Insert(125013769)
+				local config = sword:FindFirstChild("Configurations")
+				if config then
+					config.CanTeamkill.Value = if args[2] and args[2]:lower() == "false" then false else true
+				end
+				for _, v in service.GetPlayers(plr, args[1]) do
+					local Backpack = v:FindFirstChildOfClass("Backpack")
+					if Backpack then
+						sword:Clone().Parent = Backpack
+					end
+				end
+			end
+		};
+
 		iloveyou = {
 			Prefix = "?";
 			Commands = {"iloveyou", "alwaysnear", "alwayswatching"};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -2992,27 +2992,6 @@ return function(Vargs, env)
 			end
 		};
 
-		Sword = {
-			Prefix = Settings.Prefix;
-			Commands = {"sword", "givesword"};
-			Args = {"player", "allow teamkill (default: true)"};
-			Description = "Gives the target player(s) a sword";
-			AdminLevel = "Moderators";
-			Function = function(plr: Player, args: {string})
-				local sword = service.Insert(125013769)
-				local config = sword:FindFirstChild("Configurations")
-				if config then
-					config.CanTeamkill.Value = if args[2] and args[2]:lower() == "false" then false else true
-				end
-				for _, v in service.GetPlayers(plr, args[1]) do
-					local Backpack = v:FindFirstChildOfClass("Backpack")
-					if Backpack then
-						sword:Clone().Parent = Backpack
-					end
-				end
-			end
-		};
-
 		LoadAvatar = {
 			Prefix = Settings.Prefix;
 			Commands = {"loadavatar", "loadchar", "loadcharacter", "clone", "cloneplayer", "duplicate"};


### PR DESCRIPTION
This moves the `:sword` command into the category of fun commands as this really isn't used anymore by most games that use Adonis nowadays. You could just put it in serverstorage if you need to use it so badly or just keep fun commands enabled. I dont personally believe a setting is needed for this.