### PR TITLE
*Finally fixes a very big longstanding issue!* Fix erroneous plugins bricking Adonis

### DIFF
--- a/Loader/Loader/Loader.server.luau
+++ b/Loader/Loader/Loader.server.luau
@@ -125,7 +125,7 @@ else
 		warn("[DEVELOPER ERROR] Settings module errored while loading; Using defaults; Error Message: ", setTab)
 		table.insert(data.Messages, {
 			Title = "Warning!";
-			Icon = "rbxassetid://7495468117";
+			Icon = "maticon://Dangerous";
 			Message = "Settings module error detected; using default settings.";
 			Time = 15;
 		})

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -977,7 +977,6 @@ return function(Vargs, GetEnv)
 					local newVer = (level > 300) and tonumber(string.match(server.Changelog[1], "Version: (.*)"))
 
 					if Settings.Notification then
-
 						task.wait(1)
 						Functions.Notification("Welcome.", `Your rank is {rank} ({level}). Click here for commands.`, {p}, 15, "MatIcon://Verified user", Core.Bytecode(`client.Remote.Send("ProcessCommand","{Settings.Prefix}cmds")`))
 
@@ -1005,9 +1004,20 @@ return function(Vargs, GetEnv)
 							]]))
 						end
 
-						if level >= 300 and #Settings.Messages > 0 then
-							for _, Message in Settings.Messages do
-								task.delay(1, Functions.Notification, "Message", tostring(Message), {p}, math.round((#Message/19)+2.5))
+						if level >= 300 and #server.Messages > 0 then
+							for _, message in server.Messages do
+								local isString = type(message) == "string"
+
+								task.delay(
+									1,
+									Functions.Notification,
+									not isString and message.Title or "Message",
+									isString and message or not isString and message.Message or "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+									{p},
+									isString and math.round((#body/19)+2.5) or not isString and message.Time or 10,
+									not isString and message.Icon,
+									not isStringonClick
+								)
 							end
 						end
 					end

--- a/MainModule/Server/Server.luau
+++ b/MainModule/Server/Server.luau
@@ -688,7 +688,7 @@ return service.NewProxy({
 		end
 
 		--// Load Plugins; enforced NoEnv policy, make sure your plugins has the 2nd argument defined!
-		for _, module in ipairs(server.PluginsFolder:GetChildre()) do
+		for _, module in ipairs(server.PluginsFolder:GetChildren()) do
 			LoadModule(module, false, {script = module}, true, true) --noenv
 		end
 
@@ -699,8 +699,8 @@ return service.NewProxy({
 				table.insert(server.messages, {
 					Title = `The plugin {type(module) == "string" and string.sub(module, 1, 15) or module} failed to load!`,
 					Icon = "maticon://Dangerous",
-					Message = string.match(reason, "Requested module experienced an error while loading") and "Invalid code or code errors before return!" or string.match(reason, "Module code did not return exactly one value") and "The plugin returns an invalid amount of values or returns nothing at all!" or `Reason {reason}`
-					Time
+					Message = string.match(reason, "Requested module experienced an error while loading") and "The plugin has invalid code or the code fails before return!" or string.match(reason, "Module code did not return exactly one value") and "The plugin returns an invalid amount of values or returns nothing at all!" or `Reason {reason}`,
+					Time = 15
 				})
 			end, module, false, {script = module, cPcall = server.cPcall})
 		end

--- a/MainModule/Server/Server.luau
+++ b/MainModule/Server/Server.luau
@@ -688,12 +688,21 @@ return service.NewProxy({
 		end
 
 		--// Load Plugins; enforced NoEnv policy, make sure your plugins has the 2nd argument defined!
-		for _, module in ipairs(server.PluginsFolder:GetChildren()) do
+		for _, module in ipairs(server.PluginsFolder:GetChildre()) do
 			LoadModule(module, false, {script = module}, true, true) --noenv
 		end
 
 		for _, module in ipairs(data.ServerPlugins or {}) do
-			LoadModule(module, false, {script = module, cPcall = server.cPcall})
+			xpcall(LoadModule, function(reason)
+				warn(`The plugin {type(module) == "string" and string.sub(module, 1, 15) or module} failed to load! Reason: {reason}`)
+				logerror(`The plugin {type(module) == "string" and string.sub(module, 1, 15) or module} failed to load! Reason: {reason}`)
+				table.insert(server.messages, {
+					Title = `The plugin {type(module) == "string" and string.sub(module, 1, 15) or module} failed to load!`,
+					Icon = "maticon://Dangerous",
+					Message = string.match(reason, "Requested module experienced an error while loading") and "Invalid code or code errors before return!" or string.match(reason, "Module code did not return exactly one value") and "The plugin returns an invalid amount of values or returns nothing at all!" or `Reason {reason}`
+					Time
+				})
+			end, module, false, {script = module, cPcall = server.cPcall})
 		end
 
 		--// We need to do some stuff *after* plugins are loaded (in case we need to be able to account for stuff they may have changed before doing something, such as determining the max length of remote commands)
@@ -738,7 +747,7 @@ return service.NewProxy({
 				Desc = "Adonis has finished loading";
 			})
 		else
-			warn("SERVER.LOGS TABLE IS MISSING. THIS SHOULDN'T HAPPEN! SOMETHING WENT WRONG WHILE LOADING CORE MODULES(?)");
+			warn("CRITICAL ERROR! SERVER.LOGS TABLE IS MISSING. THIS SHOULDN'T HAPPEN! SOMETHING WENT WRONG WHILE LOADING CORE MODULES(?)");
 		end
 		service.Events.ServerInitialized:Fire();
 


### PR DESCRIPTION
*Finally fixes a very big longstanding issue!* 

This makes it so that erroneous plugins will no longer prevent Adonis from loading. Also a user friendly debug message is displayed for most common cases of plugin failure.
This makes debugging failing plugins a lot more easier and will especially help a lot of noobs that struggle with this.

Also fixes data.Messages not being displayed as a bonus. 