### PR TITLE
Untrack fix for specific players

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -555,15 +555,15 @@ return function(Vargs, env)
 						local TextToUse = args[2]
 						if data.Options.Chat ~= true then
 							TextToUse = service.SanitizeXML(args[2] or "Hello world!")
-						end 
+						end
 						Remote.Send(
 							v, "Function", "DisplaySystemMessageInTextChat", nil, `<font color="rgb(255, 64, 77)">{
 							service.Filter(TextToUse, plr, v)
 							}</font>`)
-					else 
+					else
 						Remote.Send(v, "Function", "ChatMessage", service.Filter(args[2], plr, v), Color3.fromRGB(255, 64, 77))
 					end
-					
+
 				end
 			end
 		};
@@ -1713,7 +1713,7 @@ return function(Vargs, env)
 			Description = "Command Box";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				Remote.MakeGui(plr,"CommandBox")																																																																													
+				Remote.MakeGui(plr,"CommandBox")
 			end;
 		};
 
@@ -2401,7 +2401,7 @@ return function(Vargs, env)
 
 					if service.Lighting:FindFirstChildWhichIsA("Atmosphere") ~= nil then
 						local Atmosphere = service.Lighting:FindFirstChildWhichIsA("Atmosphere")
-						
+
 						Atmosphere.Name = Variables.OriginalAtmosphereSettings.Name
 						Atmosphere.Density = Variables.OriginalAtmosphereSettings.Density
 						Atmosphere.Offset = Variables.OriginalAtmosphereSettings.Offset
