### PR TITLE
Use humans.txt + IsStudio for simple HttpEnabled check

### DIFF
--- a/MainModule/Server/Core/HTTP.luau
+++ b/MainModule/Server/Core/HTTP.luau
@@ -40,11 +40,15 @@ return function(Vargs, GetEnv)
 	server.HTTP = {
 		Init = Init;
 		HttpEnabled = (function()
-			local success, res = pcall(service.HttpService.GetAsync, service.HttpService, "https://www.google.com/robots.txt")
-			if not success and res:find("Http requests are not enabled.") then
-				return false
+			if service.RunService:IsStudio() then
+				return service.HttpService.HttpEnabled
+			else
+				local success, res = pcall(service.HttpService.GetAsync, service.HttpService, "https://www.google.com/humans.txt")
+				if not success and res:find("Http requests are not enabled.") then
+					return false
+				end
+				return true
 			end
-			return true
 		end)();
 		LoadstringEnabled = pcall(loadstring, "");
 


### PR DESCRIPTION
Since HttpService.HttpEnabled is most accurate on Studio rather than standard servers for some reason behind Roblox's implementations, I decided to return a simple HttpService.HttpEnabled check, but behind a RunService:IsStudio() check.

About the standard HttpEnabled check, humans.txt have a whopping 8.2 KiB(s) lower filesize than robots.txt, which in Roblox's HttpService case, is a pretty good difference.
![hr_diff](https://github.com/Epix-Incorporated/Adonis/assets/54766538/30343db8-a729-4948-9fce-fe98d39e2a66)

Tested by this code:
![RobloxStudioBeta_5TP0oiTPIG](https://github.com/Epix-Incorporated/Adonis/assets/54766538/d3245362-d166-4310-aae8-91430ebf15b7)
Without HttpEnabled:
![http_not_enabled](https://github.com/Epix-Incorporated/Adonis/assets/54766538/29d92adf-b0bc-4b25-80f4-9f94aa023cf5)
With HttpEnabled, robots.txt check:
![http_enabled_with_rb](https://github.com/Epix-Incorporated/Adonis/assets/54766538/f6a69b4d-e1f0-4915-aceb-03fa907ef744)
With HttpEnabled, humans.txt check:
![http_enabled_with_hu](https://github.com/Epix-Incorporated/Adonis/assets/54766538/8c703e68-d4eb-4bba-a8c3-727c2ef4b17b)
With HttpEnabled, including IsStudio() check which is similar to no HttpEnabled:
![http_enabled_isstudio_check](https://github.com/Epix-Incorporated/Adonis/assets/54766538/a4ec2946-e842-4f11-a351-7505c286caf7)

Predicted FAQs:
- Why not return HttpService.HttpEnabled in the first place?
https://github.com/Epix-Incorporated/Adonis/pull/1536 should explain the unreliable Roblox server's implementation.
- Why not use Variables.IsStudio?
It's initialized way after the HTTP check, thus even the Variables itself return nil during the HttpEnabled check.