### PR TITLE
Keep the player layouts in the server after a restart

### DIFF
--- a/MainModule/Server/Plugins/Server-SoftShutdown.lua
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.lua
@@ -43,6 +43,7 @@ return function(Vargs, GetEnv)
 		--// This is a reserved server
 
 		local waitTime = 5
+		local playersToTeleport = {}
 		local function teleport(player)
 			local joindata = player:GetJoinData()
 			local data = type(joindata) == "table" and joindata.TeleportData
@@ -61,7 +62,7 @@ return function(Vargs, GetEnv)
 
 				Logs:AddLog("Script", `Teleporting {player.Name} back to the main game`)
 				teleportedPlayers[player] = 1
-				TeleportService:Teleport(game.PlaceId, player, {[PARAMETER_2_NAME] = true})
+				table.insert(playersToTeleport, player)
 			end
 		end
 
@@ -69,6 +70,7 @@ return function(Vargs, GetEnv)
 		for _, player in ipairs(service.GetPlayers()) do
 			teleport(player)
 		end
+		TeleportService:TeleportPartyAsync(game.PlaceId, playersToTeleport, {[PARAMETER_2_NAME] = true})
 	end
 
 	Remote.Terminal.Commands.SoftShutdown = {

--- a/MainModule/Server/Plugins/Server-SoftShutdown.lua
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.lua
@@ -45,7 +45,7 @@ return function(Vargs, GetEnv)
 		local waitTime = 5
 		local playersToTeleport = {}
 		local jobid
-		local startTask, TeleportTask = service.ThreadService.NewTask("Teleport Players", function()
+		local startTask, TeleportTask = service.Threads.NewTask("Teleport Players", function()
 			jobid = TeleportService:TeleportPartyAsync(game.PlaceId, playersToTeleport, {[PARAMETER_2_NAME] = true})
 		end)
 		local function teleport(player)


### PR DESCRIPTION
Replace `Teleport` with `TeleportPartyAsync` to keep the same players between servers and to not spread them, causing less havoc.