### PR TITLE
Add build file shortcuts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,3 +33,15 @@ end_of_line = lf
 
 [*.txt]
 end_of_line = lf
+
+[*.bat]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[*.sh]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,7 @@
 *.yml eol=lf
 *.txt text=auto
 *.txt eol=lf
+*.bat text=auto
+*.bat eol=lf
+*.sh text=auto
+*.sh eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,10 @@
 
 # Build Files
 /Adonis_**.rbxm
+/Adonis_**.rbxmx
+/Adonis_**.rbxl
+/Adonis_**.rbxlx
 /Adonis.rbxm
+/Adonis.rbxmx
+/Adonis.rbxl
+/Adonis.rbxlx

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,6 @@
 @echo off
 SETLOCAL
 
-:: Backup if selene is not globally installed
 where selene >nul 2>nul
 IF %ERRORLEVEL% NEQ 0 (
 	SET SELENE_COMMAND=.\selene.exe
@@ -9,7 +8,6 @@ IF %ERRORLEVEL% NEQ 0 (
 	SET SELENE_COMMAND=selene
 )
 
-:: Backup if rojo is not globally installed
 where rojo >nul 2>nul
 IF %ERRORLEVEL% NEQ 0 (
 	SET ROJO_COMMAND=.\rojo.exe
@@ -17,11 +15,9 @@ IF %ERRORLEVEL% NEQ 0 (
 	SET ROJO_COMMAND=rojo
 )
 
-:: Run selene linter for loader and mainmodule
-echo Running %SELENE_COMMAND% ./MainModule ./Loader
+echo Checking for lint errors with %SELENE_COMMAND% from ./Loader and ./MainModule 
 %SELENE_COMMAND% ./MainModule ./Loader
 
-:: Run rojo build
 echo Running %ROJO_COMMAND% build -o Adonis.rbxm
 %ROJO_COMMAND% build -o Adonis.rbxm
 

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,28 @@
+@echo off
+SETLOCAL
+
+:: Backup if selene is not globally installed
+where selene >nul 2>nul
+IF %ERRORLEVEL% NEQ 0 (
+	SET SELENE_COMMAND=.\selene.exe
+) ELSE (
+	SET SELENE_COMMAND=selene
+)
+
+:: Backup if rojo is not globally installed
+where rojo >nul 2>nul
+IF %ERRORLEVEL% NEQ 0 (
+	SET ROJO_COMMAND=.\rojo.exe
+) ELSE (
+	SET ROJO_COMMAND=rojo
+)
+
+:: Run selene linter for loader and mainmodule
+echo Running %SELENE_COMMAND% ./MainModule ./Loader
+%SELENE_COMMAND% ./MainModule ./Loader
+
+:: Run rojo build
+echo Running %ROJO_COMMAND% build -o Adonis.rbxm
+%ROJO_COMMAND% build -o Adonis.rbxm
+
+ENDLOCAL

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Check for lint errors in Loader and MainModule
+printf "Checking for lint errors from ./Loader and ./MainModule"
 selene ./Loader ./MainModule
 
-# Build project file to binary model file
+printf "Running rojo build -o Adonis.rbxm"
 rojo build -o Adonis.rbxm

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Check for lint errors in Loader and MainModule
+selene ./Loader ./MainModule
+
+# Build project file to binary model file
+rojo build -o Adonis.rbxm


### PR DESCRIPTION
Adds premade build files for Adonis both for Windows and Unix based systems.
If you build Adonis files often this makes it a lot easier and less of a hassle.