### PR TITLE
Whitelist RBLX VR Controls Scheme from CoreGui Images Check

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.luau
+++ b/MainModule/Client/Plugins/Anti_Cheat.luau
@@ -292,7 +292,7 @@ return function(Vargs)
 			service.StartLoop("AntiCoreGui", 15, function()
 				xpcall(function()
 					local function getCoreUrls()
-						local coreUrls = {"rbxassetid://0", "rbxassetid://10066921516"}	-- Whitelist for Roblox Camera SFX
+						local coreUrls = {"rbxassetid://0", "rbxassetid://10066921516", "rbxassetid://13262267483", "rbxassetid://13253401424"}	-- Whitelist for Roblox Camera SFX and Quest Controls Scheme
 						local backpack = Player:FindFirstChildOfClass("Backpack")
 						local character = Player.Character
 						local starterPack = service.StarterPack


### PR DESCRIPTION
Roblox might've been slowly taking the "put the images in the cloud" route instead of putting them in the client itself. And the worst part is that it's uploaded through their employee's account rather than the Roblox (User ID 1) account itself.

Here's the log message from Adonis reports remotely sent through a webhook. 
Note that my own Adonis fork used in productions doesn't kick players when a CoreGui detection occured since I already have known IDs related to exploiting.

![i_view64_vrDNls5Skh](https://github.com/Epix-Incorporated/Adonis/assets/54766538/309fb8b4-0198-4ae5-a335-249a1974bc46)

Notice that the player info claimed that Roblox was being rendered with 1:1 aspect ratio, doesn't have a touchscreen, and primarily uses Gamepad1 as the input type.
The mentioned AssetID redirects to this image relating to VR Controls scheme:

![firefox_G5z4LjHbHq](https://github.com/Epix-Incorporated/Adonis/assets/54766538/2423c00d-0656-498d-ba64-8ae81c0d2f1b)

And the uploader, `worldsynth`, has an official Administrator badge:

![firefox_9i5VDi6AFu](https://github.com/Epix-Incorporated/Adonis/assets/54766538/d5ecb9eb-e640-4f15-9bb6-58bb7c4dbcde)

Plus it's a good thing the profile is public, revealing one more decal which looks very similar each other:

![firefox_xxm2BVxodU](https://github.com/Epix-Incorporated/Adonis/assets/54766538/80e9bd6a-d2b1-45a5-aa0a-7edc226d4d95)

Which, with all the explanation above, adding 2 more asset IDs into the whitelist is needed to make sure VR players, primarily Meta Quest users aren't getting false kicks on Roblox experiences with CoreGui Image checks enabled.

