### PR TITLE
Add preliminary support for oldlogs encryption 

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -6669,11 +6669,11 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			ListUpdater = function(plr: Player)
 				if Core.DataStore then
-					local tab = table.create(1000)
+					local tab = table.create(Logs.OldCommandLogsLimit)
 					local data = Core.GetData("OldCommandLogs")
 					if data then
-						for i, v in service.HttpService:JSONDecode(data) do
-							table.insert(tab, i, {
+						for i, v in Logs.DeserializeOldlogs(data) do
+							tab[i] = {
 								Time = v.Time,
 								Text = `{v.Text}: {v.Desc}`,
 								Desc = v.Desc

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -6677,7 +6677,7 @@ return function(Vargs, env)
 								Time = v.Time,
 								Text = `{v.Text}: {v.Desc}`,
 								Desc = v.Desc
-							})
+							}
 						end
 					end
 					return tab

--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -137,7 +137,7 @@ return function(Vargs, GetEnv)
 				end
 			end
 
-			return service.HttpService:JSONDecode(oldLogs)
+			return service.HttpService:JSONDecode(data)
 		end;
 
 		SaveCommandLogs = function()

--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -105,7 +105,7 @@ return function(Vargs, GetEnv)
 		-- // Preliminary support for oldlog encryption
 		DeserializeOldlogs = function(data)
 			if string.sub(data, 1, 1) ~= "[" and string.match(data, "^[%w%+/=]+$") then
-				data = Remote.Decrypt(Functions.Base64Decode(data), Settings.DataStoreKey)
+				data = Remote.NewDecrypt(Functions.Base64Decode(data), Settings.DataStoreKey)
 
 				if string.sub(data, 1, 2) == "\x1f\x8b" then -- Check for Gzip header and decode
 					data = assert(Functions.GzipDecompress, "No support for Gzip encoding!")(data)

--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -161,7 +161,7 @@ return function(Vargs, GetEnv)
 					xpcall(function()
 						oldLogs = Logs.DeserializeOldlogs(oldLogs)
 					end, function(reason)
-						oldLogs = nil
+						oldLogs = {}
 						warn(`Deserializing oldlogs failed due to {reason}`)
 					end)
 				end

--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -132,7 +132,7 @@ return function(Vargs, GetEnv)
 
 				if string.sub(data, 1, 2) == "\x1f\x8b" then -- Check for Gzip header and decode
 					data = assert(Functions.GzipDecompress, "No support for Gzip encoding!")(data)
-				else string.match(data, "^\x78[\x01\x5e\x9c\xda\x20\x7d\xbb\xf9]") then -- Check for Zlib header and decode
+				elseif string.match(data, "^\x78[\x01\x5e\x9c\xda\x20\x7d\xbb\xf9]") then -- Check for Zlib header and decode
 					data = assert(Functions.ZlibDecompress, "No support for Zlib encoding!")(data)
 				end
 			end

--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -125,6 +125,19 @@ return function(Vargs, GetEnv)
 			return auditLogs
 		end;
 
+		-- // Preliminary support for oldlog encryption
+		DeserializeOldlogs = function(data)
+			if string.sub(data, 1, 1) ~= "[" and string.match(data, "^[%w%+/=]+$") then
+				data = Remote.Decrypt(Functions.Base64Decode(data), Settings.DataStoreKey)
+
+				if string.sub(data, 1, 2) == "\x1f\x8b" then -- Check for GZIP header and decode
+					data = Functions.GZIPDecode(data)
+				end
+			end
+
+			return service.HttpService:JSONDecode(oldLogs)
+		end;
+
 		SaveCommandLogs = function()
 			--// Disable saving command logs in Studio; not required.
 			if service.RunService:IsStudio() or service.RunService:IsRunMode() then
@@ -143,7 +156,12 @@ return function(Vargs, GetEnv)
 
 			Core.UpdateData("OldCommandLogs", function(oldLogs)
 				if type(oldLogs) == "string" then
-					oldLogs = service.HttpService:JSONDecode(oldLogs)
+					xpcall(function()
+						oldLogs = Logs.DeserializeOldlogs(oldLogs)
+					end, function(reason)
+						oldLogs = nil
+						warn(`Deserializing oldlogs failed due to {reason}`)
+					end)
 				end
 
 				local temp = {}

--- a/MainModule/Server/Core/Logs.luau
+++ b/MainModule/Server/Core/Logs.luau
@@ -130,8 +130,10 @@ return function(Vargs, GetEnv)
 			if string.sub(data, 1, 1) ~= "[" and string.match(data, "^[%w%+/=]+$") then
 				data = Remote.Decrypt(Functions.Base64Decode(data), Settings.DataStoreKey)
 
-				if string.sub(data, 1, 2) == "\x1f\x8b" then -- Check for GZIP header and decode
-					data = Functions.GZIPDecode(data)
+				if string.sub(data, 1, 2) == "\x1f\x8b" then -- Check for Gzip header and decode
+					data = assert(Functions.GzipDecompress, "No support for Gzip encoding!")(data)
+				else string.match(data, "^\x78[\x01\x5e\x9c\xda\x20\x7d\xbb\xf9]") then -- Check for Zlib header and decode
+					data = assert(Functions.ZlibDecompress, "No support for Zlib encoding!")(data)
 				end
 			end
 


### PR DESCRIPTION
Add preliminary support for oldlogs encryption

To prevent new servers closing and setting encrypted data and then old servers closing later and failing.