### PR TITLE
Fix !wat inconsistently running due to inaccessible sounds

### DIFF
--- a/MainModule/Server/Commands/Fun.lua
+++ b/MainModule/Server/Commands/Fun.lua
@@ -199,7 +199,8 @@ return function(Vargs, env)
 			Fun = true;
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				local WOT = {3657191505, 754995791, 160715357, 4881542521, 227499602, 217714490, 130872377, 142633540, 259702986, 6884041159}
+				-- Broken sounds: {130872377, 142633540, 217714490, 227499602, 259702986, 3657191505, 4881542521}
+				local WOT = {754995791, 160715357, 6884041159}
 				Remote.Send(plr, "Function", "PlayAudio", WOT[math.random(1, #WOT)])
 			end
 		};


### PR DESCRIPTION
Pretty small change, just commented out the Sound ID's that are inaccessible so the !wat command runs every time.

I have not made any additions though, and it's only 3 working sounds from the original list, so more could (and should) be added.

Video showing the broken sounds:
https://youtu.be/yi-rNlzw3do