### PR TITLE
Close BTools and/or invalid tickets automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -37,6 +37,7 @@ body:
         - GitHub Repository
         - Anti-Exploit
         - Trello
+        - F3X/Building Tools
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yml
@@ -19,6 +19,8 @@ body:
         - Documentation
         - GitHub Repository
         - Anti-Exploit
+        - Trello
+        - F3X/Building Tools
         - Other
     validations:
       required: true

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,5 +10,9 @@
   - '### What part of Adonis is this related to\?\s+GitHub Repository'
 '🖇️ loader':
   - '### What part of Adonis is this related to\?\s+Loader/Settings'
+'trello':
+  - '### What part of Adonis is this related to\?\s+Trello'
+'❌ invalid'
+  - '### What part of Adonis is this related to\?\s+F3X/Building Tools'
 '🎏 miscellaneous':
   - '### What part of Adonis is this related to\?\s+Other'

--- a/.github/workflows/close_issues.yml
+++ b/.github/workflows/close_issues.yml
@@ -1,0 +1,23 @@
+name: Close invalid issues
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.1
+
+      - name: Close issue
+        if: github.event.label.name == '❌ invalid' && !(contains(github.event.issue.body, 'F3X/Building Tools')) &&
+        run: gh issue close --comment "This issue has been closed as invalid. Please look at our [contribution guide](https://github.com/Epix-Incorporated/Adonis/blob/master/CONTRIBUTING.md)" --reason "not planned" "1"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close BTools issue 
+        if: github.event.label.name == '❌ invalid' && (contains(github.event.issue.body, 'F3X/Building Tools')) &&
+        run: gh issue close --comment "We use F3X for our building tools system. Please [make an issue ticket](https://github.com/F3XTeam/RBX-Building-Tools/issues/new) on the F3X Team BTools repository. \~ Yours truly - E🅱️ix Agents" --reason "not planned" "1"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Closes all invalid tickets automatically and gives feedback to user
- Labels F3X tickets as invalid automatically
- Fixes Trello not being in the feature requests page
- Fix Trello not being labeled