### PR TITLE
Fix ServerNewDex not logging correctly

### DIFF
--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -61,7 +61,7 @@
 			Logs:AddLog("Script", "Successfully loaded reflection metadata to Dex")
 		else
 			Logs:AddLog("Script", "Access to HttpService is not enabled! Dex api dump could not be fetched!")
-			Logs:AddLog("Error", "Access to HttpService is not enabled! Dex api dump could not be fetched!")
+			Logs:AddLog("Errors", "Access to HttpService is not enabled! Dex api dump could not be fetched!")
 			--logError("Access to HttpService is not enabled! Dex api dump could not be fetched!")
 		end
 	end)


### PR DESCRIPTION
Fix a typo that caused an error. File was attempting to add a log to a log type that doesn't exist.

 15:44:30.182  ServerScriptService.MainModule.Server.Core.Logs:91: attempt to index nil with '__meta'
  15:44:30.183  Stack Begin
  15:44:30.183  Script 'ServerScriptService.MainModule.Server.Core.Logs', Line 91 - function AddLog
  15:44:30.183  Script 'ServerScriptService.MainModule.Server.Plugins.ServerNewDex', Line 52
  15:44:30.183  Stack End