### PR TITLE
Lock server on soft shutdown

### DIFF
--- a/MainModule/Server/Plugins/Server-SoftShutdown.luau
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.luau
@@ -84,6 +84,7 @@ return function(Vargs, GetEnv)
 					TeleportService:TeleportToPlaceInstance(game.PlaceId, jobid, player, "", {[PARAMETER_2_NAME] = true})
 				end
 			end)
+
 			for _, player in service.Players:GetPlayers() do
 				teleport(player)
 			end
@@ -102,6 +103,7 @@ return function(Vargs, GetEnv)
 		Function = function(p,args,data)
 			if service.RunService:IsStudio() then return end
 			if #Players:GetPlayers() == 0 then return end
+			Variables.ServerLock = true
 
 			local newserver = TeleportService:ReserveServer(game.PlaceId)
 			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
@@ -135,6 +137,7 @@ return function(Vargs, GetEnv)
 		AdminLevel = "Admins";
 		Function = function(plr: Player, args: {string})
 			if #Players:GetPlayers() == 0 then return end
+			Variables.ServerLock = true
 
 			if Core.DataStore then
 				Core.UpdateData("ShutdownLogs", function(logs)
@@ -161,7 +164,6 @@ return function(Vargs, GetEnv)
 					return logs
 				end)
 			end
-
 
 			local newserver = TeleportService:ReserveServer(game.PlaceId)
 			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)


### PR DESCRIPTION
I'm not saying this should be merged but I'm saying the idea should be re-visited at least.

Locks servers that are soft shutdowned. Prevents hackers and players from joining servers that are shut down and prevents potential infinite teleport loops.