### PR TITLE
Allow giving input text to notepad

### DIFF
--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -113,11 +113,11 @@ return function(Vargs, env)
 		Notepad = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"notepad", "stickynote"};
-			Args = {};
+			Args = {"text (optional)"};
 			Description = "Opens a textbox window for you to type into";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				Remote.MakeGui(plr, "Notepad", {})
+				Remote.MakeGui(plr, "Notepad", {Text = args[1]})
 			end
 		};
 


### PR DESCRIPTION
This is useful for a variety of reasons like aliases, unix like command pipes, keybinds etc.