### PR TITLE
Change :resize to use Model :ScaleTo() method

### DIFF
--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3677,15 +3677,12 @@ return function(Vargs, env)
 						continue
 					end
 
-					if char:isA("Model") then --If character is a model then we use this method
-						char:ScaleTo(num) --Uses the Roblox Model:ScaleTo method to set the scale value of the character model
-						--see; https://create.roblox.com/docs/reference/engine/classes/Model#ScaleTo
-					
+					if human and char:isA("Model") then
+						char:ScaleTo(num)					
 						if not human:GetAttribute("Adonis_OriginalHipHeight") then
-							human:SetAttribute("Adonis_OriginalHipHeight", human.HipHeight) -- Saves the original hip height of the character
+							human:SetAttribute("Adonis_OriginalHipHeight", human.HipHeight)
 						end
-						human.HipHeight = human:GetAttribute("Adonis_OriginalHipHeight") * num --Corrects humanoid hip hight to match new character size
-					
+						human.HipHeight = human:GetAttribute("Adonis_OriginalHipHeight") * num
 					elseif human and human.RigType == Enum.HumanoidRigType.R15 then
 						for _, val in human:GetChildren() do
 							if val:IsA("NumberValue") and val.Name:match(".*Scale") then

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3677,7 +3677,16 @@ return function(Vargs, env)
 						continue
 					end
 
-					if human and human.RigType == Enum.HumanoidRigType.R15 then
+					if char:isA("Model") then --If character is a model then we use this method
+						char:ScaleTo(num) --Uses the Roblox Model:ScaleTo method to set the scale value of the character model
+						--see; https://create.roblox.com/docs/reference/engine/classes/Model#ScaleTo
+						--[[ --Unsure if this is required to meet adonis standards
+						if not char:SetAttribute("Adonis_HipHeight", num) then
+							char:SetAttribute("Adonis_HipHeight", human.HipHeight)
+						end --]] -- I do not know about command prosedures eg: if we save the original value to recover later
+						human.HipHeight = human.HipHeight * num --Corrects humanoid hip hight to match new character size
+						--fixDensity(char) --Do I need this for model:ScaleTo?
+					elseif human and human.RigType == Enum.HumanoidRigType.R15 then
 						for _, val in human:GetChildren() do
 							if val:IsA("NumberValue") and val.Name:match(".*Scale") then
 								val.Value *= num

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3680,12 +3680,12 @@ return function(Vargs, env)
 					if char:isA("Model") then --If character is a model then we use this method
 						char:ScaleTo(num) --Uses the Roblox Model:ScaleTo method to set the scale value of the character model
 						--see; https://create.roblox.com/docs/reference/engine/classes/Model#ScaleTo
-						--[[ --Unsure if this is required to meet adonis standards
-						if not char:SetAttribute("Adonis_HipHeight", num) then
-							char:SetAttribute("Adonis_HipHeight", human.HipHeight)
-						end --]] -- I do not know about command prosedures eg: if we save the original value to recover later
-						human.HipHeight = human.HipHeight * num --Corrects humanoid hip hight to match new character size
-						--fixDensity(char) --Do I need this for model:ScaleTo?
+					
+						if not human:GetAttribute("Adonis_OriginalHipHeight") then
+							human:SetAttribute("Adonis_OriginalHipHeight", human.HipHeight) -- Saves the original hip height of the character
+						end
+						human.HipHeight = human:GetAttribute("Adonis_OriginalHipHeight") * num --Corrects humanoid hip hight to match new character size
+					
 					elseif human and human.RigType == Enum.HumanoidRigType.R15 then
 						for _, val in human:GetChildren() do
 							if val:IsA("NumberValue") and val.Name:match(".*Scale") then

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3677,7 +3677,7 @@ return function(Vargs, env)
 						continue
 					end
 
-					if human and char:isA("Model") then
+					if human and char:IsA("Model") then
 						char:ScaleTo(num)
 					elseif human and human.RigType == Enum.HumanoidRigType.R15 then
 						for _, val in human:GetChildren() do

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3678,11 +3678,7 @@ return function(Vargs, env)
 					end
 
 					if human and char:isA("Model") then
-						char:ScaleTo(num)					
-						if not human:GetAttribute("Adonis_OriginalHipHeight") then
-							human:SetAttribute("Adonis_OriginalHipHeight", human.HipHeight)
-						end
-						human.HipHeight = human:GetAttribute("Adonis_OriginalHipHeight") * num
+						char:ScaleTo(num)
 					elseif human and human.RigType == Enum.HumanoidRigType.R15 then
 						for _, val in human:GetChildren() do
 							if val:IsA("NumberValue") and val.Name:match(".*Scale") then


### PR DESCRIPTION
Changes the "resize" command under "Fun" to use the new modern Roblox method [Model:ScaleTo](https://create.roblox.com/docs/reference/engine/classes/Model#ScaleTo) to change player size, allowing for animations to be naturally corrected to size.

> Video of me testing the method provided
> https://github.com/user-attachments/assets/64063c26-9729-43a9-b8ed-e8724ea81cab

This is the module script used for the test of functionality for this pull request;

```luau
return function (char : Model & {Humanoid : Humanoid}, size : number)
	local num = math.clamp(size,0.01,100)	
	local human = char:FindFirstChild("Humanoid")
	char:ScaleTo(num)
	if not human:GetAttribute("Adonis_OriginalHipHeight") then
		human:SetAttribute("Adonis_OriginalHipHeight", human.HipHeight)
	end
	human.HipHeight = human:GetAttribute("Adonis_OriginalHipHeight") * num 
end
``` 

use `require(script)(game.Players.<Player>.Character,n)` to test this yourself.
