### PR TITLE
Blocked studio only prefix related settings

### DIFF
--- a/MainModule/Server/Core/Remote.lua
+++ b/MainModule/Server/Core/Remote.lua
@@ -70,14 +70,10 @@ return function(Vargs, GetEnv)
 			MobileTheme = true;
 			DefaultTheme = true;
 			HelpButtonImage = true;
-			Prefix = true;
-			PlayerPrefix = true;
-			SpecialPrefix = true;
 			BatchKey = true;
 			AnyPrefix = true;
 			DonorCommands = true;
 			DonorCapes = true;
-			ConsoleKeyCode = true;
 			SplitKey = true;
 		};
 
@@ -100,6 +96,11 @@ return function(Vargs, GetEnv)
 
 			Creators = true;
 			Permissions = true;
+
+			Prefix = true; -- Changes in-game only happen on current session; Not able to be saved (also breaks console)
+			PlayerPrefix = true; -- Completely breaks usage
+			SpecialPrefix = true; -- Completely breaks usage
+			ConsoleKeyCode = true; -- Has no effect
 
 			G_API = true;
 			G_Access = true;
@@ -789,7 +790,7 @@ return function(Vargs, GetEnv)
 			end;
 
 			PlayerEvent = function(p: Player, args: {[number]: any})
-				if service.GetEvent(tostring(args[1]) .. p.UserId) then												
+				if service.GetEvent(tostring(args[1]) .. p.UserId) then
 					service.Events[tostring(args[1]) .. p.UserId]:Fire(unpack(args,2))
 				end
 			end;
@@ -1015,13 +1016,13 @@ return function(Vargs, GetEnv)
 
 			SaveScript = function(p: Player, args: {})
 				local se = Variables.ScriptEditor[tostring(p.UserId)]
-				-- Ignore the request													
+				-- Ignore the request
 				if not se then
 					return
 				end
 				local Name = args[1]["Name"]
 				local Variable = se[Name]
-				
+
 				Variable.Script = args[1]["Text"]
 			end,
 			RunScript = function(p: Player, args: {})
@@ -1029,16 +1030,16 @@ return function(Vargs, GetEnv)
 
 				local command = Commands.ScriptEditor
 				-- This is redundant because the only way to gain an entry in Variables.ScriptEditor is to have the command run on yourself
-				-- However, better safe than sorry!													
-				if command and Admin.CheckComLevel(adminLevel, command.AdminLevel) then													
+				-- However, better safe than sorry!
+				if command and Admin.CheckComLevel(adminLevel, command.AdminLevel) then
 					local se = Variables.ScriptEditor[tostring(p.UserId)]
-					-- Ignore the request													
+					-- Ignore the request
 					if not se then
 						return
 					end
 					local Name = args[1][1]
 					local Variable = se[Name]
-					
+
 					local oError = error
 					local newenv = GetEnv(getfenv(),{
 						print = function(...) local args, str = table.pack(...), "" for i = 1, args.n do str ..= `{(i > 1 and " " or "")}{args[i]}` end Remote.Terminal.LiveOutput(p, `PRINT: {str}`) end;
@@ -1047,20 +1048,20 @@ return function(Vargs, GetEnv)
 							if level ~= nil and type(level) ~= "number" then
 								oError(string.format("bad argument #2 to 'error' (number expected, got %s)", type(level)), 2)
 							end
-	
+
 							Remote.MakeGui(p, "Output",{Title = 'LUA_DEMAND_ERROR'; Message = `{reason}`})
 							oError(`Adonis ScriptEditor error: {reason}`, (level or 1) + 1)
 						end;
 					})
 
-					-- TODO: Maybe make it not work with the server Env?													
+					-- TODO: Maybe make it not work with the server Env?
 					service.TrackTask(`Thread: ScriptEditor: {p.UserId}: {Name}`,function()
 						local func,err = Core.Loadstring(Variable["Script"], newenv)
 						if func then
 							local Succ,Err = pcall(function()
 								func()
 							end)
-							
+
 							Remote.MakeGui(p, "Output", {Title = "Error"; Message = Err})
 						else
 							Remote.MakeGui(p, "Output", {Title = "Error"; Message = err})
@@ -1343,7 +1344,7 @@ return function(Vargs, GetEnv)
 		SetLighting = function(p: Player, prop: string, value: any)
 			Remote.Send(p, "Function", "SetLighting", prop, value)
 		end;
-														
+
 		SetAtmosphere = function(p: Player, prop: string, value: any)
 			Remote.Send(p, "Function", "SetAtmosphere", prop, value)
 		end;


### PR DESCRIPTION
Pretty straightforward, after looking into issue #1540, it seems like the majority of the prefix category under ``:settings`` had no impact or completely broke usage when changed (and after joining a different server)

This is just a band-aid until someone decides to fix these underlying issues (which didn't look very simple when I took a look, due to the way commands are loaded before settings)

closes #1540 