### PR TITLE
Move `DisableRejoinAtMaxPlayers` from Settings to Variables

### DIFF
--- a/Loader/Config/Settings.luau
+++ b/Loader/Config/Settings.luau
@@ -302,7 +302,6 @@ settings.AutoClean = false		           -- Will auto clean workspace of things li
 settings.AutoCleanDelay = 60	           -- Time between auto cleans
 settings.AutoBackup = false 	           -- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
 settings.ReJail = false			           -- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
-settings.DisableRejoinAtMaxPlayers = false -- If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount.
 
 settings.Console = true				-- Whether the command console is enabled
 settings.Console_AdminsOnly = false -- If true, only admins will be able to access the console
@@ -474,7 +473,6 @@ descs.SongHint = [[ Display a hint with the current song name and ID when a song
 descs.TopBarShift = [[ By default hints and notifs will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region. ]]
 descs.DefaultTheme = [[ Theme to be used as a replacement for "Default". The new replacement theme can still use "Default" as its Base_Theme however any other theme that references "Default" as its redirects to this theme. ]]
 descs.ReJail = [[ If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed ]]
-descs.DisableRejoinAtMaxPlayers = [[ If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount. ]]
 
 descs.Messages = [[ A list of notification messages to show HeadAdmins and above on join ]]
 
@@ -592,7 +590,6 @@ order = {
 	"TopBarShift";
 	"DefaultTheme";
 	"ReJail";
-	"DisableRejoinAtMaxPlayers";
 	"";
 	"AutoClean";
 	"AutoCleanDelay";

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -434,7 +434,7 @@ return function(Vargs, env)
 			NoStudio = true; -- Commands which cannot be used in Roblox Studio (e.g. commands which use TeleportService)
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				assert(#(service.Players:GetPlayers()) < service.Players.MaxPlayers or not (Settings.DisableRejoinAtMaxPlayers or Variables.DisableRejoinAtMaxPlayers), "Cannot rejoin while server is at max capacity.")
+				assert(#(service.Players:GetPlayers()) < service.Players.MaxPlayers or not Variables.DisableRejoinAtMaxPlayers, "Cannot rejoin while server is at max capacity.")
 				service.TeleportService:TeleportAsync(game.PlaceId, {plr}, service.New("TeleportOptions", {
 					ServerInstanceId = game.JobId
 				}))

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -434,7 +434,7 @@ return function(Vargs, env)
 			NoStudio = true; -- Commands which cannot be used in Roblox Studio (e.g. commands which use TeleportService)
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				assert(#(service.Players:GetPlayers()) < service.Players.MaxPlayers or not Settings.DisableRejoinAtMaxPlayers, "Cannot rejoin while server is at max capacity.")
+				assert(#(service.Players:GetPlayers()) < service.Players.MaxPlayers or not (Settings.DisableRejoinAtMaxPlayers or Variables.DisableRejoinAtMaxPlayers), "Cannot rejoin while server is at max capacity.")
 				service.TeleportService:TeleportAsync(game.PlaceId, {plr}, service.New("TeleportOptions", {
 					ServerInstanceId = game.JobId
 				}))

--- a/MainModule/Server/Core/Variables.luau
+++ b/MainModule/Server/Core/Variables.luau
@@ -28,6 +28,7 @@ return function(Vargs, GetEnv)
 
 		Variables.BanMessage = Settings.BanMessage
 		Variables.LockMessage = Settings.LockMessage
+		Variables.DisableRejoinAtMaxPlayers = Settings.DisableRejoinAtMaxPlayers or Variables.DisableRejoinAtMaxPlayers
 
 		for _, v in Settings.MusicList or {} do table.insert(Variables.MusicList, v) end
 		for _, v in Settings.InsertList or {} do table.insert(Variables.InsertList, v) end

--- a/MainModule/Server/Core/Variables.luau
+++ b/MainModule/Server/Core/Variables.luau
@@ -67,6 +67,7 @@ return function(Vargs, GetEnv)
 		WebPanel_Initiated = false,
 		HTTPCheckUrl = "https://www.google.com/humans.txt",
 		IPInfoUrl = "https://ipinfo.io/json",
+		DisableRejoinAtMaxPlayers = false,
 		AnimatedFaces = {
 			-- R15 (Hopefully)
 			14719428401, 12936561806, 12936887700, 12937016609, 12937135097, 12939014597, 12945364777, 12945456452, 14374800823, 14367118483, 13674780763,

--- a/MainModule/Server/Dependencies/DefaultSettings.luau
+++ b/MainModule/Server/Dependencies/DefaultSettings.luau
@@ -302,7 +302,6 @@ settings.AutoClean = false		           -- Will auto clean workspace of things li
 settings.AutoCleanDelay = 60	           -- Time between auto cleans
 settings.AutoBackup = false 	           -- Run :backupmap automatically when the server starts. To restore the map, run :restoremap
 settings.ReJail = false			           -- If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed
-settings.DisableRejoinAtMaxPlayers = false -- If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount.
 
 settings.Console = true				-- Whether the command console is enabled
 settings.Console_AdminsOnly = false -- If true, only admins will be able to access the console
@@ -474,7 +473,6 @@ descs.CodeExecution = [[ Enables the use of code execution in Adonis; Scripting 
 descs.SongHint = [[ Display a hint with the current song name and ID when a song is played via :music ]]
 descs.TopBarShift = [[ By default hints and notifs will appear from the top edge of the window. Set this to true if you don't want hints/notifications to appear in that region. ]]
 descs.ReJail = [[ If true then when a player rejoins they'll go back into jail. Or if the moderator leaves everybody gets unjailed ]]
-descs.DisableRejoinAtMaxPlayers = [[ If true, disables rejoin when max players is reached to avoid an exploit that allows more players than the max amount. ]]
 
 descs.Messages = [[ A list of notification messages to show HeadAdmins and above on join ]]
 
@@ -592,7 +590,6 @@ order = {
 	"SongHint";
 	"TopBarShift";
 	"ReJail";
-	"DisableRejoinAtMaxPlayers";
 	"";
 	"AutoClean";
 	"AutoCleanDelay";


### PR DESCRIPTION
It's for a niche purpose and exists to counter an issue on Robloxes side. It's still toggleable, just not visible anymore.

I'm fine with it being turned on (if it respects past setting and doesn't override it).