### PR TITLE
Make loadstring use proto conversion

### DIFF
--- a/MainModule/Client/Client.lua
+++ b/MainModule/Client/Client.lua
@@ -279,7 +279,7 @@ local LoadModule = function(module, yield, envVars, noEnv)
 	if isRaw then
 		plugran, plug = pcall(assert(assert(client.Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module"))
 	elseif isValue then
-		plugran, plug = pcall(client.Core.LoadCode or function(...) return require(client.Shared.FiOne)(...) end, client.Functions.Base64Decode(module.Value), GetEnv({}, envVars))
+		plugran, plug = pcall(client.Core.LoadCode or function(...) return require(client.Shared.FiOne, true)(...) end, client.Functions.Base64Decode(module.Value), GetEnv({}, envVars))
 	else
 		plugran, plug = pcall(require, module)
 	end

--- a/MainModule/Client/Core/Core.lua
+++ b/MainModule/Client/Core/Core.lua
@@ -188,7 +188,7 @@ return function(Vargs, GetEnv)
 		end;
 
 		LoadBytecode = function(str, env)
-			return require(client.Shared.FiOne)(str, env)
+			return require(client.Shared.FiOne, true)(str, env)
 		end;
 
 		LoadCode = function(str, env)
@@ -311,7 +311,7 @@ return function(Vargs, GetEnv)
 						if data and data.Source then
 							local module;
 							if not exists then
-								module = require(FiOne:Clone())
+								module = require(FiOne:Clone(), true)
 								table.insert(ScriptCache,{
 									Script = srcScript;
 									Source = data.Source;

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -917,7 +917,8 @@ return function(Vargs, env)
 			CrossServerDenied = true;
 			Function = function(plr: Player, args: {string})
 				assert(Settings.CodeExecution, "CodeExecution config must be enabled for this command to work")
-				assert(string.find(Core.Bytecode(assert(args[1], "Missing Script code (argument #2)")), "\27Lua"), `Script unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
+				local bytecode = Core.Bytecode(assert(args[1], "Missing Script code (argument #2)"))
+				assert(string.find(bytecode, "\27Lua"), `Script unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
 
 				local cl = Core.NewScript("Script", args[1], true)
 				cl.Name = "[Adonis] Script"
@@ -936,7 +937,8 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			NoFilter = true;
 			Function = function(plr: Player, args: {string})
-				assert(string.find(Core.Bytecode(assert(args[1], "Missing LocalScript code (argument #2)")), "\27Lua"), `LocalScript unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
+				local bytecode = Core.Bytecode(assert(args[1], "Missing Script code (argument #2)"))
+				assert(string.find(bytecode, "\27Lua"), `LocalScript unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
 
 				local cl = Core.NewScript("LocalScript", `script.Parent = game:GetService('Players').LocalPlayer.PlayerScripts; {args[1]}`, true)
 				cl.Name = "[Adonis] LocalScript"

--- a/MainModule/Server/Commands/Admins.lua
+++ b/MainModule/Server/Commands/Admins.lua
@@ -917,22 +917,7 @@ return function(Vargs, env)
 			CrossServerDenied = true;
 			Function = function(plr: Player, args: {string})
 				assert(Settings.CodeExecution, "CodeExecution config must be enabled for this command to work")
-				assert(args[1], "Missing Script code (argument #2)")
-
-				--[[Remote.RemoveGui(plr, "Prompt_MakeScript")
-				if
-					plr == false
-					or Remote.GetGui(plr, "YesNoPrompt", {
-						Name = "Prompt_MakeScript";
-						Size = {250, 200},
-						Title = "Script Confirmation";
-						Icon = server.MatIcons.Warning;
-						Question = "Are you sure you want to execute the code directly on the server? This action is irreversible and may potentially be dangerous; only run scripts that you trust!";
-						Delay = 2;
-					}) == "Yes"
-				then]]
-				local bytecode = Core.Bytecode(args[1])
-				assert(string.find(bytecode, "\27Lua"), `Script unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
+				assert(string.find(Core.Bytecode(assert(args[1], "Missing Script code (argument #2)")), "\27Lua"), `Script unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
 
 				local cl = Core.NewScript("Script", args[1], true)
 				cl.Name = "[Adonis] Script"
@@ -940,9 +925,6 @@ return function(Vargs, env)
 				task.wait()
 				cl.Disabled = false
 				Functions.Hint("Ran Script", {plr})
-				--[[else
-					Functions.Hint("Operation cancelled", {plr})
-				end]]
 			end
 		};
 
@@ -954,10 +936,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			NoFilter = true;
 			Function = function(plr: Player, args: {string})
-				assert(args[1], "Missing LocalScript code (argument #2)")
-
-				local bytecode = Core.Bytecode(args[1])
-				assert(string.find(bytecode, "\27Lua"), `LocalScript unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
+				assert(string.find(Core.Bytecode(assert(args[1], "Missing LocalScript code (argument #2)")), "\27Lua"), `LocalScript unable to be created: {string.gsub(bytecode, "Loadstring%.LuaX:%d+:", "")}`)
 
 				local cl = Core.NewScript("LocalScript", `script.Parent = game:GetService('Players').LocalPlayer.PlayerScripts; {args[1]}`, true)
 				cl.Name = "[Adonis] LocalScript"

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -621,7 +621,7 @@ return function(Vargs, GetEnv)
 			local wrapped = Core.RegisterScript({
 				Script = scr;
 				Code = execCode;
-				Source = source:IsA("Script") and source or Core.Bytecode(source);
+				Source = scr:IsA("Script") and source or Core.Bytecode(source);
 				noCache = noCache;
 				runLimit = runLimit;
 			})

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -1451,7 +1451,7 @@ return function(Vargs, GetEnv)
 						if data and data.Source then
 							local module;
 							if not exists then
-								module = require(srcScript:IsA("LocalScript") and server.Shared.FiOne:Clone() or Core.GetLoadstring(), true)
+								module = require(srcScript:IsA("LocalScript") and server.Shared.FiOne:Clone() or Core.GetLoadstring())
 								table.insert(Core.ScriptCache, {
 									Script = srcScript;
 									Source = data.Source;

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -621,7 +621,7 @@ return function(Vargs, GetEnv)
 			local wrapped = Core.RegisterScript({
 				Script = scr;
 				Code = execCode;
-				Source = src:IsA("Script") and source or Core.Bytecode(source);
+				Source = source:IsA("Script") and source or Core.Bytecode(source);
 				noCache = noCache;
 				runLimit = runLimit;
 			})

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -621,7 +621,7 @@ return function(Vargs, GetEnv)
 			local wrapped = Core.RegisterScript({
 				Script = scr;
 				Code = execCode;
-				Source = scr:IsA("Script") and source or Core.Bytecode(source);
+				Source = scr:IsA("LocalScript") and Core.Bytecode(source) or source;
 				noCache = noCache;
 				runLimit = runLimit;
 			})
@@ -1451,7 +1451,7 @@ return function(Vargs, GetEnv)
 						if data and data.Source then
 							local module;
 							if not exists then
-								module = require(srcScript:IsA("Script") and Core.GetLoadstring() or server.Shared.FiOne:Clone(), true)
+								module = require(srcScript:IsA("LocalScript") and server.Shared.FiOne:Clone() or Core.GetLoadstring(), true)
 								table.insert(Core.ScriptCache, {
 									Script = srcScript;
 									Source = data.Source;

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -593,7 +593,7 @@ return function(Vargs, GetEnv)
 
 		Bytecode = function(str: string)
 			if Core.BytecodeCache[str] then return Core.BytecodeCache[str] end
-			local f, buff = Core.Loadstring(str)
+			local f, buff = Core.Loadstring(str, "LuaC")
 			Core.BytecodeCache[str] = buff
 			return buff
 		end;

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -1451,7 +1451,7 @@ return function(Vargs, GetEnv)
 						if data and data.Source then
 							local module;
 							if not exists then
-								module = require(srcScript:IsA("Script") and Core.GetLoadstring() or server.Shared.FiOne:Clone())
+								module = require(srcScript:IsA("Script") and Core.GetLoadstring() or server.Shared.FiOne:Clone(), true)
 								table.insert(Core.ScriptCache, {
 									Script = srcScript;
 									Source = data.Source;

--- a/MainModule/Server/Core/Core.lua
+++ b/MainModule/Server/Core/Core.lua
@@ -621,7 +621,7 @@ return function(Vargs, GetEnv)
 			local wrapped = Core.RegisterScript({
 				Script = scr;
 				Code = execCode;
-				Source = Core.Bytecode(source);
+				Source = src:IsA("Script") and source or Core.Bytecode(source);
 				noCache = noCache;
 				runLimit = runLimit;
 			})
@@ -1451,7 +1451,7 @@ return function(Vargs, GetEnv)
 						if data and data.Source then
 							local module;
 							if not exists then
-								module = require(server.Shared.FiOne:Clone())
+								module = require(srcScript:IsA("Script") and Core.GetLoadstring() or server.Shared.FiOne:Clone())
 								table.insert(Core.ScriptCache, {
 									Script = srcScript;
 									Source = data.Source;

--- a/MainModule/Server/Dependencies/Loadstring/VirtualEnv.lua
+++ b/MainModule/Server/Dependencies/Loadstring/VirtualEnv.lua
@@ -1,4 +1,5 @@
 local vEnv = getfenv()
+vEnv.script = nil
 
 return function()
 	return vEnv

--- a/MainModule/Server/Dependencies/Loadstring/VirtualEnv.lua
+++ b/MainModule/Server/Dependencies/Loadstring/VirtualEnv.lua
@@ -1,0 +1,5 @@
+local vEnv = getfenv()
+
+return function()
+	return vEnv
+end

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -74,7 +74,7 @@ local function protoConvert(proto, opRemap, opType, opMode)
 		elseif regType == "ABx" then
 			v.is_K = mode.b == "OpArgK"
 		elseif regType == "AsBx" then
-			v.sBx, v.Bx = v.Bx - 131071, nil
+			v.sBx, v.Bx = v.Bx - 131071, nil -- Fix for signed registers being treated as unsigned 18 bit registers
 		end
 
 		if v.is_K then

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -106,7 +106,7 @@ return function(str, env)
 		local func = luaY:parser(LuaState, zio, nil, name or "::Adonis::Loadstring::")
 
 		if PROTO_CONVERT and env ~= "LuaC" then
-			protoConvert(func, fiOne.opcode_rm, fiOne.opcode_t, fiOne.opcode_m)
+			protoConvert(func, fiOne.OPCODE_RM, fiOne.OPCODE_T, fiOne.OPCODE_M)
 			f = fiOne.wrap_state(func, env or getvenv())
 		else
 			writer, buff = luaU:make_setS()

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -64,7 +64,7 @@ local function protoConvert(proto, opRemap, opType, opMode)
 			v.is_KC = mode.c == "OpArgK" and v.C > 0xFF
 
 			if op == 10 then -- decode NEWTABLE array size, store it as constant value
-				local e = bit32.band(bit32.rshift(data.B, 3), 31)
+				local e = bit32.band(bit32.rshift(v.B, 3), 31)
 				if e == 0 then
 					v.const = v.B
 				else
@@ -116,7 +116,7 @@ return function(str, env)
 	end)
 	
 	if ran then
-		return f, buff.data
+		return f, buff and buff.data
 	else
 		return nil, error
 	end

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -48,7 +48,7 @@ local function protoConvert(proto, opRemap, opType, opMode)
 	proto.max_stack, proto.maxstacksize = proto.maxstacksize, nil
 	proto.num_param, proto.numparams = proto.numparams, nil
 	proto.num_upval, proto.sizeupvalues = proto.sizeupvalues, nil
-	proto.sizecode, proto.sizek, proto.sizelineinfo, proto.sizelocvars, proto.sizep = nil, nil, nil, nil, nil -- Clean up garbage values
+	proto.sizecode, proto.sizek, proto.sizelineinfo, proto.sizelocvars, proto.sizep, proto.nups = nil, nil, nil, nil, nil, nil -- Clean up garbage values
 
 	for i, v in to1BasedIndex(proto.k) do
 		const[i] = v.value

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -109,12 +109,12 @@ return function(str, env)
 		else
 			writer, buff = luaU:make_setS()
 			luaU:dump(LuaState, func, writer, buff)
-			f = fiOne.bc_to_state(fiOne.wrap_state(buff.data, env))
+			f = fiOne.wrap_state(fiOne.bc_to_state(buff.data), env)
 		end
 	end, function(err)
 		return `{err}\n\n--- Loadstring Stacktrace Begin --- \n{debug.traceback("",2)}\n--- Loadstring Stacktrace End --- \n`
 	end)
-	
+
 	if ran then
 		return f, buff and buff.data
 	else

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -73,6 +73,8 @@ local function protoConvert(proto, opRemap, opType, opMode)
 			end
 		elseif regType == "ABx" then
 			v.is_K = mode.b == "OpArgK"
+		elseif regType == "AsBx" then
+			v.sBx, v.Bx = v.Bx - 131071, nil
 		end
 
 		if v.is_K then

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -44,7 +44,7 @@ end
 local function protoConvert(proto, opRemap, opType, opMode)
 	local const = table.create(#proto.k + 1)
 	proto.code, proto.lines, proto.subs = to1BasedIndex(proto.code), to1BasedIndex(proto.lineinfo), to1BasedIndex(proto.p)
-	proto.linfeinfo, proto.p = nil, nil
+	proto.lineinfo, proto.p = nil, nil
 	proto.max_stack, proto.maxstacksize = proto.maxstacksize, nil
 	proto.num_param, proto.numparams = proto.numparams, nil
 	proto.num_upval, proto.sizeupvalues = proto.sizeupvalues, nil

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -1,7 +1,8 @@
 --[[
 	Credit to einsteinK.
 	Credit to Stravant for LBI.
-	
+	Credit to ccuser44 for proto conversion.
+
 	Credit to the creators of all the other modules used in this.
 	
 	Sceleratis was here and decided modify some things.
@@ -9,17 +10,18 @@
 	einsteinK was here again to fix a bug in LBI for if-statements
 --]]
 
-local waitDeps = {
-	'FiOne';
-	'LuaK';
-	'LuaP';
-	'LuaU';
-	'LuaX';
-	'LuaY';
-	'LuaZ';
+local PROTO_CONVERT = true -- If proto conversion is used instead of serialise->deserialise
+local DEPENDANCIES = {
+	"FiOne";
+	"LuaK";
+	"LuaP";
+	"LuaU";
+	"LuaX";
+	"LuaY";
+	"LuaZ";
 }
 
-for _, v in ipairs(waitDeps) do 
+for _, v in ipairs(DEPENDANCIES) do 
 	script:WaitForChild(v)
 end
 
@@ -27,14 +29,72 @@ local luaX = require(script.LuaX)
 local luaY = require(script.LuaY)
 local luaZ = require(script.LuaZ)
 local luaU = require(script.LuaU)
-local fiOne = require(script.FiOne)
+local loadBytecode, fiOne = require(script.FiOne)
+
+local function to1BasedIndex(tbl)
+	local tbl = table.move(tbl, 0, #tbl + (tbl[0] and 1), 1)
+	tbl[0] = nil
+
+	return tbl
+end
+
+local function protoConvert(proto, opRemap, opType, opMode)
+	local const = table.create(#proto.k + 1)
+	proto.code, proto.lines, proto.subs = to1BasedIndex(proto.code), to1BasedIndex(proto.lineinfo), to1BasedIndex(proto.p)
+	proto.linfeinfo, proto.p = nil, nil
+	proto.max_stack, proto.maxstacksize = proto.maxstacksize, nil
+	proto.num_param, proto.numparams = proto.numparams, nil
+	proto.num_upval, proto.sizeupvalues = proto.sizeupvalues, nil
+	proto.sizecode, proto.sizek, proto.sizelineinfo, proto.sizelocvars, proto.sizep = nil, nil, nil, nil, nil -- Clean up garbage values
+
+	for i, v in to1BasedIndex(proto.k) do
+		const[i] = v.value
+	end
+
+	proto.const, proto.k = const, nil
+
+	for i, v in proto.code do
+		local op = v.OP
+		v.op, v.OP = opRemap[op], nil
+		local regType = opType[op]
+		local mode = opMode[op]
+
+		if regType == "ABC" then
+			v.is_KB = mode.b == "OpArgK" and v.B > 0xFF -- post process optimization
+			v.is_KC = mode.c == "OpArgK" and v.C > 0xFF
+
+			if op == 10 then -- decode NEWTABLE array size, store it as constant value
+				local e = bit32.band(bit32.rshift(data.B, 3), 31)
+				if e == 0 then
+					v.const = v.B
+				else
+					v.const = bit32.lshift(bit32.band(v.B, 7) + 8, e - 1)
+				end
+			end
+		elseif regType == "ABx" then
+			v.is_K = mode.b == "OpArgK"
+		end
+
+		if v.is_K then
+			v.const = proto.const[v.Bx + 1] -- offset for 1 based index
+		else
+			if v.is_KB then v.const_B = proto.const[v.B - 0xFF] end
+
+			if v.is_KC then v.const_C = proto.const[v.C - 0xFF] end
+		end
+	end
+
+	for _, v in proto.subs do
+		protoConvert(v, opRemap, opType, opMode)
+	end
+end
 
 luaX:init()
 local LuaState = {}
 
 getfenv().script = nil
 
-return function(str,env)
+return function(str, env)
 	local f, writer, buff
 	env = env or getfenv(2)
 	local name = (type(env.script) == "userdata" and env.script:GetFullName())
@@ -42,9 +102,15 @@ return function(str,env)
 		local zio = luaZ:init(luaZ:make_getS(str), nil)
 		if not zio then return error() end
 		local func = luaY:parser(LuaState, zio, nil, name or "::Adonis::Loadstring::")
-		writer, buff = luaU:make_setS()
-		luaU:dump(LuaState, func, writer, buff)
-		f = fiOne(buff.data, env)
+
+		if PROTO_CONVERT then
+			protoConvert(func, fiOne.opcode_rm, fiOne.opcode_t, fiOne.opcode_m)
+			f = loadBytecode(func, env)
+		else
+			writer, buff = luaU:make_setS()
+			luaU:dump(LuaState, func, writer, buff)
+			f = loadBytecode(buff.data, env)
+		end
 	end, function(err)
 		return `{err}\n\n--- Loadstring Stacktrace Begin --- \n{debug.traceback("",2)}\n--- Loadstring Stacktrace End --- \n`
 	end)

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -11,7 +11,7 @@
 --]]
 
 local PROTO_CONVERT = true -- If proto conversion is used instead of serialise->deserialise
-local DEPENDANCIES = {
+local DEPENDENCIES = {
 	"FiOne";
 	"LuaK";
 	"LuaP";
@@ -21,7 +21,7 @@ local DEPENDANCIES = {
 	"LuaZ";
 }
 
-for _, v in ipairs(DEPENDANCIES) do 
+for _, v in ipairs(DEPENDENCIES) do 
 	script:WaitForChild(v)
 end
 

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -101,8 +101,7 @@ return function(str, env)
 	local f, writer, buff
 	local name = (env and type(env.script) == "userdata") and env.script:GetFullName()
 	local ran, error = xpcall(function()
-		local zio = luaZ:init(luaZ:make_getS(str), nil)
-		if not zio then return error() end
+		local zio = assert(luaZ:init(luaZ:make_getS(str), nil), "Failed to get buffered stream")
 		local func = luaY:parser(LuaState, zio, nil, name or "::Adonis::Loadstring::")
 
 		if PROTO_CONVERT and env ~= "LuaC" then

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -1,3 +1,4 @@
+--# selene: allow(incorrect_standard_library_use)
 --[[
 	Credit to einsteinK.
 	Credit to Stravant for LBI.

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -32,7 +32,7 @@ local luaU = require(script.LuaU)
 local loadBytecode, fiOne = require(script.FiOne)
 
 local function to1BasedIndex(tbl)
-	local tbl = table.move(tbl, 0, #tbl + (tbl[0] and 1), 1)
+	local tbl = table.move(tbl, 0, #tbl + (tbl[0] and 1 or 0), 1)
 	tbl[0] = nil
 
 	return tbl

--- a/MainModule/Server/Dependencies/Loadstring/init.lua
+++ b/MainModule/Server/Dependencies/Loadstring/init.lua
@@ -29,7 +29,7 @@ local luaX = require(script.LuaX)
 local luaY = require(script.LuaY)
 local luaZ = require(script.LuaZ)
 local luaU = require(script.LuaU)
-local loadBytecode, fiOne = require(script.FiOne)
+local fiOne = require(script.FiOne)
 
 local function to1BasedIndex(tbl)
 	local tbl = table.move(tbl, 0, #tbl + (tbl[0] and 1 or 0), 1)
@@ -105,11 +105,11 @@ return function(str, env)
 
 		if PROTO_CONVERT then
 			protoConvert(func, fiOne.opcode_rm, fiOne.opcode_t, fiOne.opcode_m)
-			f = loadBytecode(func, env)
+			f = fiOne.wrap_state(func, env)
 		else
 			writer, buff = luaU:make_setS()
 			luaU:dump(LuaState, func, writer, buff)
-			f = loadBytecode(buff.data, env)
+			f = fiOne.bc_to_state(fiOne.wrap_state(buff.data, env))
 		end
 	end, function(err)
 		return `{err}\n\n--- Loadstring Stacktrace Begin --- \n{debug.traceback("",2)}\n--- Loadstring Stacktrace End --- \n`

--- a/MainModule/Server/Dependencies/LocalScriptBase.client.lua
+++ b/MainModule/Server/Dependencies/LocalScriptBase.client.lua
@@ -1,8 +1,8 @@
 task.wait()
 local execute = script:FindFirstChild("Execute")
-local code, runCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
+local code, loadCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
 local env = getfenv()
 
 if code then
-	runCode(code, env)()
+	loadCode(code, env)()
 end

--- a/MainModule/Server/Dependencies/LocalScriptBase.client.lua
+++ b/MainModule/Server/Dependencies/LocalScriptBase.client.lua
@@ -1,10 +1,8 @@
 task.wait()
 local execute = script:FindFirstChild("Execute")
-local code, lbi = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
+local code, runCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
+local env = getfenv()
 
 if code then
-	local func = lbi(code, getfenv())
-	if func then
-		func()
-	end
+	runCode(code, env)()
 end

--- a/MainModule/Server/Dependencies/ScriptBase.server.lua
+++ b/MainModule/Server/Dependencies/ScriptBase.server.lua
@@ -4,5 +4,5 @@ local code, loadCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, ex
 local canUseLoadstring = loadstring and pcall(loadstring, "local a = 5 local b = a + 5") or false
 
 if code then
-	(canUseLoadstring and loadstring(code) or loadCode(code, --[[getfenv()]]))()
+	(canUseLoadstring and loadstring(code) or loadCode(code--[[, getfenv()]]))()
 end

--- a/MainModule/Server/Dependencies/ScriptBase.server.lua
+++ b/MainModule/Server/Dependencies/ScriptBase.server.lua
@@ -1,12 +1,8 @@
 task.wait()
 local execute = script:FindFirstChild("Execute")
-local code, lbi = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
-
+local code, runCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
 local canUseLoadstring = loadstring and pcall(loadstring, "local a = 5 local b = a + 5") or false
 
 if code then
-	local func = canUseLoadstring and loadstring(code) or lbi(code, getfenv())
-	if func then
-		func()
-	end
+	(canUseLoadstring and loadstring(code) or runCode(code, --[[getfenv()]]))()
 end

--- a/MainModule/Server/Dependencies/ScriptBase.server.lua
+++ b/MainModule/Server/Dependencies/ScriptBase.server.lua
@@ -1,8 +1,8 @@
 task.wait()
 local execute = script:FindFirstChild("Execute")
-local code, runCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
+local code, loadCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
 local canUseLoadstring = loadstring and pcall(loadstring, "local a = 5 local b = a + 5") or false
 
 if code then
-	(canUseLoadstring and loadstring(code) or runCode(code, --[[getfenv()]]))()
+	(canUseLoadstring and loadstring(code) or loadCode(code, --[[getfenv()]]))()
 end

--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -198,7 +198,7 @@ local function LoadModule(module, yield, envVars, noEnv, isCore)
 	local isRaw = type(module) == "string"
 	local isValue = not isFunc and not isRaw and module:IsA("StringValue")
 	local module = (isFunc and service.New("ModuleScript", {Name = "Non-Module Loaded"})) or module
-	local plug = (isFunc and module) or isValue and (server.Core.LoadCode or function(...) return require(server.Shared.FiOne)(...) end)(server.Functions.Base64Decode(module.Value), GetEnv({}, envVars)) or isRaw and assert(assert(server.Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
+	local plug = (isFunc and module) or isValue and (server.Core.LoadCode or function(...) return require(server.Shared.FiOne, true)(...) end)(server.Functions.Base64Decode(module.Value), GetEnv({}, envVars)) or isRaw and assert(assert(server.Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
 
 	if server.Modules and not isFunc and not isRaw then
 		table.insert(server.Modules,module)

--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -198,7 +198,7 @@ local function LoadModule(module, yield, envVars, noEnv, isCore)
 	local isRaw = type(module) == "string"
 	local isValue = not isFunc and not isRaw and module:IsA("StringValue")
 	local module = (isFunc and service.New("ModuleScript", {Name = "Non-Module Loaded"})) or module
-	local plug = (isFunc and module) or isValue and (server.Core.LoadCode or function(...) return require(server.Shared.FiOne, true)(...) end)(server.Functions.Base64Decode(module.Value), GetEnv({}, envVars)) or isRaw and assert(assert(server.Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
+	local plug = (isFunc and module) or isValue and (server.Core.LoadCode or function(...) return require(server.Shared.FiOne)(...) end)(server.Functions.Base64Decode(module.Value), GetEnv({}, envVars)) or isRaw and assert(assert(server.Core.Loadstring, "Cannot compile plugin due to Core.Loadstring missing")(module, GetEnv({}, envVars)), "Failed to compile module")() or require(module)
 
 	if server.Modules and not isFunc and not isRaw then
 		table.insert(server.Modules,module)

--- a/MainModule/Server/Shared/FiOne.lua
+++ b/MainModule/Server/Shared/FiOne.lua
@@ -1087,12 +1087,13 @@ function wrap_lua_func(state, env, upvals)
 	return exec_wrap
 end
 
-return function(BCode, Env)
-	return wrap_lua_func(stm_lua_bytecode(BCode), Env or {})
-end, {
-	bc_to_state = stm_lua_bytecode,--lua_bc_to_state,
-	wrap_state = wrap_lua_func,--lua_wrap_state,
+return setmetatable({
+	bc_to_state = lua_bc_to_state,
+	wrap_state = lua_wrap_state,
 	opcode_rm = OPCODE_RM,
 	opcode_t = OPCODE_T,
 	opcode_m = OPCODE_M,
-}
+}, {__call = function(BCode, Env)
+	return lua_wrap_state(lua_bc_to_state(BCode), Env or {})
+end})
+

--- a/MainModule/Server/Shared/FiOne.lua
+++ b/MainModule/Server/Shared/FiOne.lua
@@ -1089,4 +1089,10 @@ end
 
 return function(BCode, Env)
 	return wrap_lua_func(stm_lua_bytecode(BCode), Env or {})
-end
+end, {
+	bc_to_state = stm_lua_bytecode,--lua_bc_to_state,
+	wrap_state = wrap_lua_func,--lua_wrap_state,
+	opcode_rm = OPCODE_RM,
+	opcode_t = OPCODE_T,
+	opcode_m = OPCODE_M,
+}

--- a/MainModule/Server/Shared/FiOne.lua
+++ b/MainModule/Server/Shared/FiOne.lua
@@ -1091,6 +1091,6 @@ return setmetatable({
 	OPCODE_RM = OPCODE_RM,
 	OPCODE_T = OPCODE_T,
 	OPCODE_M = OPCODE_M,
-}, {__call = function(BCode, Env) -- Backwards compatibility for legacy rerubi usage
+}, {__call = function(_, BCode, Env) -- Backwards compatibility for legacy rerubi usage
 	return lua_wrap_state(lua_bc_to_state(BCode), Env or {})
 end})

--- a/MainModule/Server/Shared/FiOne.lua
+++ b/MainModule/Server/Shared/FiOne.lua
@@ -1088,9 +1088,9 @@ end
 return setmetatable({
 	bc_to_state = lua_bc_to_state,
 	wrap_state = lua_wrap_state,
-	opcode_rm = OPCODE_RM,
-	opcode_t = OPCODE_T,
-	opcode_m = OPCODE_M,
+	OPCODE_RM = OPCODE_RM,
+	OPCODE_T = OPCODE_T,
+	OPCODE_M = OPCODE_M,
 }, {__call = function(BCode, Env) -- Backwards compatibility for legacy rerubi usage
 	return lua_wrap_state(lua_bc_to_state(BCode), Env or {})
 end})

--- a/MainModule/Server/Shared/FiOne.lua
+++ b/MainModule/Server/Shared/FiOne.lua
@@ -1093,7 +1093,7 @@ return setmetatable({
 	opcode_rm = OPCODE_RM,
 	opcode_t = OPCODE_T,
 	opcode_m = OPCODE_M,
-}, {__call = function(BCode, Env)
+}, {__call = function(BCode, Env) -- Backwards compatibility for legacy rerubi usage
 	return lua_wrap_state(lua_bc_to_state(BCode), Env or {})
 end})
 


### PR DESCRIPTION
Make loadstring use proto conversion instead of serialising to bytecode & deserialising.
Improves performance of compilation by avoiding the bytecode step all together and using the protos directly

Idea from how Roblox exploits used to proto convert