### PR TITLE
Fix lint error in nightly

### DIFF
--- a/MainModule/Server/Dependencies/ClientLoader.client.luau
+++ b/MainModule/Server/Dependencies/ClientLoader.client.luau
@@ -144,7 +144,7 @@ local function checkChild(child)
 
 		print("Getting origName")
 		origName = nameVal and nameVal.Value or child.Name
-		prit(`Got name: {origName}`)
+		print(`Got name: {origName}`)
 
 		print("Changing child parent...")
 		child.Parent = nil
@@ -241,7 +241,7 @@ else
 	if not playerGui then
 		warn("PlayerGui not found after 10 minutes")
 		Kick(player, "ACLI: PlayerGui Never Appeared (Waited 10 Minutes)")
-	else
+	--else
 		--playerGui.Changed:Connect(function() -- How about no
 		--	if playerGui.Name ~= "PlayerGui" then
 		--		playerGui.Name = "PlayerGui"


### PR DESCRIPTION
Fixes a lint error in nightly. So apparently Selene did not work at all for one of the pulls so this got through. Anyways the `ClientLoader` file that it was on is not used at all so it could safely be deleted later.