### PR TITLE
Fix :unfly command not working when SignalBehavior is set to Deferred

### DIFF
--- a/MainModule/Server/Dependencies/Assets/Fly.client.lua
+++ b/MainModule/Server/Dependencies/Assets/Fly.client.lua
@@ -238,7 +238,9 @@ function DPadifyInput(direction, isGame)
 	if yDir == 0 then HandleInput("Forward", isGame, false); HandleInput("Backward", isGame, false) end
 end
 
-listenConnection(part.DescendantRemoving, function(Inst)
+task.spawn(function()
+	local Inst = part.DescendantRemoving:Wait()
+
 	if Inst == bPos or Inst == bGyro or Inst == speedVal or Inst == noclip then
 		if conn then
 			conn:Disconnect()
@@ -247,7 +249,7 @@ listenConnection(part.DescendantRemoving, function(Inst)
 		for _, Signal in pairs(RBXConnections) do
 			Signal:Disconnect()
 		end
-		
+
 		contextService:UnbindAction("Toggle Flight")
 
 		Stop()


### PR DESCRIPTION
Resolves #1435 

When the `:unfly` command deletes the flying script and related values, the flying script relies on the `DescendantRemoving` event to detect when the script and related values are being destroyed by the command.

Because of how the Deferred SignalBehavior works, the `DescendantRemoving` event will be deferred and will not fire before the script is destroyed and all of it's connections disconnected, meaning the event is disconnected before it is fired. A solution, as the one I've committed to the script, is to use `RBXScriptSignal:Wait()` which will continue to fire immediately instead of being deferred.

The linked video below records three play tests, which in order demonstrate:
1. The current implementation of the code running with Deferred SignalBehavior, to provide evidence of the bug's existence.
2. The new implementation of the code running with Deferred SignalBehavior, to demonstrate that the fix works.
3. The new implementation of the code running with Immediate SignalBehavior, to demonstrate that this fix does not break Immediate SignalBehavior for games that may still be using it.

Video Demonstration:
https://streamable.com/o7ckds