### PR TITLE
Fixed TextBox capability warning

### DIFF
--- a/MainModule/Client/Core/Process.luau
+++ b/MainModule/Client/Core/Process.luau
@@ -169,7 +169,7 @@ return function(Vargs, GetEnv)
 			end
 
 			local textbox = service.UserInputService:GetFocusedTextBox()
-			if textbox then
+			if textbox and service.CheckProperty(textbox, "ReleaseFocus") then
 				textbox:ReleaseFocus()
 			end
 
@@ -179,7 +179,7 @@ return function(Vargs, GetEnv)
 		HandleTextChatCommands = function()
 			local data = Remote.Get("PlayerData")
 			local adminLevel, isDonor = data.AdminLevel, data.isDonor
-	
+
 			if service.TextChatService and service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService then
 				local function onCommandAdded(command)
 					if not command:IsA("TextChatCommand") then


### PR DESCRIPTION
Resolves bug where if the TextBox wasn't accessible (usually CoreGui instances) it would error due to not having the correct capabilities to access the instance.

Warning:
![image](https://github.com/user-attachments/assets/c36d01b1-9550-4c8c-8996-102c8431c4da)
