### PR TITLE
Added Luau global import optimisation

### DIFF
--- a/MainModule/Server/Dependencies/Loadstring/LuaX.lua
+++ b/MainModule/Server/Dependencies/Loadstring/LuaX.lua
@@ -34,7 +34,7 @@
 --   * Added env localisation aiding for parser
 --   * Made lexer pre-lex lex tree instead of using on-the-fly lexing.
 --     Necessary for env localisation and more efficient than building
-       a parse tree (which would require full pre-lexing as well)
+--     a parse tree (which would require full pre-lexing as well)
 --
 -- To use the lexer:
 -- (1) luaX:init() to initialize the lexer


### PR DESCRIPTION
Make compiler localize Luau globals if env is safe
For this to happen the parser has to know what globals are used and if env is safe so a pre-made lex tree must be used. 

NOTE: Unfortunately uses a quick hack to add lex tokens in the lexer instead of having a parser function only add a local set expression containing the globals to the main chunk.