### PR TITLE
Fixed :unfreecam breaking player's camera when they had it toggled off (and added mandatory feedback when run) 

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6895,10 +6895,7 @@ return function(Vargs, env)
 
 						Remote.Send(v, "Function", "SetView", "reset")
 						service.Debris:AddItem(freecam, 2)
-
-						if Settings.CommandFeedback then
-							Functions.Notification("Notification", "Freecam has been disabled.", {v}, 15)
-						end
+						Functions.Notification("Notification", "Freecam has been disabled.", {v}, 15)
 					end
 				end
 			end

--- a/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
@@ -407,6 +407,7 @@ local PlayerState = {} do
 
 	-- Restore state
 	function PlayerState.Pop()
+		if cameraFieldOfView == nil then return end
 		for name, isEnabled in pairs(coreGuis) do
 			StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType[name], isEnabled)
 		end
@@ -519,6 +520,8 @@ do
 		if a == "End" or a == "Stop" then
 			RF.OnClientInvoke = nil
 			Debris:AddItem(RF, 0.5)
+			ContextActionService:UnbindAction("FreecamToggle")
+			ContextActionService:UnbindAction("FreecamToggle2")
 			StopFreecam()
 		end
 	end


### PR DESCRIPTION
Noticed that ``:unfreecam`` was broken, so I looked at the discord, and it seems like it has been broken since 2022 (ref. https://discord.com/channels/81902207070380032/1024709526827585597)

This is caused when freecam is currently toggled off when ``:unfreecam`` is ran

Also removed the binds during the removal of it internally, making it so the user can't get stuck inside freecam if they time it correctly (by toggling it right after it queues StopFreecam(), but prior to deletion)

Lastly, removed the CommandFeedback check so the user is aware that their freecam was removed (specifically in cases where they are not currently in it)