### PR TITLE
Implement IP cache on serverdetails (Location)

### DIFF
--- a/MainModule/Server/Commands/Players.lua
+++ b/MainModule/Server/Commands/Players.lua
@@ -977,8 +977,10 @@ return function(Vargs, env)
 				local elevated = Admin.CheckAdmin(plr)
 
 				local serverInfo = select(2, xpcall(function()
-					local res = service.HttpService:JSONDecode(service.HttpService:GetAsync("https://ipinfo.io/json"))
-
+					local res = Variables.IPInfo or service.HttpService:JSONDecode(service.HttpService:GetAsync("https://ipinfo.io/json"))
+					if not Variables.IPInfo then
+						Variables.IPInfo = res
+					end
 					return {
 						country = `{require(server.Dependencies.CountryRegionCodes)[res.country] or "N/A"} ({res.country})`,
 						city = res.city,


### PR DESCRIPTION
Should resolve an issue where multiple requests seems to have caused the endpoint to ratelimit and not return any information about the servers location:

![image](https://github.com/Epix-Incorporated/Adonis/assets/64731916/365ce654-e738-4d58-bb8b-ec2b544347c4)