### PR TITLE
Add Text Selections to the :players Command

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -1351,6 +1351,7 @@ return function(Vargs, env)
 					Size = {300, 240};
 					AutoUpdate = if not args[1] or (args[1]:lower() == "true" or args[1]:lower() == "yes") then 1 else nil;
 					Update = "PlayerList";
+					TextSelectable = true;
 				})
 			end
 		};


### PR DESCRIPTION
Allowed text in the :players command to copy and pasted. (selectable)

**Proof of Functionality:**

https://github.com/user-attachments/assets/921d0cda-8a7c-45d4-9917-3cae917a03eb



