### PR TITLE
Prevent used globals from being counted multiple times in :ss

### DIFF
--- a/MainModule/Server/Dependencies/Loadstring/LuaX.luau
+++ b/MainModule/Server/Dependencies/Loadstring/LuaX.luau
@@ -917,7 +917,7 @@ function luaX:llex(ls, Token)
 		-- Global optimisation helper
 		if self.DEOP[ts] then
 		  ls.safeenv = false
-		elseif self.globalvars[ts] then
+		elseif self.globalvars[ts] and not table.find(ls.usedglobals, ts) then
 		  table.insert(ls.usedglobals, ts)
 		end
 


### PR DESCRIPTION
After #1486 introduced the global import optimization update in Loadstring, global variables are being counted towards the 200 local variable limit multiple times. This causes the limit to be depleted very quickly in some cases. The change in #1587 addressed a formatting error in LuaY that concealed this issue in LuaX, but didn't fix the root cause of the error, which is what this change should do.

Me and @ServerNoob found that if you only localize used globals once, the number of local variables created comes down significantly. I'm not sure if this is an actual issue or intentional behavior for optimization purposes, but since the exact same script that worked before #1486 is now causing errors (and also works in a normal Luau environment on Roblox, like the Developer Console), I think this is a bug.

Proof of functionality: https://www.youtube.com/watch?v=1IwQZPIvMvw
In the video, I imported Adonis into a new baseplate, and modified the config + LuaY to print local vars. Then, I ran the same testing script on: 
1. the latest LuaX in Adonis (didn't work)
2. LuaX after making this change (worked)
3. LuaX before #1486 was introduced (worked)

Steps script followed in pof: https://github.com/user-attachments/files/18431880/Steps.txt