### PR TITLE
Use standardized naming for build files that respects gitignore

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,10 +67,10 @@ jobs:
           path: ${{ steps.naming.outputs.output_name }}.rbxm
         
       - name: Build Loader
-        run: rojo build -o loader.rbxm .github/loader.deploy.project.json
+        run: rojo build -o Adonis_Loader.rbxm .github/loader.deploy.project.json
         
       - name: Build MainModule
-        run: rojo build -o module.rbxm .github/module.deploy.project.json
+        run: rojo build -o Adonis_MainModule.rbxm .github/module.deploy.project.json
 
       - name: Send Standalone Release to Discord channel
         uses: tsickert/discord-webhook@v6.0.0
@@ -84,7 +84,7 @@ jobs:
           url: "${{ secrets.PUBURL2 }}/?assetId=${{ secrets.LOADER_ID }}"
           method: "POST"
           contentType: "multipart/form-data"
-          files: '{ "file": "loader.rbxm" }'
+          files: '{ "file": "Adonis_Loader.rbxm" }'
           customHeaders: '{ "upload-secret": "${{ secrets.PUBURL2_SECRET }}" }'
           timeout: 10000
           
@@ -94,6 +94,6 @@ jobs:
           url: "${{ secrets.PUBURL2 }}/?assetId=${{ secrets.MODULE_ID }}"
           method: "POST"
           contentType: "multipart/form-data"
-          files: '{ "file": "module.rbxm" }'
+          files: '{ "file": "Adonis_MainModule.rbxm" }'
           customHeaders: '{ "upload-secret": "${{ secrets.PUBURL2_SECRET }}" }'
           timeout: 10000


### PR DESCRIPTION
This doesn't apply to the #releases build files because they are controlled by a Github secret. They should be standardized too with the `Adonis_` prefix.