### PR TITLE
Allow moderators to run `:sudo` and remove `:showlogs`

### DIFF
--- a/MainModule/Server/Commands/Creators.luau
+++ b/MainModule/Server/Commands/Creators.luau
@@ -190,22 +190,6 @@ return function(Vargs, env)
 			end
 		};
 
-		Sudo = {
-			Prefix = Settings.Prefix;
-			Commands = {"sudo"};
-			Args = {"player", "command"};
-			Description = "Runs a command as the target player(s)";
-			AdminLevel = "Creators";
-			CrossServerDenied = true;
-			Function = function(plr: Player, args: {string})
-				assert(args[1], "Missing target player (argument #1)")
-				assert(args[2], "Missing command string (argument #2)")
-				for _, v in service.GetPlayers(plr, args[1], {NoFakePlayer = true}) do
-					task.defer(Process.Command, v, args[2], {isSystem = true})
-				end
-			end
-		};
-
 		ClearPlayerData = {
 			Prefix = Settings.Prefix;
 			Commands = {"clearplayerdata", "clrplrdata", "clearplrdata", "clrplayerdata"};

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -6689,24 +6689,6 @@ return function(Vargs, env)
 			end
 		};
 
-		ShowLogs = {
-			Prefix = Settings.Prefix;
-			Commands = {"showlogs", "showcommandlogs"};
-			Args = {"autoupdate? (default: false)", "player"};
-			Description = "Shows the target player(s) the command logs.";
-			AdminLevel = "Moderators";
-			Function = function(plr: Player, args: {string})
-				local autoUpdate = false
-				if args[1] and table.find({"yes", "true", "1", "autoupdate", "on"}, args[1]:lower()) then
-					autoUpdate = true
-				end
-				local str = `{Settings.Prefix}logs {tostring(autoUpdate) or ""}`
-				for _, v in service.GetPlayers(plr, args[2]) do
-					Admin.RunCommandAsPlayer(str, v)
-				end
-			end
-		};
-
 		Mute = {
 			Prefix = Settings.Prefix;
 			Commands = {"mute", "silence"};
@@ -6931,7 +6913,6 @@ return function(Vargs, env)
 				local ReverbType = Enum.ReverbType
 				local reverbs = ReverbType:GetEnumItems()
 				if not rev or not ReverbType[rev] then
-
 					Functions.Hint("Reverb type was not specified or is invalid. Opening list of valid reverb types", {plr})
 
 					local tab = table.create(#reverbs)
@@ -6969,6 +6950,30 @@ return function(Vargs, env)
 				assert(args[2] == "true" or args[2] == "false", "Invalid argument #2 (boolean expected)")
 				for _, v in service.GetPlayers(plr, args[1]) do
 					Remote.Send(v, "Function", "SetCore", "ResetButtonCallback", if args[2] == "true" then true else false)
+				end
+			end
+		};
+
+		Sudo = {
+			Prefix = Settings.Prefix;
+			Commands = {"sudo"};
+			Args = {"player", "command"};
+			Description = "Runs a command as the target player(s)";
+			AdminLevel = "Players";
+			CrossServerDenied = true;
+			Function = function(plr: Player, args: {string})
+				assert(args[1], "Missing target player (argument #1)")
+				assert(args[2], "Missing command string (argument #2)")
+				local isCreator = Admin.IsPlaceOwner(plr) or Admin.GetLevel(plr) >= Settings.Ranks.Creators.Level
+				local options = {
+					IsDonor = not isCreator and Admin.CheckDonor(plr),
+					Level = not isCreator and Admin.GetLevel(plr),
+					Player = not isCreator and plr,
+					isSystem = isCreator
+				}
+
+				for _, v in service.GetPlayers(plr, args[1], {NoFakePlayer = true}) do
+					task.defer(Process.Command, v, args[2], options)
 				end
 			end
 		};

--- a/MainModule/Server/Plugins/Misc_Features.luau
+++ b/MainModule/Server/Plugins/Misc_Features.luau
@@ -68,6 +68,7 @@ return function(Vargs, GetEnv)
 		[":giveplayerpoints <player> <amount>"] = ":script local Players = game:GetService(\"Players\") for _, v in ipairs(_G.Adonis.GetPlayers(Players:GetPlayers()[math.random(1, #Players:GetPlayers())], \"<player>\")) do game:GetService(\"PointsService\"):AwardPoints(v.UserId, <amount>) end",
 		[":sendplayerpoints <player> <amount>"] = ":script local Players = game:GetService(\"Players\") for _, v in ipairs(_G.Adonis.GetPlayers(Players:GetPlayers()[math.random(1, #Players:GetPlayers())], \"<player>\")) do game:GetService(\"PointsService\"):AwardPoints(v.UserId, <amount>) end",
 		[":flyclip <player>"] = ":fly <player> true";
+		[":showlogs <player> <autoupdate>"] = ":sudo <player> :logs <autoupdate>";
 	} do
 		if not Variables.Aliases[k] then
 			Variables.Aliases[k] = v


### PR DESCRIPTION
Allow moderators to run `:sudo` and remove `:showlogs`

This is currently as a draft for further review particularly because of potential security implications if something is wrong.

*WORK IN PROGRESS*