### PR TITLE
Revert "Fix text being editable in lists"

### DIFF
--- a/MainModule/Client/UI/Default/Window.rbxmx
+++ b/MainModule/Client/UI/Default/Window.rbxmx
@@ -1768,10 +1768,6 @@ return function(data, env)
 							TextEditable = false;
 							ClearTextOnFocus = false;
 						})
-
-						label:GetPropertyChangedSignal("Text"):Connect(function()
-							label.Text = ` {text}`
-						end)
 					else
 						label = create(onClick and "TextButton" or "TextLabel",{
 							Text = ` {text}`;


### PR DESCRIPTION
Reverts Epix-Incorporated/Adonis#1425

Dublicated by `TextEditable = false`