### PR TITLE
Fix for :freecam locking mouse in the center of the screen due to shift-lock activation

### DIFF
--- a/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
@@ -272,7 +272,8 @@ local Input = {} do
 				Enum.KeyCode.D, Enum.KeyCode.K,
 				Enum.KeyCode.E, Enum.KeyCode.I,
 				Enum.KeyCode.Q, Enum.KeyCode.Y,
-				Enum.KeyCode.Up, Enum.KeyCode.Down
+				Enum.KeyCode.Up, Enum.KeyCode.Down,
+				Enum.KeyCode.LeftShift, Enum.KeyCode.RightShift
 			)
 			ContextActionService:BindActionAtPriority("FreecamMousePan",          MousePan,   false, INPUT_PRIORITY, Enum.UserInputType.MouseMovement)
 			ContextActionService:BindActionAtPriority("FreecamMouseWheel",        MouseWheel, false, INPUT_PRIORITY, Enum.UserInputType.MouseWheel)
@@ -483,6 +484,7 @@ do
 	end
 
 	local function HandleActivationInput(action, state, input)
+		if UserInputService.MouseBehavior == Enum.MouseBehavior.LockCenter then return end
 		if state == Enum.UserInputState.Begin then
 			if input.KeyCode == FREECAM_MACRO_KB[#FREECAM_MACRO_KB] then
 				CheckMacro(FREECAM_MACRO_KB)

--- a/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
@@ -452,12 +452,14 @@ local function StartFreecam()
 	PlayerState.Push()
 	RunService:BindToRenderStep("Freecam", Enum.RenderPriority.Camera.Value, StepFreecam)
 	Input.StartCapture()
+	UserInputService.MouseBehavior = Enum.MouseBehavior.LockCenter
 end
 
 local function StopFreecam()
 	Input.StopCapture()
 	RunService:UnbindFromRenderStep("Freecam")
 	PlayerState.Pop()
+	UserInputService.MouseBehavior = Enum.MouseBehavior.Default
 end
 
 ------------------------------------------------------------------------
@@ -484,7 +486,6 @@ do
 	end
 
 	local function HandleActivationInput(action, state, input)
-		if UserInputService.MouseBehavior == Enum.MouseBehavior.LockCenter then return end
 		if state == Enum.UserInputState.Begin then
 			if input.KeyCode == FREECAM_MACRO_KB[#FREECAM_MACRO_KB] then
 				CheckMacro(FREECAM_MACRO_KB)


### PR DESCRIPTION
I was recently informed of a bug where if you turn on free-cam while you have shift-lock on, it will lock your mouse to the center of your screen (and it will stay locked until you do the bug again or rejoin).

After fixing this, I also found out that the reverse happens, where shift-lock can be toggled while in free-cam, and if you exit freecam during this, the same issue occurs.

I have thoroughly tested this—no more cursor locks.