### PR TITLE
Fix Unity theme's List RichText

### DIFF
--- a/MainModule/Client/UI/Unity/List.lua
+++ b/MainModule/Client/UI/Unity/List.lua
@@ -251,7 +251,10 @@ return function(data, env)
 					end
 
 					scroller.CanvasPosition = Vector2.new(0, 0);
-					scroller:GenerateList(getPage(currentListTab, PageCounter));
+					scroller:GenerateList(getPage(currentListTab, PageCounter), {
+						RichTextAllowed = RichText;
+						TextSelectable = TextSelectable;
+					});
 				end
 
 				lastPageButton.BackgroundTransparency = origLTrans;
@@ -304,7 +307,10 @@ return function(data, env)
 					end
 
 					scroller.CanvasPosition = Vector2.new(0, 0);
-					scroller:GenerateList(getPage(currentListTab, PageCounter));
+					scroller:GenerateList(getPage(currentListTab, PageCounter), {
+						RichTextAllowed = RichText;
+						TextSelectable = TextSelectable;
+					});
 				end
 
 				lastPageButton.BackgroundTransparency = origLTrans;


### PR DESCRIPTION
Was never referencing variables when switching pages

Fixes #1532 