### PR TITLE
Addition of HiddenThemes setting

### DIFF
--- a/Loader/Config/Settings.lua
+++ b/Loader/Config/Settings.lua
@@ -270,7 +270,7 @@ settings.CommandCooldowns = {
 		Server = 0;
 		Cross = 0;
 	}
-]]	
+]]
 }
 
 settings.FunCommands = true				-- Are fun commands enabled?
@@ -296,6 +296,7 @@ settings.Notification = true	           -- Whether or not to show the "You're an
 settings.SongHint = true		           -- Display a hint with the current song name and ID when a song is played via :music
 settings.TopBarShift = false	           -- By default hints and notifications will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region.
 settings.DefaultTheme = "Default"		   -- Theme to be used as a replacement for "Default". The new replacement theme can still use "Default" as its Base_Theme however any other theme that references "Default" as its redirects to this theme.
+settings.HiddenThemes = {}				   -- Hide themes from the theme selector tab inside the userpanel. Each theme name must be the specific name such as "Mobilius"
 settings.Messages = {}			           -- A list of notification messages to show HeadAdmins and above on join
 settings.AutoClean = false		           -- Will auto clean workspace of things like hats and tools
 settings.AutoCleanDelay = 60	           -- Time between auto cleans

--- a/MainModule/Client/UI/Default/UserPanel.lua
+++ b/MainModule/Client/UI/Default/UserPanel.lua
@@ -1508,7 +1508,7 @@ return function(data, env)
 						local themes = {"Game Theme"}
 						for _, v in ipairs(client.UIFolder:GetChildren()) do
 							local theme = (string.sub(v.Name, 1, 5) == "NoEnv" and string.sub(v.Name, 7)) or v.Name
-							if theme ~= "README" then
+							if theme ~= "README" and v:GetAttribute("Hidden") ~= true then
 								table.insert(themes, theme)
 							end
 						end

--- a/MainModule/Server/Dependencies/DefaultSettings.lua
+++ b/MainModule/Server/Dependencies/DefaultSettings.lua
@@ -271,7 +271,7 @@ settings.CommandCooldowns = {
 		Server = 0;
 		Cross = 0;
 	}
-]]	
+]]
 }
 
 settings.FunCommands = true				-- Are fun commands enabled?
@@ -296,6 +296,7 @@ settings.SaveCommandLogs = true	           -- If command logs are saved to the d
 settings.Notification = true	           -- Whether or not to show the "You're an admin" and "Updated" notifications
 settings.SongHint = true		           -- Display a hint with the current song name and ID when a song is played via :music
 settings.TopBarShift = false	           -- By default hints and notifications will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region.
+settings.HiddenThemes = {}				   -- Hide themes from the theme selector tab inside the userpanel. Each theme name must be the specific name such as "Mobilius"
 settings.Messages = {}			           -- A list of notification messages to show HeadAdmins and above on join
 settings.AutoClean = false		           -- Will auto clean workspace of things like hats and tools
 settings.AutoCleanDelay = 60	           -- Time between auto cleans

--- a/MainModule/Server/Server.lua
+++ b/MainModule/Server/Server.lua
@@ -536,7 +536,7 @@ return service.NewProxy({
 			AdonisDebugEnabled.Value = true
 			AdonisDebugEnabled.Parent = Folder.Parent.Client
 		end
-		
+
 		setfenv(1, setmetatable({}, {__metatable = unique}))
 
 		--// Server Variables
@@ -587,7 +587,19 @@ return service.NewProxy({
 			end
 		end
 
+		if type(server.Settings.HiddenThemes) == "table" then
+			for _, theme in ipairs(server.Client.UI:GetChildren()) do
+				if table.find(server.Settings.HiddenThemes, theme.Name) then
+					theme:SetAttribute("Hidden", true)
+				end
+			end
+		end
+
 		for _, theme in pairs(data.Themes or {}) do
+			if type(server.Settings.HiddenThemes) == "table" and table.find(server.Settings.HiddenThemes, theme.Name) then
+				theme:SetAttribute("Hidden", true)
+			end
+
 			theme:Clone().Parent = server.Client.UI
 		end
 


### PR DESCRIPTION
Addition of the `HiddenThemes` setting that allows for themes to be hidden from the UserPanel 'Client' section, useful for internal themes.

PoF:
![image](https://github.com/Epix-Incorporated/Adonis/assets/64731916/024ae8ef-52ee-46f1-8075-94b2df3d90b0)
