### PR TITLE
Add new encryption function

### DIFF
--- a/MainModule/Client/Core/Process.luau
+++ b/MainModule/Client/Core/Process.luau
@@ -97,7 +97,7 @@ return function(Vargs, GetEnv)
 						client.Finish_Loading()
 					end
 				elseif Core.Key then
-					local comString = Remote.Decrypt(com,Core.Key)
+					local comString = Remote.NewDecrypt(com,Core.Key)
 					local command = (data.Mode == "Get" and Remote.Returnables[comString]) or Remote.Commands[comString]
 					if command then
 						local rets = {service.TrackTask(`Remote: {comString}`, command, false, args)}

--- a/MainModule/Client/Core/Remote.luau
+++ b/MainModule/Client/Core/Remote.luau
@@ -379,7 +379,7 @@ return function(Vargs, GetEnv)
 
 		Send = function(com,...)
 			Core.LastUpdate = os.time()
-			Remote.Fire(Remote.Encrypt(com,Core.Key),...)
+			Remote.Fire(Remote.NewEncrypt(com,Core.Key),...)
 		end;
 
 		GetFire = function(...)
@@ -434,7 +434,7 @@ return function(Vargs, GetEnv)
 
 		Get = function(com,...)
 			Core.LastUpdate = os.time()
-			local ret = Remote.GetFire(Remote.Encrypt(com,Core.Key),...)
+			local ret = Remote.GetFire(Remote.NewEncrypt(com,Core.Key),...)
 			if type(ret) == "table" then
 				return unpack(ret);
 			else

--- a/MainModule/Client/Core/Remote.luau
+++ b/MainModule/Client/Core/Remote.luau
@@ -45,6 +45,9 @@ return function(Vargs, GetEnv)
 		Functions = client.Functions;
 		Process = client.Process;
 		Remote = client.Remote;
+		Remote.NewDecrypt = function(str, key, cache) -- Bxor works both ways. May want to make a seperate function tho
+			return Remote.NewEncrypt(str, key, cache or Remote.NewDecodeCache)
+		end;
 
 		Remote.Init = nil;
 	end
@@ -92,6 +95,8 @@ return function(Vargs, GetEnv)
 		PendingReturns = {};
 		EncodeCache = {};
 		DecodeCache = {};
+		NewEncodeCache = {};
+		NewDecodeCache = {};
 		Received = 0;
 		Sent = 0;
 
@@ -516,6 +521,29 @@ return function(Vargs, GetEnv)
 				for i = 1, #str do
 					local keyPos = (i % keyLen) + 1
 					writeu8(rawStr, (readu8(rawStr, i) - readu8(rawKey, keyPos)) % 126 - 1)
+				end
+
+				cache[key] = keyCache
+				keyCache[str], keyCache[1] = buffer.tostring(rawStr), rawKey
+				return keyCache[str]
+			end
+		end;
+
+		NewEncrypt = function(str: string, key: string, cache: {[string]: (buffer|{[string]: string})}?)
+			cache = cache or Remote.NewEncodeCache or {}
+			local keyCache = cache[key] or {}
+
+			if not key or not str then
+				return str
+			elseif keyCache[str] then
+				return keyCache[str]
+			else
+				local writeu8, readu8, bxor = buffer.writeu8, buffer.readu8, bit32.bxor
+				local rawStr, rawKey = buffer.fromstring(str), keyCache[1] or buffer.fromstring(key)
+				local keyLen = #key
+
+				for i = 0, #str - 1 do
+					writeu8(rawStr, bxor(readu8(rawStr, i), readu8(rawKey, i % keyLen)))
 				end
 
 				cache[key] = keyCache

--- a/MainModule/Client/Core/Remote.luau
+++ b/MainModule/Client/Core/Remote.luau
@@ -543,7 +543,7 @@ return function(Vargs, GetEnv)
 				local keyLen = #key
 
 				for i = 0, #str - 1 do
-					writeu8(rawStr, bxor(readu8(rawStr, i), readu8(rawKey, i % keyLen)))
+					writeu8(rawStr, i, bxor(readu8(rawStr, i), readu8(rawKey, i % keyLen)))
 				end
 
 				cache[key] = keyCache

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -26,8 +26,8 @@ return function(Vargs, GetEnv)
 		logError = logError or env.logError;
 		Routine = Routine or env.Routine;
 		Commands = Remote.Commands
