### PR TITLE
[Core.luau] Add task.wait workaround for loading large data in Studio

### DIFF
--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -1290,9 +1290,10 @@ return function(Vargs, GetEnv)
 								if data then
 									--// TODO: Possibly find a better way to "batch" TableUpdates to prevent script exhaustion
 									local isStudio = service.RunService:IsStudio() -- Studio lag workaround for loading larger data such as BannedList
+									local isHugeTable = #data > 1000
 									for i = 1, #data do
 										LoadData("TableUpdate", data[i])
-										if (isStudio and #data > 500 and i % 25 == 0) or i % 250 == 0 then
+										if (isStudio and isHugeTable and i % 25 == 0) or i % 250 == 0 then
 											task.wait()
 										end
 									end

--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -1289,9 +1289,10 @@ return function(Vargs, GetEnv)
 								local data = GetData(tData.TableKey)
 								if data then
 									--// TODO: Possibly find a better way to "batch" TableUpdates to prevent script exhaustion
+									local isStudio = service.RunService:IsStudio() -- Studio lag workaround for loading larger data such as BannedList
 									for i = 1, #data do
 										LoadData("TableUpdate", data[i])
-										if i % 250 == 0 then
+										if (isStudio and #data > 500 and i % 25 == 0) or i % 250 == 0 then
 											task.wait()
 										end
 									end


### PR DESCRIPTION
## Description
This will mitigate the extreme lag at the first 5-10 seconds caused by huge amounts of stored data such as BannedList.

**DISCLAIMER**: This is just a workaround for some of those who did have thousands of banlists in Adonis alone, either due to the long history of the experience itself, or the developer of such experience used Adonis banlist for auto-banning (which is kind of bad idea due to datastore constraints; and useless since BanAsync is there)

## Results
Experience in question has 8,000+ bans stored in Adonis datastore.
Before:
![image](https://github.com/user-attachments/assets/2232ad1a-5889-48a4-ac55-cc728f5fbb00)

After:

![image](https://github.com/user-attachments/assets/14fef6db-997a-4aa8-905c-d508ecb2c80d)
