### PR TITLE
Fix Console UI unfocusing on click in certain themes

### DIFF
--- a/MainModule/Client/UI/Aero/Console.rbxmx
+++ b/MainModule/Client/UI/Aero/Console.rbxmx
@@ -825,6 +825,13 @@ return function(data, env)
 		end
 	end
 
+	local function isInConsoleBounds(pos)
+		for i,v in ipairs(playergui:GetGuiObjectsAtPosition(pos.X, pos.Y)) do
+			if v == gui or v == gui.Frame then return true end
+		end
+		return false
+	end
+
 	text.FocusLost:Connect(function(enterPressed)
 		if enterPressed then
 			if text.Text~='' and string.len(text.Text)>1 then
@@ -838,9 +845,10 @@ return function(data, env)
 				end)
 				client.Remote.Send('ProcessCommand',text.Text)
 			end
+			close()
+		elseif not isInConsoleBounds(player:GetMouse()) then
+			close()
 		end
-
-		close()
 	end)
 
 	text.Changed:Connect(function(c)

--- a/MainModule/Client/UI/Default/Console.rbxmx
+++ b/MainModule/Client/UI/Default/Console.rbxmx
@@ -546,7 +546,8 @@ return function(data, env)
 	if env then
 		setfenv(1, env)
 	end
-
+	local player = service.Players.LocalPlayer
+	local playergui = player.PlayerGui
 	local UI = client.UI
 	local Remote = client.Remote
 	local Variables = client.Variables
@@ -706,14 +707,22 @@ return function(data, env)
 		opened = true
 	end
 
+	local function isInConsoleBounds(pos)
+		for i,v in ipairs(playergui:GetGuiObjectsAtPosition(pos.X, pos.Y)) do
+			if v == gui or v == gui.Frame then return true end
+		end
+		return false
+	end
+
 	text.FocusLost:Connect(function(enterPressed)
 		if enterPressed then
-			if string.len(text.Text) > 1 then
-				Remote.Send("ProcessCommand", text.Text)
+			if text.Text ~= '' and string.len(text.Text) > 1 then
+				Remote.Send('ProcessCommand', text.Text)
 			end
+			closeConsole()
+		elseif not isInConsoleBounds(player:GetMouse()) then
+			closeConsole()
 		end
-
-		closeConsole()
 	end)
 
 	text:GetPropertyChangedSignal("Text"):Connect(function()

--- a/MainModule/Client/UI/Rounded/Console.rbxmx
+++ b/MainModule/Client/UI/Rounded/Console.rbxmx
@@ -636,14 +636,22 @@ return function(data, env)
 		end
 	end
 
+	local function isInConsoleBounds(pos)
+		for i,v in ipairs(playergui:GetGuiObjectsAtPosition(pos.X, pos.Y)) do
+			if v == gui or v == gui.Frame then return true end
+		end
+		return false
+	end
+
 	text.FocusLost:Connect(function(enterPressed)
 		if enterPressed then
-			if text.Text~='' and string.len(text.Text)>1 then
-				client.Remote.Send('ProcessCommand',text.Text)
+			if text.Text ~= '' and string.len(text.Text) > 1 then
+				client.Remote.Send('ProcessCommand', text.Text)
 			end
+			close()
+		elseif not isInConsoleBounds(player:GetMouse()) then
+			close()
 		end
-
-		close()
 	end)
 
 	text.Changed:Connect(function(c)

--- a/MainModule/Client/UI/Steampunk/Console.rbxmx
+++ b/MainModule/Client/UI/Steampunk/Console.rbxmx
@@ -67,6 +67,8 @@ return function(data, env)
 		setfenv(1, env)
 	end
 
+	local player = service.Players.LocalPlayer
+	local playergui = player.PlayerGui
 	local UI = client.UI
 	local Remote = client.Remote
 	local Variables = client.Variables
@@ -226,14 +228,22 @@ return function(data, env)
 		opened = true
 	end
 
+	local function isInConsoleBounds(pos)
+		for i,v in ipairs(playergui:GetGuiObjectsAtPosition(pos.X, pos.Y)) do
+			if v == gui or v == gui.Frame then return true end
+		end
+		return false
+	end
+
 	text.FocusLost:Connect(function(enterPressed)
 		if enterPressed then
-			if string.len(text.Text) > 1 then
-				Remote.Send("ProcessCommand", text.Text)
+			if text.Text ~= '' and string.len(text.Text) > 1 then
+				Remote.Send('ProcessCommand', text.Text)
 			end
+			closeConsole()
+		elseif not isInConsoleBounds(player:GetMouse()) then
+			closeConsole()
 		end
-
-		closeConsole()
 	end)
 
 	text:GetPropertyChangedSignal("Text"):Connect(function()

--- a/MainModule/Client/UI/Windows XP/Console.rbxmx
+++ b/MainModule/Client/UI/Windows XP/Console.rbxmx
@@ -608,14 +608,22 @@ return function(data, env)
 		end
 	end
 
+	local function isInConsoleBounds(pos)
+		for i,v in ipairs(playergui:GetGuiObjectsAtPosition(pos.X, pos.Y)) do
+			if v == gui or v == gui.Frame then return true end
+		end
+		return false
+	end
+
 	text.FocusLost:Connect(function(enterPressed)
 		if enterPressed then
-			if text.Text~='' and string.len(text.Text)>1 then
-				client.Remote.Send('ProcessCommand',text.Text)
+			if text.Text ~= '' and string.len(text.Text) > 1 then
+				client.Remote.Send('ProcessCommand', text.Text)
 			end
+			close()
+		elseif not isInConsoleBounds(player:GetMouse()) then
+			close()
 		end
-
-		close()
 	end)
 
 	text.Changed:Connect(function(c)


### PR DESCRIPTION
Some themes didn't even check if the user clicked within the UI, so I've made it consistent with all the built-in themes.

Fixes #1109 