### PR TITLE
Add Unix-like pipe IO support

### DIFF
--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -415,8 +415,8 @@ return function(Vargs, GetEnv)
 			if string.match(msg, Settings.BatchKey) then
 				local overrideArgs = {}
 
-				for cmd, argPass in string.gmatch(msg, `([^{Settings.BatchKey}]+)({Settings.BatchKey}?[%d,>]*)`) do
-					cmd, overrideMap = Functions.Trim(cmd), Process.GetOverrideMap(argPass)
+				for cmd, overrideMap in string.gmatch(msg, `([^{Settings.BatchKey}]+)({Settings.BatchKey}?[%d,>]*)`) do
+					cmd, overrideMap = Functions.Trim(cmd), Process.GetOverrideMap(overrideMap)
 
 					local waiter = `{Settings.PlayerPrefix}wait`
 					if string.sub(string.lower(cmd), 1, #waiter) == waiter then

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -384,6 +384,25 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
+		GetOverrideMap = function(str)
+			local inputs, outputs = string.match(str, `{Settings.BatchKey}([%d,]+)>([%d,]+)`)
+			local tbl1, tbl2 = {}, {}
+			local i = 0
+
+			for num in string.gmatch(inputs, "(%d+),?") do
+				table.insert(tbl1, tonumber(num) or 1)
+			end
+
+			for num in string.gmatch(outputs, "(%d+),?") do
+				i += 1
+				if tbl1[i] then
+					tbl2[tbl1[i]] = tonumber(num) or 1
+				end
+			end
+
+			return tbl2
+		end;
+
 		Command = function(p, msg, opts, noYield)
 			opts = opts or {}
 

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -672,6 +672,7 @@ return function(Vargs, GetEnv)
 					Anti.Detected(p, "Kick", "Chatted message over the maximum character limit")
 				elseif not isMuted then
 					if not Admin.CheckSlowMode(p) then
+						msg = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.UnsanitiseXML(msg) or msg -- Hack to fix TextChatService invalidly XML escaping messages
 						local msg = string.sub(msg, 1, Process.MsgStringLimit)
 						local filtered = service.LaxFilter(msg, p)
 

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -672,7 +672,7 @@ return function(Vargs, GetEnv)
 					Anti.Detected(p, "Kick", "Chatted message over the maximum character limit")
 				elseif not isMuted then
 					if not Admin.CheckSlowMode(p) then
-						msg = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.UnsanitiseXML(msg) or msg -- Hack to fix TextChatService invalidly XML escaping messages
+						msg = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.UnsanitizeXML(msg) or msg -- Hack to fix TextChatService invalidly XML escaping messages
 						local msg = string.sub(msg, 1, Process.MsgStringLimit)
 						local filtered = service.LaxFilter(msg, p)
 

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -389,11 +389,11 @@ return function(Vargs, GetEnv)
 			local tbl1, tbl2 = {}, {}
 			local i = 0
 
-			for num in string.gmatch(inputs, "(%d+),?") do
+			for num in string.gmatch(inputs or "", "(%d+),?") do
 				table.insert(tbl1, tonumber(num) or 1)
 			end
 
-			for num in string.gmatch(outputs, "(%d+),?") do
+			for num in string.gmatch(outputs or "", "(%d+),?") do
 				i += 1
 				if tbl1[i] then
 					tbl2[tbl1[i]] = tonumber(num) or 1

--- a/MainModule/Server/Core/Process.lua
+++ b/MainModule/Server/Core/Process.lua
@@ -431,7 +431,7 @@ return function(Vargs, GetEnv)
 							task.wait(tonumber(num))
 						end
 					else
-						local returnArgs = Process.Command(p, cmd, opts, false)
+						local returnArgs = table.pack(Process.Command(p, cmd, opts, false))
 						table.clear(overrideArgs)
 
 						for i, i2 in overrideMap do

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -947,7 +947,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		end;
 
 		UnsanitizeXML = function(str)
-			return string.gsub(str, "&;", {
+			return string.gsub(str, "&%w+;", {
 				["&apos;"] = "'",
 				["&quot;"] = "\"",
 				["&lt;"] = "<",

--- a/MainModule/Server/Shared/Service.lua
+++ b/MainModule/Server/Shared/Service.lua
@@ -946,6 +946,16 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 			})
 		end;
 
+		UnsanitizeXML = function(str)
+			return string.gsub(str, "&;", {
+				["&apos;"] = "'",
+				["&quot;"] = "\"",
+				["&lt;"] = "<",
+				["&gt;"] = ">",
+				["&amp;"] = "&"
+			})
+		end;
+
 		SanitizeXML = function(str)
 			return string.gsub(str, "['\"<>&]", {
 				["'"] = "&apos;",


### PR DESCRIPTION
Fixes #1433
Adds rudimentary IO pipe support (may not work with aliases well)

Example usage `!pnum |1>1 :format "The game has %s players" |1>2 :concat "Server Message:" |1>1 :message`