### PR TITLE
Fix incompatibility with legacy `service.Yield`

### DIFF
--- a/MainModule/Server/Shared/Service.luau
+++ b/MainModule/Server/Shared/Service.luau
@@ -257,7 +257,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		GetEvent = function(name)
 			if not HookedEvents[name] then
 				--// GoodSignal has been setup to be fully backwards-compatible with the existing Events system
-				local event = service.GoodSignal.new()
+				local event = service.Signal.new()
 
 				HookedEvents[name] = event
 				return event
@@ -746,7 +746,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 			end
 
 			if doYield and not tab.Finished then
-				return select(2, tab.Yield:Wait());
+				return tab.Yield:Wait()
 			end
 		end;
 


### PR DESCRIPTION
- Legacy `service.Yield` was improperly putting the self argument to the varargs of the function but instead of fixing it a workaround was added for queue and I did not catch this bug during testing.
- Also fixed an apparent typo of not converting `GoodSignal` to `Signal`. I swear I did this but apparently I did not? Anyways this fixes it too.

PoF:
![image](https://github.com/user-attachments/assets/e71370ea-e1b6-4e83-91b8-fffbc8e67485)
