### PR TITLE
Make getting the KEY from the server a RemoteFunction

### DIFF
--- a/MainModule/Client/Core/Core.lua
+++ b/MainModule/Client/Core/Core.lua
@@ -168,7 +168,12 @@ return function(Vargs, GetEnv)
 
 					if not Core.Key then
 						log("~! Getting key from server")
-						Remote.Fire(`{client.DepsName}GET_KEY`)
+						Core.Key = Remote.Get(`{client.DepsName}GET_KEY`)
+						if Core.Key then
+							client.Finish_Loading()
+						else
+							Remote.Fire(`{client.DepsName}GET_KEY`)
+						end
 					end
 				end
 			end

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -317,21 +317,41 @@ return function(Vargs, GetEnv)
 
 						if type(com) == "string" then
 							if com == `{keys.Special}GET_KEY` then
-								if keys.LoadingStatus == "WAITING_FOR_KEY" then
-									Remote.Fire(p, `{keys.Special}GIVE_KEY`, keys.Key)
-									keys.LoadingStatus = "LOADING"
-									keys.RemoteReady = true
+								if cliData.Mode == "Get" then
+									AddLog("RemoteFires", {
+										Text = `{p.Name} requested key from server`,
+										Desc = "Player requested key from server",
+										Player = p;
+									})
 
-									AddLog("Script", string.format("%s requested client keys", p.Name))
-									--else
-									--Anti.Detected(p, "kick","Communication Key Error (r10003)")
+									if keys.LoadingStatus == "WAITING_FOR_KEY" then
+										keys.LoadingStatus = "LOADING"
+										keys.RemoteReady = true
+										AddLog("Script", string.format("%s requested client keys", p.Name))
+
+										return keys.Key
+										--else
+										--Anti.Detected(p, "kick","Communication Key Error (r10003)")
+									end
+								elseif cliData.Mode == "Fire" then
+									if keys.LoadingStatus == "WAITING_FOR_KEY" then
+										Remote.Fire(p, `{keys.Special}GIVE_KEY`, keys.Key)
+										keys.LoadingStatus = "LOADING"
+										keys.RemoteReady = true
+
+										AddLog("Script", string.format("%s requested client keys", p.Name))
+										--else
+										--Anti.Detected(p, "kick","Communication Key Error (r10003)")
+									end
+
+									AddLog("RemoteFires", {
+										Text = `{p.Name} requested key from server`,
+										Desc = "Player requested key from server",
+										Player = p;
+									})
+								else
+									Anti.Detected(p, "kick","Communication Key Error (r10003)")
 								end
-
-								AddLog("RemoteFires", {
-									Text = `{p.Name} requested key from server`,
-									Desc = "Player requested key from server",
-									Player = p;
-								})
 							elseif rateLimitCheck and string.len(com) <= Remote.MaxLen then
 								local comString = Decrypt(com, keys.Key, keys.Cache)
 								local command = (cliData.Mode == "Get" and Remote.Returnables[comString]) or Remote.Commands[comString]


### PR DESCRIPTION
# Make getting the KEY from the server a RemoteFunction
Doing this will add a layer of security to the client.

This prevents key grabbing by a backdoor stalking RemoteEvents/RemoteFunction. (Fail safe is in to allow RemoteEvents to give key when RemoteFunction fails.)

PoF:
https://github.com/Epix-Incorporated/Adonis/assets/122803145/3ab92eaa-8e49-424a-96b1-e5800b3374e6