### PR TITLE
Fix leap year handling

### DIFF
--- a/MainModule/Client/UI/Default/Profile.luau
+++ b/MainModule/Client/UI/Default/Profile.luau
@@ -87,7 +87,7 @@ return function(data, env)
 			{"Display Name", player.DisplayName, "The player's custom display name"},
 			{"Username", player.Name, "The player's unique Roblox username"},
 			{"User ID", player.UserId, "The player's unique Roblox user ID"},
-			{"Acc. Age", `{player.AccountAge} days ({string.format("%.2f", player.AccountAge/365)} years)`, "How long the player has been registered on Roblox"},
+			{"Acc. Age", `{player.AccountAge} days ({string.format("%.2f", player.AccountAge/365.25)} years)`, "How long the player has been registered on Roblox"},
 			}) do
 			generaltab:Add("TextLabel", {
 				Text = `  {v[1]}: `;


### PR DESCRIPTION
Proof:
- https://duckduckgo.com/?t=ffab&q=how+many+days+in+a+year&ia=web
- https://en.wikipedia.org/wiki/Year
- https://en.wikipedia.org/wiki/Leap_year

This does not account for a leap year miss that happens every 400 years which would make the real value 365.2425 days but that doesn't matter, it's close enough to the accepted 365.25 years