### PR TITLE
:freecam now has a controller keybind (DPadLeft)

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -6858,7 +6858,7 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"freecam"};
 			Args = {"player"};
-			Description = "Makes it so the target player(s)'s cam can move around freely (Press Space or Shift+P to toggle freecam)";
+			Description = "Makes it so the target player(s)'s cam can move around freely (Press Shift+P, F, or DPadLeft to toggle freecam)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for _, v in service.GetPlayers(plr, args[1]) do
@@ -6873,7 +6873,7 @@ return function(Vargs, env)
 					freecam.ResetOnSpawn = false
 					freecam.Freecam.Disabled = false
 					freecam.Parent = plrgui
-					Functions.Notification("Notification", "Freecam has been enabled. Press Shift+P, or F to toggle freecam on or off.", {v}, 15)
+					Functions.Notification("Notification", "Freecam has been enabled. Press Shift+P, F, or DPadLeft to toggle freecam on or off.", {v}, 15)
 				end
 			end
 		};

--- a/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
@@ -492,7 +492,7 @@ do
 				CheckMacro(FREECAM_MACRO_KB)
 			end
 			
-			if input.KeyCode == Enum.KeyCode.F then
+			if input.KeyCode == Enum.KeyCode.F or input.KeyCode == Enum.KeyCode.DPadLeft then
 				ToggleFreecam()
 			end
 		end

--- a/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
+++ b/MainModule/Server/Dependencies/Assets/Freecam.rbxmx
@@ -501,6 +501,7 @@ do
 
 	ContextActionService:BindActionAtPriority("FreecamToggle", HandleActivationInput, false, TOGGLE_INPUT_PRIORITY, FREECAM_MACRO_KB[#FREECAM_MACRO_KB])
 	ContextActionService:BindActionAtPriority("FreecamToggle2", HandleActivationInput, false, TOGGLE_INPUT_PRIORITY, Enum.KeyCode.F)
+	ContextActionService:BindActionAtPriority("FreecamToggleDPAD", HandleActivationInput, false, TOGGLE_INPUT_PRIORITY, Enum.KeyCode.DPadLeft)
 	
 	RF.OnClientInvoke = function(a, b, c)
 		if a == "Disable" and enabled then
@@ -522,6 +523,7 @@ do
 			Debris:AddItem(RF, 0.5)
 			ContextActionService:UnbindAction("FreecamToggle")
 			ContextActionService:UnbindAction("FreecamToggle2")
+			ContextActionService:UnbindAction("FreecamToggleDPAD")
 			StopFreecam()
 		end
 	end


### PR DESCRIPTION
I saw a new user in the discord say they couldn't freecam on console anymore, as it doesn't automatically push them onto it now, so I added a key bind.

Side note: The discord user mentioned DPad L & R would be a good keybind, and that's not possible on the Xbox controller which I used to test because the DPAD only goes down on one side. I wanted this to be universal to all consoles that roblox supports.