### PR TITLE
Fixed LocalScriptBase.client.lua erroring when ran before Adonis has been loaded on client.

### DIFF
--- a/MainModule/Server/Dependencies/LocalScriptBase.client.lua
+++ b/MainModule/Server/Dependencies/LocalScriptBase.client.lua
@@ -1,4 +1,6 @@
-task.wait()
+while rawget(_G, "Adonis") == nil do
+	task.wait()
+end
 local execute = script:FindFirstChild("Execute")
 local code, loadCode = rawget(_G, "Adonis").Scripts.ExecutePermission(script, execute and execute.Value)
 local env = getfenv()


### PR DESCRIPTION
Title. See issue #1515 for more info.
