### PR TITLE
Fix for :undance (:uneffect alias) not stopping dance animation

### DIFF
--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -1017,7 +1017,7 @@ return function(Vargs, GetEnv)
 			local animator = human and human:FindFirstChildOfClass("Animator") or human and human:WaitForChild("Animator", 9e9)
 			if not animator then return end
 			for _, v in animator:GetPlayingAnimationTracks() do
-				if v.Name == "ADONIS_Animation" then v:Stop() ; human.Jump = true end
+				if v.Name == "ADONIS_Animation" then v:Stop() end
 			end
 		end;
 

--- a/MainModule/Client/Core/Functions.lua
+++ b/MainModule/Client/Core/Functions.lua
@@ -1011,6 +1011,16 @@ return function(Vargs, GetEnv)
 			track:Play()
 		end;
 
+		StopAnimation = function()
+			local char = service.Player.Character
+			local human = char and char:FindFirstChildOfClass("Humanoid")
+			local animator = human and human:FindFirstChildOfClass("Animator") or human and human:WaitForChild("Animator", 9e9)
+			if not animator then return end
+			for _, v in animator:GetPlayingAnimationTracks() do
+				if v.Name == "ADONIS_Animation" then v:Stop() ; human.Jump = true end
+			end
+		end;
+
 		SetLighting = function(prop,value)
 			if service.Lighting[prop]~=nil then
 				service.Lighting[prop] = value

--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -1375,6 +1375,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				for i, v in service.GetPlayers(plr, args[1]) do
 					Remote.MakeGui(v, "Effect", {Mode = "Off";})
+					Functions.StopAnimation(v)
 				end
 			end
 		};

--- a/MainModule/Server/Core/Functions.lua
+++ b/MainModule/Server/Core/Functions.lua
@@ -1125,6 +1125,16 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
+		StopAnimation = function(player)
+			if player.Character then
+				local human = player.Character:FindFirstChildOfClass("Humanoid")
+				if human and not human:FindFirstChildOfClass("Animator") then
+					service.New("Animator", human)
+				end
+				Remote.Send(player,"Function","StopAnimation")
+			end
+		end;
+
 		GetEnumValue = function(enum, item)
 			local valid = false
 			for _,v in enum:GetEnumItems() do


### PR DESCRIPTION
The ``:undance`` command existed (as an alias for ``:uneffect`` or UnEffect), but never really stopped the dance that was played.

This addition adds the command, the server call, and the client side. If it finds an animation named "ADONIS_Animation" it stops it and then makes the user jump (an extremely efficient way to restore default animations, if the character was stationary)

After Update: https://youtu.be/_NkJnWv3UcM
Before Update: https://youtu.be/EogfvpDfJKA