### PR TITLE
Add aliases to multiple commands.

### DIFF
--- a/MainModule/Server/Commands/Creators.luau
+++ b/MainModule/Server/Commands/Creators.luau
@@ -11,7 +11,7 @@ return function(Vargs, env)
 	return {
 		DirectBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"directban"};
+			Commands = {"directban", "dban"};
 			Args = {"username(s)", "reason"};
 			Description = "Adds the specified user(s) to the global ban list; saves";
 			AdminLevel = "Creators";
@@ -48,7 +48,7 @@ return function(Vargs, env)
 
 		UnDirectBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"directunban", "undirectban"};
+			Commands = {"directunban", "undirectban", "dunban"};
 			Args = {"username(s)"};
 			Description = "Removes the specified user(s) from the global ban list; saves";
 			AdminLevel = "Creators";

--- a/MainModule/Server/Commands/Creators.luau
+++ b/MainModule/Server/Commands/Creators.luau
@@ -48,7 +48,7 @@ return function(Vargs, env)
 
 		UnDirectBan = {
 			Prefix = Settings.Prefix;
-			Commands = {"directunban", "undirectban", "dunban"};
+			Commands = {"directunban", "undirectban", "undban"};
 			Args = {"username(s)"};
 			Description = "Removes the specified user(s) from the global ban list; saves";
 			AdminLevel = "Creators";

--- a/MainModule/Server/Shared/Changelog.luau
+++ b/MainModule/Server/Shared/Changelog.luau
@@ -18,7 +18,7 @@ return {
 	"(Git/omwot) Improve Modern theme (#1598)";
 	"(Git/jun022222222) Make mats & colors list selectable (#1599)";
 	"(Git/24rr) Add a search player bar for :privatechat (#1594)";
-	"(Git/cl1ents) Update "MakeLocalScript" and "LoadLocalScript" commands (#1603)";
+	"(Git/cl1ents) Update MakeLocalScript and LoadLocalScript commands (#1603)";
 	"";
 	"[Patch v260.2 2024-08-11 21:50 UTC] @Dimenpsyonal";
 	"Fix alias arguments (#1581)";

--- a/MainModule/Server/Shared/Credits.luau
+++ b/MainModule/Server/Shared/Credits.luau
@@ -98,6 +98,7 @@ return {
 		{Text = "@PurpleCreativity",Desc = "Open Source Contributor"};
 		{Text = "@ScriptedConnor",	Desc = "Open Source Contributor"};
 		{Text = "@omwot",			Desc = "Open Source Contributor"};
+		{Text = "@AidenJamesYt",    Desc = "Open Source Contributor"};
 	};
 
 	Misc = {


### PR DESCRIPTION
# Changes

# Aliases Added

- Added "getadmin" as an alias for the "GetScript" command. :getadmin is more commonly used than :getscript.
- Added "dban" as an alias for the "DirectBan" command. Quickens command usage.
- Added "dunban" as an alias for the "UnDirectBan" command. Quickens command usage.

# Credits Added

- Added "@AidenJamesYt" to "Contributors" as an Open Source Contributor.

