### PR TITLE
Fix :pchat glitching

### DIFF
--- a/MainModule/Client/UI/Default/PrivateChat.luau
+++ b/MainModule/Client/UI/Default/PrivateChat.luau
@@ -321,7 +321,7 @@ return function(data, env)
 		Parent = chatlog;
 		FillDirection = "Vertical";
 		HorizontalAlignment = "Left";
-		VerticalAlignment = "Bottom";
+		VerticalAlignment = "Top";
 		SortOrder = "LayoutOrder";
 	})
 
@@ -358,7 +358,6 @@ return function(data, env)
 				local p = vargs[1]
 				local message = vargs[2]
 				if newMessage then
-					print('sdf')
 					newMessage({
 						PlayerName = p.Name;
 						PlayerDisplayName = p.DisplayName;


### PR DESCRIPTION
Fixes #1802 
This makes the chat start from the top but it will fix the unnecessary blank space at the bottom.
AND you can look back at all the messages too.

![image](https://github.com/user-attachments/assets/8470a9ab-ee58-4f02-8455-43ecff50b88e)
![image](https://github.com/user-attachments/assets/20af014d-1fb8-4be7-a3f2-467f296f9e40)

