### PR TITLE
Added missing CanvasGroup class within GetGuiData() func

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -561,6 +561,7 @@ return function(Vargs, GetEnv)
 				"ScreenGui";
 				"GuiMain";
 				"Frame";
+				"CanvasGroup";
 				"TextButton";
 				"TextLabel";
 				"ImageButton";


### PR DESCRIPTION
Currently the :viewguis / :showguis command would ignore any canvasgroup frame. 

Now that canvas group is becoming more popular, I feel it is necessary to implement this as a class to look for when copying UI Data.

# Current behaviour:
https://github.com/Epix-Incorporated/Adonis/assets/44067130/e99cc39d-78c6-4617-bdc8-84619c484fe0

# Updated behaviour:
https://github.com/Epix-Incorporated/Adonis/assets/44067130/bf902413-7d37-463c-ac03-186951eee6c2

