### PR TITLE
Move :guiview` to a window

### DIFF
--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -597,57 +597,90 @@ return function(Vargs, GetEnv)
 		end;
 
 		LoadGuiData = function(data)
-			local make; make = function(dat)
-				local props = dat.Properties
-				local children = dat.Children
-				local gui = service.New(props.ClassName)
+			local zIndex = -2^31 -- Signed 32 bit intiger
+			local make; make = function(data, parent)
+				local props = data.Properties
+				local gui = props.ClassName ~= "ScreenGui" and service.New(props.ClassName)
 
-				for i,v in props do
-					pcall(function()
-						gui[i] = v
-					end)
+				if gui then
+					for k, v in props do
+						pcall(function()
+							gui[k] = v
+						end)
+					end
 				end
 
-				for i,v in children do
+				for _, v in data.Children do
 					pcall(function()
-						local g = make(v)
+						local g = make(v, gui or parent)
 						if g then
-							g.Parent = gui
+							g.Parent = gui or parent
 						end
 					end)
 				end
+
 				return gui
 			end
 
-			local temp = Instance.new("Folder")
-			for _, v in service.PlayerGui:GetChildren() do
-				if not UI.Get(v) then
-					v.Parent = temp
-				end
-			end
-			Variables.GuiViewFolder = temp
-			local folder = service.New("Folder",{Parent = service.PlayerGui; Name = "LoadedGuis"})
-			for _, v in data.Children do
-				pcall(function()
-					local g = make(v)
-					if g then
-						g.Parent = folder
+			local function normaliseIndex(gui)
+				local remap = {}
+				local mapIndex; mapIndex = function(object)
+					local index = object.Properties.ZIndex
+
+					if type(index) == "number" then
+						if not remap[index] then
+							remap[index] = {object.Properties}
+						else
+							table.insert(remap[index], object.Properties)
+						end
 					end
-				end)
+
+					for _, v in object.Children do
+						pcall(mapIndex, v)
+					end
+				end
+
+				pcall(mapIndex, gui)
+
+				for _, objects in remap do
+					zIndex += 1
+
+					for _, v in objects do
+						v.ZIndex = zIndex
+					end
+				end
+
+				return gui
 			end
+
+			local GuiViewContainer = UI.Make("Window", {
+				Name = "Player GUI View";
+				Title = "Player GUI View";
+				Icon = client.MatIcons["Grid view"];
+				AllowMultiple = true;
+				SizeLocked = false
+			})
+
+			table.sort(data.Children, function(t1, t2)
+				if t1.DisplayOrder and t2.DisplayOrder then
+					return t1.DisplayOrder >= t2.DisplayOrder
+				end
+
+				return false
+			end)
+
+			Variables.GuiViewFolder = GuiViewContainer
+			zIndex = GuiViewContainer.ZIndex or zIndex
+
+			for _, v in data.Children do
+				pcall(make, normaliseIndex(v), GuiViewContainer)
+			end
+
+			GuiViewContainer:Ready()
 		end;
 
 		UnLoadGuiData = function()
-			for _, v in service.PlayerGui:GetChildren() do
-				if v.Name == "LoadedGuis" then
-					v:Destroy()
-				end
-			end
-
 			if Variables.GuiViewFolder then
-				for _, v in Variables.GuiViewFolder:GetChildren() do
-					v.Parent = service.PlayerGui
-				end
 				Variables.GuiViewFolder:Destroy()
 				Variables.GuiViewFolder = nil
 			end

--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -196,7 +196,7 @@ return function(Vargs, GetEnv)
 		SetView = function(ob)
 			local CurrentCamera = workspace.CurrentCamera
 
-			if ob=='reset' then
+			if ob == "reset" then
 				CurrentCamera.CameraType = Enum.CameraType.Custom
 				CurrentCamera.CameraSubject = service.Player.Character:FindFirstChildOfClass("Humanoid")
 				CurrentCamera.FieldOfView = 70
@@ -415,6 +415,7 @@ return function(Vargs, GetEnv)
 				"Name";
 				"Parent";
 				"Archivable";
+				"DisplayOrder";
 				"SelectionImageObject";
 				"Active";
 				"BackgroundColor3";
@@ -623,13 +624,14 @@ return function(Vargs, GetEnv)
 			end
 
 			local function normaliseIndex(gui)
-				local remap = {}
+				local remap, order = {}, {}
 				local mapIndex; mapIndex = function(object)
 					local index = object.Properties.ZIndex
 
 					if type(index) == "number" then
 						if not remap[index] then
 							remap[index] = {object.Properties}
+							table.insert(order, index)
 						else
 							table.insert(remap[index], object.Properties)
 						end
@@ -641,11 +643,12 @@ return function(Vargs, GetEnv)
 				end
 
 				pcall(mapIndex, gui)
+				table.sort(order)
 
-				for _, objects in remap do
+				for _, index in order do
 					zIndex += 1
 
-					for _, v in objects do
+					for _, v in remap[index] do
 						v.ZIndex = zIndex
 					end
 				end
@@ -662,8 +665,9 @@ return function(Vargs, GetEnv)
 			})
 
 			table.sort(data.Children, function(t1, t2)
-				if t1.DisplayOrder and t2.DisplayOrder then
-					return t1.DisplayOrder >= t2.DisplayOrder
+				local o1, o2 = t1.Properties.DisplayOrder, t2.Properties.DisplayOrder
+				if o1 and o2 then
+					return o1 < o2
 				end
 
 				return false


### PR DESCRIPTION
This moves the contents of `:guiview` to a window. This allows you view the GUIs of multiple players and also fixes a plethora of bugs that the current `:guiview` command has.

PoF:
![image](https://github.com/user-attachments/assets/db3e4163-06e4-4b6e-a15f-3391d910db60)
