### PR TITLE
Enforce LF linefeed for .txt files too

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,3 +30,6 @@ end_of_line = lf
 
 [*.rbxmx]
 end_of_line = lf
+
+[*.txt]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,5 @@
 *.toml eol=lf
 *.yml text=auto
 *.yml eol=lf
+*.txt text=auto
+*.txt eol=lf


### PR DESCRIPTION
This classification is missing from .txt files