### PR TITLE
Optimize linkedlists

### DIFF
--- a/MainModule/Server/Shared/DoubleLinkedList.luau
+++ b/MainModule/Server/Shared/DoubleLinkedList.luau
@@ -34,27 +34,26 @@ function LinkNode:Destroy()
 end
 
 --[==[
-    LinkedNode end
+	LinkedNode end
 ]==]
 
 function LinkedList.new()
 	local self = setmetatable({}, LinkedList)
-	
+
 	self.snode = nil
 	self.enode = nil
-	
+
 	self.count = 0
-	
+
 	return self
 end
 
 function LinkedList:IsReal()
-    --// this is a ghost function
-    --// don't remove it
+	--// this is a ghost function
+	--// don't remove it
 end
 
 function LinkedList:AddStart(data)
-	
 	local old = self.snode
 	local newNode = LinkNode.new(data)
 	newNode:setprev(nil)
@@ -65,13 +64,11 @@ function LinkedList:AddStart(data)
 	end
 	newNode:setnext(old)
 	self.snode = newNode
-	
+
 	self.count += 1
-	
 end
 
 function LinkedList:AddEnd(data)
-
 	local old = self.enode
 	local newNode = LinkNode.new(data)
 	newNode:setnext(nil)
@@ -82,9 +79,8 @@ function LinkedList:AddEnd(data)
 	end
 	newNode:setprev(old)
 	self.enode = newNode
-	
+
 	self.count += 1
-	
 end
 
 function LinkedList:AddToStartAndRemoveEndIfEnd(data, limit)
@@ -95,79 +91,75 @@ function LinkedList:AddToStartAndRemoveEndIfEnd(data, limit)
 end
 
 function LinkedList:AddBetweenNodes(data, left, right)
-	
 	if not left or not right then
 		return false
 	end
-	
+
 	local newNode = LinkNode.new(data)
 	newNode:setnext()
 	newNode:setprev()
-	
+
 	left:setnext(newNode)
 	right:setprev(newNode)
-	
+
 	self.count += 1
-	
 end
 
 function LinkedList:RemoveNode(node)
-	
 	local prev = node.prev
 	local nextN = node.next
 
 	if self.snode == node then
 		self.snode = nextN
 	end
-	
+
 	if self.enode == node then
 		self.enode = prev
 	end
-	
+
 	if nextN then
 		nextN:setprev(prev)
 	end
 	if prev then
 		prev:setnext(nextN)
 	end
-	
+
 	node:setnext(nil)
 	node:setprev(nil)
-	
+
 	node:Destroy()
-	
+
 	self.count -= 1
-	
 end
 
-function LinkedList:Get(val : any)
-	local nodes = {}
+function LinkedList:Get(val: any)
+	local nodes = table.create(self.count)
 	local curr = self.snode 
-	local tinsert = table.insert
+
 	while curr and type(curr) == "table" do 
 		if val then 
-            --// Pass a function and Adonis will pass through the current node into it
-            --// Return true to add it to the "list"
-            --// Final list will be returned after the call
-            --// Passed value:
-            --[==[
-                Node: 
-                    .data: The data inside of the node
-                    .next: The next node in the list
-                    .prev: The previous node in the list
-            ]==]
-            if type(val) == "function" then
-                local success, found = pcall(val, curr)
-                if success and found then
-                    tinsert(nodes, curr)
-                end
-            else 
-                if curr.data == val then
-                    tinsert(nodes, curr)
-                end
-            end
+			--// Pass a function and Adonis will pass through the current node into it
+			--// Return true to add it to the "list"
+			--// Final list will be returned after the call
+			--// Passed value:
+			--[==[
+				Node: 
+					.data: The data inside of the node
+					.next: The next node in the list
+					.prev: The previous node in the list
+			]==]
+			if type(val) == "function" then
+				local success, found = pcall(val, curr)
+				if success and found then
+					table.insert(nodes, curr)
+				end
+			else 
+				if curr.data == val then
+					table.insert(nodes, curr)
+				end
+			end
 		else
-			tinsert(nodes, curr)
+			table.insert(nodes, curr)
 		end
 		curr = curr.next
 	end
@@ -175,42 +167,42 @@ function LinkedList:Get(val : any)
 end
 
 --// Returns a list of all passing notes with data
-function LinkedList:GetAsTable(val : any)
-	local nodes = {}
+function LinkedList:GetAsTable(val: any)
+	local nodes = table.create(self.count)
 	local curr = self.snode 
-	local tinsert = table.insert
+
 	while curr and type(curr) == "table" do 
-        --// Pass a function and Adonis will pass through the current node into it
-        --// Return true to add it to the "list"
-        --// Final list will be returned after the call
-        --// Passed value:
-        --[==[
-            Node: 
-                .data: The data inside of the node
-                .next: The next node in the list
-                .prev: The previous node in the list
-        ]==]
+		--// Pass a function and Adonis will pass through the current node into it
+		--// Return true to add it to the "list"
+		--// Final list will be returned after the call
+		--// Passed value:
+		--[==[
+			Node: 
+				.data: The data inside of the node
+				.next: The next node in the list
+				.prev: The previous node in the list
+		]==]
 		if val then 
-            if type(val) == "function" then
-                local success, found = pcall(val, curr)
-                if success and found then
-                    tinsert(nodes, curr.data)
-                end
-            else 
-                if curr.data == val then
-                    tinsert(nodes, curr.data)
-                end
-            end
-        else 
-            tinsert(nodes, curr.data)
-        end
+			if type(val) == "function" then
+				local success, found = pcall(val, curr)
+				if success and found then
+					table.insert(nodes, curr.data)
+				end
+			else 
+				if curr.data == val then
+					table.insert(nodes, curr.data)
+				end
+			end
+		else 
+			table.insert(nodes, curr.data)
+		end
 		curr = curr.next
 	end
 	return nodes
 end
 
 function LinkedList:Destroy()
-	for i,_ in self do
+	for i, _ in self do
 		self[i] = nil
 	end
 	setmetatable(self, nil)


### PR DESCRIPTION
- Pre-allocate LL -> table conversion table size. Avoids repeated allocations for large tables. Speeds up oldlogs saving
- Use a builtin for `table.insert` for the LL -> table conversion
