### PR TITLE
Fix debounce for antiexploit notifications

### DIFF
--- a/MainModule/Server/Core/Anti.luau
+++ b/MainModule/Server/Core/Anti.luau
@@ -187,7 +187,7 @@ return function(Vargs, GetEnv)
 
 			if Settings.AENotifs == true or Settings.ExploitNotifications == true then -- AENotifs for old loaders
 				local debounceIndex = `{action}{player}{info}`
-				if os.clock() < antiNotificationResetTick then
+				if os.clock() > antiNotificationResetTick then
 					antiNotificationDebounce = {}
 					antiNotificationResetTick = os.clock() + 60
 				end

--- a/MainModule/Server/Core/Anti.luau
+++ b/MainModule/Server/Core/Anti.luau
@@ -193,13 +193,15 @@ return function(Vargs, GetEnv)
 				end
 
 				if not antiNotificationDebounce[debounceIndex] then
-					antiNotificationDebounce[debounceIndex] = 1
+					antiNotificationDebounce[debounceIndex] = 0
 				elseif
 					(string.lower(action) == "log" or string.lower(action) == "kill") and
 					antiNotificationDebounce[debounceIndex] > 3
 				then
 					return
 				end
+
+				antiNotificationDebounce[debounceIndex] += 1
 
 				for _, plr in service.Players:GetPlayers() do
 					if Admin.GetLevel(plr) >= Settings.Ranks.Moderators.Level then

--- a/MainModule/Server/Core/Anti.luau
+++ b/MainModule/Server/Core/Anti.luau
@@ -193,7 +193,7 @@ return function(Vargs, GetEnv)
 				end
 
 				if not antiNotificationDebounce[debounceIndex] then
-					antiNotificationDebounce[debounceIndex] = 0
+					antiNotificationDebounce[debounceIndex] = 1
 				elseif
 					(string.lower(action) == "log" or string.lower(action) == "kill") and
 					antiNotificationDebounce[debounceIndex] > 3


### PR DESCRIPTION
- Changed the comparison on `antiNotificationResetTick` from less than to greater than; this means the debounce table will be cleared after 60 seconds, and not within 60 seconds.
- Added a line to increase the number within the debounce table, which will properly be able to meet the `> 3` criteria.

PoF: Tested, can confirm works as intended. 
![image](https://github.com/user-attachments/assets/1a59b0a5-cd40-47a3-a739-d309591da31f)
(I'm guessing this is how it works, right?)