### PR TITLE
Remove hyperion debug info and remove tbl alias added in nightly

### DIFF
--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -81,7 +81,7 @@ return function(Vargs, GetEnv)
 
 	local Detected = function(action, info, nocrash)
 		if NetworkClient and action ~= "_" then
-			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", action, tostring(info)..(hyperionEnabled and " - Hyperion is enabled" or isXbox and " - On Xbox" or isMobile and " - On mobile" or ""))
+			pcall(Send, "D".."e".."t".."e".."c".."t".."e".."d", action, tostring(info)..(isXbox and " - On Xbox" or isMobile and " - On mobile" or ""))
 			task.wait(0.5)
 			if action == "k".."i".."c".."k" then
 				if not isStudio then

--- a/MainModule/Client/Core/Anti.lua
+++ b/MainModule/Client/Core/Anti.lua
@@ -50,7 +50,6 @@ return function(Vargs, GetEnv)
 	local Kick = Player.Kick
 	local isXbox = service.GuiService:IsTenFootInterface()
 	local isMobile = service.UserInputService.TouchEnabled and not service.UserInputService.KeyboardEnabled and not service.UserInputService.MouseEnabled
-	local hyperionEnabled = not isXbox and not isMobile and (#tostring(tonumber(string.sub(tostring{}, 8))) > 10)
 
 	local function Init()
 		UI = client.UI;

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -1196,7 +1196,7 @@ return function(Vargs, env)
 
 		ShowTrelloBansList = {
 			Prefix = Settings.Prefix;
-			Commands = {"trellobans", "trellobanlist", "tbl", "syncedtrellobans", "showtrellobans"};
+			Commands = {"trellobans", "trellobanlist", "syncedtrellobans", "showtrellobans"};
 			Args = {};
 			Description = "Shows bans synced from Trello.";
 			TrelloRequired = true;


### PR DESCRIPTION
- Remove hyperion debug info because hyperion is always used on PC
- Remove tbl alias added in the current nightly (it's not released so people don't even know it exists). tbl really doesnt make sense for an alias for trello bans as it could mean a lot of other things like table which is a more often used acronym for it