### PR TITLE
:freecam now consistently gives out toggle instructions

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6873,10 +6873,7 @@ return function(Vargs, env)
 					freecam.ResetOnSpawn = false
 					freecam.Freecam.Disabled = false
 					freecam.Parent = plrgui
-
-					if Settings.CommandFeedback then
-						Functions.Notification("Notification", "Freecam has been enabled. Press Shift+P to toggle freecam on or off.", {v}, 15)
-					end
+					Functions.Notification("Notification", "Freecam has been enabled. Press Shift+P to toggle freecam on or off.", {v}, 15)
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6873,7 +6873,7 @@ return function(Vargs, env)
 					freecam.ResetOnSpawn = false
 					freecam.Freecam.Disabled = false
 					freecam.Parent = plrgui
-					Functions.Notification("Notification", "Freecam has been enabled. Press Shift+P to toggle freecam on or off.", {v}, 15)
+					Functions.Notification("Notification", "Freecam has been enabled. Press Shift+P, or F to toggle freecam on or off.", {v}, 15)
 				end
 			end
 		};

--- a/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
@@ -522,8 +522,6 @@ do
 			StopFreecam()
 		end
 	end
-	
-	ToggleFreecam() -- Runs the freecam automatically
 end]]></ProtectedString>
 				<int64 name="SourceAssetId">-1</int64>
 				<BinaryString name="Tags"></BinaryString>


### PR DESCRIPTION
Nothing major, just QoL changes;

1. Freecam does not automatically turn on when the command is run
2. Whoever the target user that received freecam now gets instructions on how to toggle it

I have recently noticed newer players not knowing how to turn off freecam, and I believe this will be very good at informing users that they have access to freecam and how to use it, instead of forcing it onto them (then having them stuck on it).