-		Decrypt = Remote.Decrypt
-		Encrypt = Remote.Encrypt
+		Decrypt = Remote.NewDecrypt
+		Encrypt = Remote.NewEncrypt
 		AddLog = Logs.AddLog
 		TrackTask = service.TrackTask
 		Pcall = server.Pcall

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -1144,7 +1144,7 @@ return function(Vargs, GetEnv)
 			assert(p and p:IsA("Player"), `Remote.Send: {p.Name} is not a valid Player`)
 			local keys = Remote.Clients[tostring(p.UserId)]
 			if keys and keys.RemoteReady == true then
-				Remote.Fire(p, Remote.Encrypt(com, keys.Key, keys.Cache), ...)
+				Remote.Fire(p, Remote.NewEncrypt(com, keys.Key, keys.Cache), ...)
 			end
 		end;
 
@@ -1160,7 +1160,7 @@ return function(Vargs, GetEnv)
 		Get = function(p: Player, com: string, ...)
 			local keys = Remote.Clients[tostring(p.UserId)]
 			if keys and keys.RemoteReady == true then
-				local ret = Remote.GetFire(p, Remote.Encrypt(com, keys.Key, keys.Cache), ...)
+				local ret = Remote.GetFire(p, Remote.NewEncrypt(com, keys.Key, keys.Cache), ...)
 				if type(ret) == "table" then
 					return unpack(ret)
 				else

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -28,8 +28,10 @@ return function(Vargs, GetEnv)
 		Settings = server.Settings;
 		Defaults = server.Defaults.Settings;
 		Commands = server.Commands;
-
 		logError = env.logError;
+		Remote.NewDecrypt = function(str, key, cache) -- Bxor works both ways. May want to make a seperate function tho
+			return Remote.NewEncrypt(str, key, cache or Remote.NewDecodeCache)
+		end;
 
 		Remote.Init = nil;
 		Logs:AddLog("Script", "Remote Module Initialized")
@@ -60,6 +62,8 @@ return function(Vargs, GetEnv)
 		PendingReturns = {};
 		EncodeCache = {};
 		DecodeCache = {};
+		NewEncodeCache = {};
+		NewDecodeCache = {};
 		RemoteExecutionConfirmed = {};
 
 		TimeUntilKeyDestroyed = 60 * 5; --// How long until a player's key data should be completely removed?
@@ -1387,6 +1391,29 @@ return function(Vargs, GetEnv)
 				for i = 1, #str do
 					local keyPos = (i % keyLen) + 1
 					writeu8(rawStr, (readu8(rawStr, i) - readu8(rawKey, keyPos)) % 126 - 1)
+				end
+
+				cache[key] = keyCache
+				keyCache[str], keyCache[1] = buffer.tostring(rawStr), rawKey
+				return keyCache[str]
+			end
+		end;
+
+		NewEncrypt = function(str: string, key: string, cache: {[string]: (buffer|{[string]: string})}?)
+			cache = cache or Remote.NewEncodeCache or {}
+			local keyCache = cache[key] or {}
+
+			if not key or not str then
+				return str
+			elseif keyCache[str] then
+				return keyCache[str]
+			else
+				local writeu8, readu8, bxor = buffer.writeu8, buffer.readu8, bit32.bxor
+				local rawStr, rawKey = buffer.fromstring(str), keyCache[1] or buffer.fromstring(key)
+				local keyLen = #key
+
+				for i = 0, #str - 1 do
+					writeu8(rawStr, bxor(readu8(rawStr, i), readu8(rawKey, i % keyLen)))
 				end
 
 				cache[key] = keyCache

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -1413,7 +1413,7 @@ return function(Vargs, GetEnv)
 				local keyLen = #key
 
 				for i = 0, #str - 1 do
-					writeu8(rawStr, bxor(readu8(rawStr, i), readu8(rawKey, i % keyLen)))
+					writeu8(rawStr, i, bxor(readu8(rawStr, i), readu8(rawKey, i % keyLen)))
 				end
 
 				cache[key] = keyCache


### PR DESCRIPTION
Fixes #1701

This uses a bitwise bxor instead of a rot based algorithm, and it supports the full 255 8bit range instead of 127 7bit range. Also faster, at least with optimized environment.

