### PR TITLE
Partially revert PR-1673 due to unhandled error

### DIFF
--- a/MainModule/Server/Dependencies/TrelloAPI.luau
+++ b/MainModule/Server/Dependencies/TrelloAPI.luau
@@ -10,8 +10,8 @@
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 local print = function(...) warn("[Adonis TrelloAPI]: INFO:", ...) end
+local error = function(...) warn("[Adonis TrelloAPI]: ERROR:", ...) end
 local warn = function(...) warn("[Adonis TrelloAPI]: WARN:", ...) end
-local error = function(message, level) warn("[Adonis TrelloAPI]: ERROR:", message) return error("[Adonis TrelloAPI]: ERROR:"..message, level == 0 and 0 or 1 + (level or 1)) end
 
 local HttpService = game:GetService("HttpService")
 local Weeks = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}


### PR DESCRIPTION
2 months ago, the way errors were displayed was changed to actually use "error()". This caused games to break that used Adonis,  as whenever the connection fails,  HTTP.luau would fail as well as the require was not pcall'd.

![image](https://github.com/user-attachments/assets/917f9674-6736-4e42-a932-8635a8573a57)