### PR TITLE
LoadExistingPlayer no longer warns while loading a player

### DIFF
--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -495,7 +495,10 @@ return function(Vargs, GetEnv)
 		end;
 
 		LoadExistingPlayer = function(p)
-			warn(`Loading existing player: {p}`)
+			AddLog(Logs.Script, {
+				Text = `Loading existing player: {p}`;
+				Desc = "Loading player that joined before Adonis loaded";
+			})
 
 			TrackTask(`Thread: Setup Existing Player: {p}`, function()
 				Process.PlayerAdded(p)


### PR DESCRIPTION
LoadExistingPlayer will no longer warn players in the Developer Console, and it has been replaced with AddLog.
Logs for `Loading existing player` can now be found in `:scriptlogs`

![image](https://github.com/Epix-Incorporated/Adonis/assets/73362346/479b9ba5-6452-4298-812a-26b4723788de)