### PR TITLE
Prevent Anti.RemovePlayer from kicking if in studio

### DIFF
--- a/MainModule/Server/Core/Anti.luau
+++ b/MainModule/Server/Core/Anti.luau
@@ -49,8 +49,15 @@ return function(Vargs, GetEnv)
 
 		RemovePlayer = function(p, info)
 			info = tostring(info) or "No Reason Given"
-
-			pcall(function() service.UnWrap(p):Kick(`:: Adonis Anti Cheat :: {info}`) end)
+			
+			if service.RunService:IsStudio() then
+				warn(`:: Adonis Anti Cheat :: Anticheat triggered for {p.Name}, not kicking because in studio; {info}`)
+				return;
+			end
+			
+			pcall(function()
+				service.UnWrap(p):Kick(`:: Adonis Anti Cheat :: {info}`)
+			end)
 
 			task.wait(1)
 


### PR DESCRIPTION
Prevents Anti.RemovePlayer from removing the player if the server is in studio, displays a nice warn message instead 😁.
Anti.Detected also has a studio check so .RemovePlayer should have it too
https://discord.com/channels/81902207070380032/1289583833162973267/1289583833162973267

PoF:
https://github.com/user-attachments/assets/b8dc465d-f200-4090-aa90-0f497d97de1b