### PR TITLE
Actually fixed quoted args

### DIFF
--- a/MainModule/Server/Core/Functions.luau
+++ b/MainModule/Server/Core/Functions.luau
@@ -1319,7 +1319,7 @@ return function(Vargs, GetEnv)
 				if #tab>=num then
 					break
 				elseif #tab>=num-1 then
-					table.insert(tab,string.sub(msg,#str+3,#msg))
+					table.insert(tab,string.sub(msg,#str+#tab+1,#msg))
 					continue
 				end
 


### PR DESCRIPTION
A fix for a pr (#1766) I made
Still unsure if this will break some commands due to a space so I have it as a draft for right now

PoF (for the commands actually affected):
![image](https://github.com/user-attachments/assets/cf0f09b8-c3ae-4091-8a39-493f86dfe5b1)
![image](https://github.com/user-attachments/assets/15e5afcc-468c-47b5-800a-7df734d58111)