PoF:
![image](https://github.com/user-attachments/assets/5030e55e-6222-4362-b828-6110a82d03bf)
![image](https://github.com/user-attachments/assets/61c6b752-27c6-4c62-aabc-bffe97713a88)
![image](https://github.com/user-attachments/assets/304cff5d-eec7-4e56-b5ef-94b30b22575b)

PoF script:
```lua
-- Constants

local STRING_AMOUNT = 5e4
local STRING_MAX_LEN = 6e3
local STRING_MIN_CHAR = 1
local STRING_MAX_CHAR = 125
local ALLOW_ERROR = true

-- Code
local Remote = {}

local function hexEncode(data)
	local isString = type(data) == "string"
	local lenght = isString and string.len(data) or buffer.len(data)
	local encoded = {}
	
	if isString then
		for i = 1, lenght do
			encoded[i] = string.format("%02x", string.byte(data, i, i))
		end
	else
		for i = 1, lenght do
			encoded[i] = string.format("%02x", buffer.readu8(data, i - 1))
		end
	end

	return string.upper(table.concat(encoded, " "))
end

local NewEncrypt = function(str: string, key: string, cache: {[string]: (buffer|{[string]: string})}?)
	cache = cache or Remote.NewEncodeCache or {}
	local keyCache = cache[key] or {}

	if not key or not str then
		return str
	elseif keyCache[str] then
		return keyCache[str]
	else
		local writeu8, readu8, bxor = buffer.writeu8, buffer.readu8, bit32.bxor
		local rawStr, rawKey = buffer.fromstring(str), keyCache[1] or buffer.fromstring(key)
		local keyLen = #key

		for i = 0, #str - 1 do
			writeu8(rawStr, i, bxor(readu8(rawStr, i), readu8(rawKey, i % keyLen)))
		end

		cache[key] = keyCache
		keyCache[str], keyCache[1] = buffer.tostring(rawStr), rawKey
		return keyCache[str]
	end
end;

local NewDecrypt = function(str, key, cache) -- Bxor works both ways. May want to make a seperate function tho
	return NewEncrypt(str, key, cache or Remote.NewDecodeCache)
end;

task.wait(5)
print("Creating character list...")
task.wait()

local strings = table.create(STRING_AMOUNT)
local rawLenght = 0

for i = 1, STRING_AMOUNT do
	local str = buffer.create(math.random(1, STRING_MAX_LEN))

	for i2 = 0, buffer.len(str) - 1 do
		buffer.writeu8(str, i2, math.random(STRING_MIN_CHAR, STRING_MAX_CHAR))
	end

	if i % 2 ~= 0 then
		rawLenght += buffer.len(str)
	end
	strings[i] = buffer.tostring(str)
end

print("Encrypting characters...")
task.wait(0.1)
local amount = 0
local encryptedLenght = 0
local start = os.clock()

for i = 1, STRING_AMOUNT, 2 do
	local str, key = assert(strings[i], "String is missing!"), assert(strings[i + 1], "Key is missing!")
	local newEncVal = NewEncrypt(str, key)
	local newDecVal = NewDecrypt(newEncVal, key)
	local strLen, newEncLen = string.len(str), string.len(newEncVal)

	assert(type(newEncVal) == "string", "New encryption value isn't a string!")
	assert(type(newDecVal) == "string", "New decryption value isn't a string!")
	assert(xpcall(function()
		assert(newEncLen == strLen, "New encryption value has an incorrect length!")
		assert(newDecVal == str, "New decryption value isn't original!")
		assert(newEncVal ~= str, "New encryption value isn't encrypted! V1")
		assert(newEncVal ~= newDecVal, "New encryption value isn't encrypted! V2")
	end, function(reason)
		warn(`Encrypting of string #{math.floor(i / 2) + 1} failed due to: {reason}`)
		print(`Key:\t{hexEncode(key)}\nSourceStr:\t{hexEncode(str)}\nNewEncrypt:\t{hexEncode(newEncVal)}\nNewDecrypt:\t{hexEncode(newDecVal)}}`)
	end) or ALLOW_ERROR, "Invalid encrypted string data!")

	amount += 1
	encryptedLenght += newEncLen
end

assert(encryptedLenght == rawLenght, `Amount of characters doesn't match! Encrypted lenght: {encryptedLenght} Raw lenght: {rawLenght}`)
print("Encryption funcs successfully tested. Amount tested:", amount, "Amount of strings:", #strings, "Took:", tostring(os.clock() - start), "seconds", "Amount of characters encrypted:", encryptedLenght)
```
