### PR TITLE
Add override for TShirt Asset Type

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -5414,7 +5414,8 @@ return function(Vargs, env)
 				assert(success and productInfo, "Invalid item ID")
 
 				local AssetTypeNameDescriptionOverides = {
-					DynamicHead = "Head"
+					DynamicHead = "Head";
+					TShirt = "GraphicTShirt"
 				}
 				--local typeEnum = Enum.AvatarAssetType:FromValue(productInfo.AssetTypeId)
 				local typeId = productInfo.AssetTypeId


### PR DESCRIPTION
Fixes an issue when running `:tshirt <player> <asset id>` where it looks for TShirt in the humanoid description.

This happened because robloxed change the property from TShirt to GraphicTShirt and the asset type name is still TShirt (which is looks for)

PoF:

https://github.com/user-attachments/assets/eb4e38b7-3dc3-4b98-9c5b-578314ce1515