@@ -2539,7 +2539,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		Clip = {
 			Prefix = Settings.Prefix;
 			Commands = {"clip", "unnoclip"};
@@ -2552,7 +2552,7 @@ return function(Vargs, env)
 					if old then
 						if old.Clip.Value then
 							old.Clip.Value = false
-							
+
 							task.delay(.5,function() old:Destroy() end)
 
 							if Settings.CommandFeedback then
@@ -2808,7 +2808,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		BubbleChat = {
 			Prefix = Settings.Prefix;
 			Commands = {"bchat", "dchat", "bubblechat", "dialogchat"};
@@ -2838,7 +2838,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators",
 			Function = function(plr: Player, args: { string })
 				local plrChar = assert(plr.Character, "You don't have a character")
-				local plrHum = assert(plrChar:FindFirstChildOfClass("Humanoid", "You don't have a humanoid"))
+				local plrHum = assert(plrChar:FindFirstChildOfClass("Humanoid"), "You don't have a humanoid")
 
 				local persistent = args[2] and (args[2]:lower() == "true" or args[2]:lower() == "yes")
 				if persistent and type(Variables.TrackingTable[plr.Name]) ~= "table" then
@@ -2908,14 +2908,14 @@ return function(Vargs, env)
 							beam.Color3 = v.TeamColor.Color
 						end)
 						local plrCharRemovingConn = plr.CharacterRemoving:Once(function()
-							Remote.RemoveLocal(plr, `{v.Name}Tracker`)
+							Remote.RemoveLocal(plr, `{v.Name}_Tracker`)
 							teamChangeConn:Disconnect()
 							if charRemovingConn then
 								charRemovingConn:Disconnect()
 							end
 						end)
 						charRemovingConn = v.CharacterRemoving:Once(function()
-							Remote.RemoveLocal(plr, `{v.Name}Tracker`)
+							Remote.RemoveLocal(plr, `{v.Name}_Tracker`)
 							teamChangeConn:Disconnect()
 							plrCharRemovingConn:Disconnect()
 						end)
@@ -2937,7 +2937,7 @@ return function(Vargs, env)
 				else
 					local trackTargets = Variables.TrackingTable[plr.Name]
 					for _, v in service.GetPlayers(plr, args[1]) do
-						Remote.RemoveLocal(plr, `{v.Name}Tracker`)
+						Remote.RemoveLocal(plr, `{v.Name}_Tracker`)
 						if trackTargets then
 							trackTargets[v] = nil
 						end
@@ -4619,7 +4619,7 @@ return function(Vargs, env)
 			Description = "Teleport player1(s) to player2, a waypoint, or specific coords, use :tp player1 waypoint-WAYPOINTNAME to use waypoints, x,y,z for coords";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				
+
 				if args[2] and (string.match(args[2], "^waypoint%-(.*)") or string.match(args[2], "wp%-(.*)")) then
 					local m = string.match(args[2], "^waypoint%-(.*)") or string.match(args[2], "wp%-(.*)")
 					local point
@@ -4629,7 +4629,7 @@ return function(Vargs, env)
 							point=v
 						end
 					end
-					
+
 					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 						if point then
 							local Character = v.Character
@@ -4876,7 +4876,7 @@ return function(Vargs, env)
 					for i = (l-1) * math.floor(numPlayers/lines) + 1, l * math.floor(numPlayers/lines) do
 						local char = players[i].Character
 						if not char then continue end
-						
+
 						char:SetAttribute("ADONIS_isTeleporting", true)
 						task.delay(0.5, function() if char then char:SetAttribute("ADONIS_isTeleporting", nil) end end)
 
@@ -4907,7 +4907,7 @@ return function(Vargs, env)
 					for i = lines*math.floor(numPlayers/lines)+1, lines*math.floor(numPlayers/lines) + numPlayers%lines do
 						local char = players[i].Character
 						if not char then continue end
-						
+
 						char:SetAttribute("ADONIS_isTeleporting", true)
 						task.delay(0.5, function() if char then char:SetAttribute("ADONIS_isTeleporting", nil) end end)
 
@@ -4968,7 +4968,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		RemoveLeaderstat = {
 			Prefix = Settings.Prefix;
 			Commands = {"removestats", "delstat"};
@@ -5001,7 +5001,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		NewStat = {
 			Prefix = Settings.Prefix;
 			Commands = {"newstat", "createstat", "cstat"};
@@ -5015,19 +5015,19 @@ return function(Vargs, env)
 				end
 				local statType = if args[2] then args[2]:lower() else "number"
 				local FilteredStatName = service.BroadcastFilter(statName, plr)
-				
+
 				if FilteredStatName ~= statName then
 					error("Stat name is filtered! Sorry!")
 				end
-				
-				for _,p in service.GetPlayers() do 
+
+				for _,p in service.GetPlayers() do
 					local leaderstats = p:FindFirstChild("leaderstats") or service.New("Folder")
 					leaderstats.Name = "leaderstats"
-					if statName then 
-						if not leaderstats:FindFirstChild(FilteredStatName) then 
-							local newStat = service.New(if statType == "number" then "NumberValue" else "StringValue") 
+					if statName then
+						if not leaderstats:FindFirstChild(FilteredStatName) then
+							local newStat = service.New(if statType == "number" then "NumberValue" else "StringValue")
 							newStat.Name = FilteredStatName
-							if statType ~= "number" then 
+							if statType ~= "number" then
 								newStat.Value = "N/A"
 							end
 							newStat.Parent = leaderstats
@@ -5037,7 +5037,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		AddToStat = {
 			Prefix = Settings.Prefix;
 			Commands = {"add", "addtostat", "addstat"};
@@ -5137,7 +5137,7 @@ return function(Vargs, env)
 								else
 									bCreateNewDefaultClothing = true
 								end
-								
+
 								if bCreateNewDefaultClothing then
 									-- Set a new specified clothing.
 									local humDescClone = humanoidAppliedDesc:Clone()
@@ -5424,7 +5424,7 @@ return function(Vargs, env)
 				end
 			end,
 		},
-		
+
 		AvatarItem = {
 			Prefix = Settings.Prefix;
 			Commands = {"avataritem", "giveavtaritem", "catalogitem", "accessory", "hat", "tshirt", "givetshirt", "shirt", "giveshirt", "pants", "givepants", "face", "anim",
@@ -5457,7 +5457,7 @@ return function(Vargs, env)
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
-						
+
 						if not typeEnum then
 							if v.Character:GetAttribute("LoadingSavedOutfit") then continue end
 
@@ -5506,7 +5506,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		RemoveTShirt = {
 			Prefix = Settings.Prefix;
 			Commands = {"removetshirt", "untshirt", "notshirt"};
@@ -6254,7 +6254,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-		
+
 		GivePackage = {
 			Prefix = Settings.Prefix;
 			Commands = {"package", "givepackage", "setpackage", "bundle"};
@@ -6315,7 +6315,7 @@ return function(Vargs, env)
 				assert(args[1], "Missing player name")
 				local target = service.GetPlayers(plr, assert(args[2], "Missing username or UserId"), {
 					AllowUnknownUsers = true;
-				}) 
+				})
 				if target then
 					target = target[1]
 					local success, desc = pcall(service.Players.GetHumanoidDescriptionFromUserId, service.Players, target.UserId)
@@ -6476,11 +6476,11 @@ return function(Vargs, env)
 			ListUpdater = function(plr: Player)
 				local Count = if Logs.Errors.__meta == "DLL" then Logs.Errors.count else #Logs.Errors
 				local tab = table.create(Count)
-				for i, v in 
-					if Logs.Errors.__meta == "DLL" then 
-						Logs.Errors:GetAsTable() 
-					else 
-						Logs.Errors 
+				for i, v in
+					if Logs.Errors.__meta == "DLL" then
+						Logs.Errors:GetAsTable()
+					else
+						Logs.Errors
 				do
 					table.insert(tab, i, {
 						Time = v.Time;
@@ -6629,11 +6629,11 @@ return function(Vargs, env)
 			ListUpdater = function(plr: Player)
 				local Count = if Logs.Commands.__meta == "DLL" then Logs.Commands.count else #Logs.Commands
 				local tab = table.create(Count)
-				for i, v in 
-					if Logs.Commands.__meta == "DLL" then 
-						Logs.Commands:GetAsTable() 
-						else 
-						Logs.Commands 
+				for i, v in
+					if Logs.Commands.__meta == "DLL" then
+						Logs.Commands:GetAsTable()
+						else
+						Logs.Commands
 				do
 					table.insert(tab, i, {
 						Time = v.Time;

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -501,9 +501,9 @@ return function(Vargs, GetEnv)
 					if not opts.IgnoreErrors then
 						if type(cmdError) == "string" then
 							AddLog("Errors", `[{matched}] {cmdError}`)
-	
+
 							cmdError = cmdError:match("%d: (.+)$") or cmdError
-	
+
 							if not isSystem then
 								Remote.MakeGui(p, "Output", {
 									Message = cmdError,
@@ -644,7 +644,7 @@ return function(Vargs, GetEnv)
 						end
 					else
 						local msg = string.sub(msg, 1, Process.MsgStringLimit)
-						
+
 						if Settings.ChatCommands then
 							if Admin.DoHideChatCmd(p, msg) then
 								Remote.Send(p,"Function","ChatMessage",`> {msg}`,Color3.new(1, 1, 1))
@@ -748,8 +748,8 @@ return function(Vargs, GetEnv)
 						return "REMOVED"
 					end
 				end
-				
-				do 
+
+				do
 					local Removed = false
 					local success, err = pcall(function()
 						for filter,func in pairs(server.Variables.PlayerJoinFilters) do
@@ -767,8 +767,8 @@ return function(Vargs, GetEnv)
 						return "REMOVED"
 					end
 				end
-				
-				
+
+
 			end)
 
 			if not ran then
@@ -846,8 +846,8 @@ return function(Vargs, GetEnv)
 				Player = p;
 			})
 
-			for _,rateLimit in RateLimiter do 
-				if not rateLimit.Caches then 
+			for _,rateLimit in RateLimiter do
+				if not rateLimit.Caches then
 					continue
 				end
 				rateLimit.Caches[p.UserId] = nil
@@ -882,7 +882,7 @@ return function(Vargs, GetEnv)
 					trackTargets[p] = nil
 					local otherPlr = service.Players:FindFirstChild(otherPlrName)
 					if otherPlr then
-						task.defer(Remote.RemoveLocal, otherPlr, `{p.Name}Tracker`)
+						task.defer(Remote.RemoveLocal, otherPlr, `{p.Name}_Tracker`)
 					end
 				end
 			end
@@ -944,7 +944,7 @@ return function(Vargs, GetEnv)
 
 				if Settings.Detection and Settings.AllowClientAntiExploit then
 					Remote.Send(p, "LaunchAnti", "MainDetection")
-					
+
 					Remote.Send(p, "LaunchAnti", "AntiAntiIdle", {
 						Enabled = (Settings.AntiAntiIdle ~= false or Settings.AntiClientIdle ~= false)
 					})
@@ -984,7 +984,7 @@ return function(Vargs, GetEnv)
 					local newVer = (level > 300) and tonumber(string.match(server.Changelog[1], "Version: (.*)"))
 
 					if Settings.Notification then
-            
+
 						task.wait(1)
 						Functions.Notification("Welcome.", `Your rank is {rank} ({level}). Click here for commands.`, {p}, 15, "MatIcon://Verified user", Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.Prefix}cmds')`))
 
@@ -1011,7 +1011,7 @@ return function(Vargs, GetEnv)
 									window:Ready()
 							]]))
 						end
-						
+
 						if level >= 300 and #Settings.Messages > 0 then
 							for _, Message in Settings.Messages do
 								task.delay(1, Functions.Notification, "Message", tostring(Message), {p}, math.round((#Message/19)+2.5))
@@ -1055,7 +1055,7 @@ return function(Vargs, GetEnv)
 		CharacterAdded = function(p, char, ...)
 			local key = tostring(p.UserId)
 			local keyData = Remote.Clients[key]
-										
+
 			local args = {...}
 
 			if keyData then
@@ -1079,11 +1079,11 @@ return function(Vargs, GetEnv)
 						Message = Variables.NotifMessage
 					})
 				end
-											
-				if 
-					(not args[1] or 
+
+				if
+					(not args[1] or
 						(args[1] and typeof(args[1]) == 'table' and args[1].FinishedLoading == nil or args[1].FinishedLoading == true))
-					and 
+					and
 						(Settings.Console and (not Settings.Console_AdminsOnly or level > 0)) then
 					Remote.RefreshGui(p, "Console")
 				end
@@ -1133,8 +1133,8 @@ return function(Vargs, GetEnv)
 					and char:WaitForChild("HumanoidRootPart", 2)
 				then
 					for otherPlrName, trackTargets in Variables.TrackingTable do
-						if trackTargets[p] then
-							server.Commands.Track.Function(service.Players[otherPlrName], {`@{p.Name}`, "true"})
+						if trackTargets[p] and service.Players:FindFirstChild(otherPlrName) then
+							Admin.RunCommandAsPlayer(`{Settings.Prefix}track`, service.Players[otherPlrName], `@{p.Name}`, "true")
 						end
 					end
 				end


### PR DESCRIPTION
Resolves issue where missing `_` would prevent the "untrack" command from properly removing the tracking instance.

Also added small fix to a typo in the commands assert and some player checking for persistent tracking.