### PR TITLE
;starterhealth and ;unstarterhealth

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -7140,5 +7140,83 @@ return function(Vargs, env)
 				})
 			end
 		};
+
+		StarterHealth = {
+			Prefix = Settings.Prefix;
+			Commands = {"starterhealth", "starthealth"};
+			Args = {"player", "health"};
+			Description = "Sets the target player(s)'s starting health";
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local health = tonumber(args[2])
+				assert(health, "Invalid health value")
+				local plrs = service.GetPlayers(plr, args[1])
+				for _, v in plrs do
+					server.Variables.Starter.Health[v.UserId] = health
+				end
+				Functions.Hint(`Your starter health was set to {health}`, plrs)
+				if Settings.CommandFeedback then
+					Functions.Hint(`You set {#plrs} players starter health to {health}`, {plr})
+				end
+			end
+
+		},
+
+		UnStarterHealth = {
+			Prefix = Settings.Prefix;
+			Commands = {"unstarterhealth", "unstarthealth", "resetstarterhealth"};
+			Args = {"player"};
+			Description = "Removes the target player(s)'s custom starting health";
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				local plrs = service.GetPlayers(plr, args[1])
+				for _, v in plrs do
+					server.Variables.Starter.Health[v.UserId] = nil
+				end
+				Functions.Hint(`Your starter health was reset`, plrs)
+				if Settings.CommandFeedback then
+					Functions.Hint(`You reset {#plrs} players starter health`, {plr})
+				end
+			end
+		};
+
+		StarterSpeed = {
+			Prefix = Settings.Prefix;
+			Commands = {"starterspeed", "startspeed"};
+			Args = {"player", "speed"};
+			Description = "Sets the target player(s)'s starting speed";
+			AdminLevel = "Admins";
+			Function = function(plr: Player, args: {string})
+				local speed = tonumber(args[2])
+				assert(speed, "Invalid speed value")
+				local plrs = service.GetPlayers(plr, args[1])
+				for _, v in plrs do
+					server.Variables.Starter.Speed[v.UserId] = speed
+				end
+
+				Functions.Hint(`Your starter speed was set to {speed}`, plrs)
+				if Settings.CommandFeedback then
+					Functions.Hint(`You set {#plrs} players starter speed to {speed}`, {plr})
+				end
+			end
+		};
+
+		UnStarterSpeed = {
+			Prefix = Settings.Prefix;
+			Commands = {"unstarterspeed", "unstartspeed", "resetstarterspeed"};
+			Args = {"player"};
+			Description = "Removes the target player(s)'s custom starting speed";
+			AdminLevel = "Admins";
+			Function = function(plr: Player, args: {string})
+				local plrs = service.GetPlayers(plr, args[1])
+				for _, v in plrs do
+					server.Variables.Starter.Speed[v.UserId] = nil
+				end
+				Functions.Hint(`Your starter speed was reset`, plrs)
+				if Settings.CommandFeedback then
+					Functions.Hint(`You reset {#plrs} players starter speed`, {plr})
+				end
+			end
+		};
 	}
 end

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -1158,6 +1158,18 @@ return function(Vargs, GetEnv)
 						end
 					end
 				end
+
+				local Hum = char:FindFirstChildOfClass("Humanoid")
+				if not Hum then return end
+				local Health = Variables.Starter.Health[p.UserId]
+				if Health then
+					Hum.MaxHealth = Health
+					Hum.Health = Hum.MaxHealth
+				end
+				local Speed = Variables.Starter.Speed[p.UserId]
+				if Speed then
+					Hum.WalkSpeed = Speed
+				end
 			end
 		end;
 

--- a/MainModule/Server/Core/Variables.luau
+++ b/MainModule/Server/Core/Variables.luau
@@ -64,7 +64,7 @@ return function(Vargs, GetEnv)
 
 	local Lighting = service.Lighting
 	local atmosphere = Lighting:FindFirstChildWhichIsA("Atmosphere")
-	
+
 	server.Variables = {
 		Init = Init,
 		RunAfterInit = AfterInit,
@@ -142,7 +142,7 @@ return function(Vargs, GetEnv)
 			Name = Lighting.Name,
 			Sky = Lighting:FindFirstChildOfClass("Sky") and Lighting:FindFirstChildOfClass("Sky"):Clone(),
 		},
-		
+
 		AtmosphereSettings = {
 			Name = atmosphere and atmosphere.Name,
 			Density = atmosphere and atmosphere.Density,
@@ -261,5 +261,10 @@ return function(Vargs, GetEnv)
 				Settings = server.Settings.Whitelist
 			},
 		};
+
+		Starter = {
+			Health = {};
+			Speed = {};
+		}
 	}
 end


### PR DESCRIPTION
Adds the following commands

- ;starterhealth <players> <health>
- ;unstarterhealth <players>
- ;starterspeed <players> <speed>
- ;unstarterspeed <players>

Works by adding a value to Variables.Starter.Health/Speed respectuflly

This is checked in Process.CharacterAdded

POF: https://cdn.discordapp.com/attachments/1300432207286108231/1343485881394266163/2025-02-24-02-30-8634.mp4?ex=67bd723a&is=67bc20ba&hm=2b913651b0b75465936cb1f1a92fbff1ab6fcffdbb447372185b6bd1e39d4bdf&
