### PR TITLE
Fix for :invisible command's BillboardGui invisibility function

### DIFF
--- a/MainModule/Server/Commands/Moderators.lua
+++ b/MainModule/Server/Commands/Moderators.lua
@@ -3775,13 +3775,16 @@ return function(Vargs, env)
 								obj.Transparency = 1
 								if obj:FindFirstChild("face") then
 									obj.face.Transparency = 1
-								elseif obj:FindFirstChildOfClass("BillboardGui") then
+								end
+								if obj:FindFirstChildOfClass("BillboardGui") then
 									obj:FindFirstChildOfClass("BillboardGui").Enabled = false
 								end
 							elseif obj:IsA("Accoutrement") and obj:FindFirstChild("Handle") then
 								obj.Handle.Transparency = 1
 							elseif obj:IsA("ForceField") then
 								obj.Visible = false
+							elseif obj:IsA("BillboardGui") then
+								obj.Enabled = false
 							elseif obj.Name == "Head" then
 								local face = obj:FindFirstChildOfClass("Decal")
 								if face then
@@ -3808,13 +3811,16 @@ return function(Vargs, env)
 								obj.Transparency = 0
 								if obj:FindFirstChild("face") then
 									obj.face.Transparency = 0
-								elseif obj:FindFirstChildOfClass("BillboardGui") then
+								end
+								if obj:FindFirstChildOfClass("BillboardGui") then
 									obj:FindFirstChildOfClass("BillboardGui").Enabled = true
 								end
 							elseif obj:IsA("Accoutrement") and obj:FindFirstChild("Handle") then
 								obj.Handle.Transparency = 0
 							elseif obj:IsA("ForceField") and obj.Name ~="ADONIS_FULLGOD" then
 								obj.Visible = true
+							elseif obj:IsA("BillboardGui") then
+								obj.Enabled = true
 							elseif obj.Name == "Head" then
 								local face = obj:FindFirstChildOfClass("Decal")
 								if face then


### PR DESCRIPTION
Previous BillboardGui invisibility patch doesn't really work well, since it's in the elseif after checking the face, which means it only works on Dynamic Heads. Now it's in the separate if's after the face decal check, as well as the separate obj:IsA("BillboardGui") check in case of certain BillboardGui systems being put inside the character model instead of Head.

After this patch, the BillboardGui invisibility should work again.

Before:
![image](https://github.com/Epix-Incorporated/Adonis/assets/54766538/7412325e-79f6-492d-92d0-bcb376ddcc82)

After:
![image](https://github.com/Epix-Incorporated/Adonis/assets/54766538/b252c3ac-36da-4a4b-93ea-09a1f14f74ce)
