### PR TITLE
Fix invalid admin level giving no warning

### DIFF
--- a/MainModule/Server/Core/Admin.luau
+++ b/MainModule/Server/Core/Admin.luau
@@ -1461,15 +1461,22 @@ return function(Vargs, GetEnv)
 
 		StringToComLevel = function(str)
 			local strType = type(str)
-			if strType == "string" and string.lower(str) == "players" then
-				return 0
-			end
 			if strType == "number" then
 				return str
+			elseif strType == "string" then
+				if string.lower(str) == "players" then
+					return 0
+				end
+
+				local lvl = Settings.Ranks[str]
+				if not lvl then
+					return -1
+				end
+
+				return lvl.Level
 			end
 
-			local lvl = Settings.Ranks[str]
-			return (lvl and lvl.Level) or tonumber(str)
+			return tonumber(str)
 		end;
 
 		CheckComLevel = function(plrAdminLevel, comLevel)

--- a/MainModule/Server/Core/Commands.luau
+++ b/MainModule/Server/Core/Commands.luau
@@ -112,7 +112,13 @@ return function(Vargs, GetEnv)
 
 			local lvl = cmd.AdminLevel
 			if type(lvl) == "string" and lvl ~= "Donors" then
-				cmd.AdminLevel = Admin.StringToComLevel(lvl)
+				local resp = Admin.StringToComLevel(lvl)
+				if resp == nil or resp == -1 then
+					warn(`'AdminLevel' for command {ind} is provided as '{lvl}' but is invalid. Defaulting to 0.`)
+					resp = 0
+				end
+
+				cmd.AdminLevel = resp
 			elseif type(lvl) == "table" then
 				for b, v in lvl do
 					lvl[b] = Admin.StringToComLevel(v)


### PR DESCRIPTION
This is another issue that I encountered while dealing with Adonis in our game.

When a command's provided `AdminLevel` does not exist, it defaults to the `Players`. I don't see why such behavior would be intended or anyone would rely on such functionality. At least in my case, I made a typo while creating a plugin only to find out that the command was accessible to everyone, when it was only meant to be locked to another `AdminLevel`.

The proposed fix for this PR is to warn that such behavior is happening, so at least it's transparent and could be caught before it does any actual harm. A more user-facing approach would be to use some algorithm, such as Levenshtein or a simple one like the one provided below, to inform them of the potential typo:
```luau
local function TruncatedCompare(s1: str, s2: str)
    local minLength = math.min(string.len(s1), string.len(s2))
    local s1Truncated = string.sub(s1, 1, minLength)
    local s2Truncated = string.sub(s2, 1, minLength)
    return s1Truncated == s2Truncated
end 
```

Example output:
```luau
warn(`'AdminLevel' for command example is provided as 'Player' but is invalid. Defaulting to 0 (did you mean to type 'Players' instead?).`).
```

If the alternative approach is acceptable or preferred, please let me know. Thanks!