### PR TITLE
New "clear" sub-command on "whitelist" for easy whitelist clearing

### DIFF
--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -380,7 +380,7 @@ return function(Vargs, env)
 						error("Missing user argument")
 					end
 				elseif sub == "remove" then
-				if args[2] then
+					if args[2] then
 						for i, v in Variables.Whitelist.Lists.Settings do
 							if string.sub(string.lower(v), 1,#args[2]) == string.lower(args[2])then
 								table.remove(Variables.Whitelist.Lists.Settings,i)

--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -348,8 +348,8 @@ return function(Vargs, env)
 		Whitelist = {
 			Prefix = Settings.Prefix;
 			Commands = {"wl", "enablewhitelist", "whitelist"};
-			Args = {"on/off/add/remove/list", "optional player"};
-			Description = "Enables/disables the whitelist; :wl username to add them to the whitelist";
+			Args = {"on/off/add/remove/list/wipe", "optional player"};
+			Description = "Enables/disables the server whitelist; :wl username to add them to the whitelist";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
 				local sub = string.lower(args[1])
@@ -380,7 +380,7 @@ return function(Vargs, env)
 						error("Missing user argument")
 					end
 				elseif sub == "remove" then
-					if args[2] then
+				if args[2] then
 						for i, v in Variables.Whitelist.Lists.Settings do
 							if string.sub(string.lower(v), 1,#args[2]) == string.lower(args[2])then
 								table.remove(Variables.Whitelist.Lists.Settings,i)
@@ -399,8 +399,11 @@ return function(Vargs, env)
 						end
 					end
 					Remote.MakeGui(plr, "List", {Title = "Whitelist List"; Tab = Tab;})
+				elseif sub == "wipe" then
+					Variables.Whitelist.Lists.Settings = {}
+					Functions.Hint("Cleared server whitelist", service.Players:GetPlayers())
 				else
-					error("Invalid subcommand (on/off/add/remove/list)")
+					error("Invalid subcommand (on/off/add/remove/list/wipe)")
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -348,7 +348,7 @@ return function(Vargs, env)
 		Whitelist = {
 			Prefix = Settings.Prefix;
 			Commands = {"wl", "enablewhitelist", "whitelist"};
-			Args = {"on/off/add/remove/list/wipe", "optional player"};
+			Args = {"on/off/add/remove/list/clear", "optional player"};
 			Description = "Enables/disables the server whitelist; :wl username to add them to the whitelist";
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
@@ -399,11 +399,11 @@ return function(Vargs, env)
 						end
 					end
 					Remote.MakeGui(plr, "List", {Title = "Whitelist List"; Tab = Tab;})
-				elseif sub == "wipe" then
+				elseif sub == "clear" then
 					Variables.Whitelist.Lists.Settings = {}
 					Functions.Hint("Cleared server whitelist", service.Players:GetPlayers())
 				else
-					error("Invalid subcommand (on/off/add/remove/list/wipe)")
+					error("Invalid subcommand (on/off/add/remove/list/clear)")
 				end
 			end
 		};

--- a/MainModule/Server/Dependencies/TrelloAPI.luau
+++ b/MainModule/Server/Dependencies/TrelloAPI.luau
@@ -10,8 +10,8 @@
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 local print = function(...) warn("[Adonis TrelloAPI]: INFO:", ...) end
+local error = function(...) warn("[Adonis TrelloAPI]: ERROR:", ...) end
 local warn = function(...) warn("[Adonis TrelloAPI]: WARN:", ...) end
-local error = function(message, level) warn("[Adonis TrelloAPI]: ERROR:", message) return error("[Adonis TrelloAPI]: ERROR:"..message, level == 0 and 0 or 1 + (level or 1)) end
 
 local HttpService = game:GetService("HttpService")
 local Weeks = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}

--- a/MainModule/Server/Dependencies/TrelloAPI.luau
+++ b/MainModule/Server/Dependencies/TrelloAPI.luau
@@ -10,8 +10,8 @@
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 local print = function(...) warn("[Adonis TrelloAPI]: INFO:", ...) end
-local error = function(...) warn("[Adonis TrelloAPI]: ERROR:", ...) end
 local warn = function(...) warn("[Adonis TrelloAPI]: WARN:", ...) end
+local error = function(message, level) warn("[Adonis TrelloAPI]: ERROR:", message) return error("[Adonis TrelloAPI]: ERROR:"..message, level == 0 and 0 or 1 + (level or 1)) end
 
 local HttpService = game:GetService("HttpService")
 local Weeks = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}


### PR DESCRIPTION
Create a new sub-command on the whitelist command that allows administrators to completely clear the whitelist settings without having to clear each and every single entry individually.