### PR TITLE
Refactor Autocomplete suggestions in Default theme

### DIFF
--- a/MainModule/Client/Core/UI.luau
+++ b/MainModule/Client/Core/UI.luau
@@ -63,6 +63,13 @@ return function(Vargs, GetEnv)
 		UI.RunLast = nil;
 	end
 
+	local function TruncatedCompare(s1: str, s2: str)
+		local minLength = math.min(string.len(s1), string.len(s2))
+		local s1Truncated = string.sub(s1, 1, minLength)
+		local s2Truncated = string.sub(s2, 1, minLength)
+		return s1Truncated == s2Truncated
+	end 
+
 	getfenv().client = nil
 	getfenv().service = nil
 	getfenv().script = nil
@@ -546,7 +553,23 @@ return function(Vargs, GetEnv)
 			gTable:Register(gui)
 
 			return gTable,gIndex
-		end
+		end;
+
+		Autocomplete = function(provided: string, arg: string)
+			local matches = {}
+			if not provided or not arg then
+				return matches
+			end
+
+			for _, player in service.Players:GetPlayers() do
+				local name = player.Name
+				if provided == "$" or TruncatedCompare(string.lower(name), string.lower(provided)) then
+					table.insert(matches, name)
+				end
+			end
+
+			return matches
+		end;
 	}
 
 	client.UI.RegisterGui = client.UI.Register

--- a/MainModule/Client/UI/Default/Console.rbxmx
+++ b/MainModule/Client/UI/Default/Console.rbxmx
@@ -124,7 +124,7 @@
 					<token name="HorizontalScrollBarInset">0</token>
 					<int name="LayoutOrder">0</int>
 					<Content name="MidImage"><url>http://roblox.com/asset?id=158348114</url></Content>
-					<string name="Name">PlayerList</string>
+					<string name="Name">AutocompleteList</string>
 					<Ref name="NextSelectionDown">null</Ref>
 					<Ref name="NextSelectionLeft">null</Ref>
 					<Ref name="NextSelectionRight">null</Ref>
@@ -560,7 +560,7 @@ return function(data, env)
 	local frame = gui.Frame
 	local text = frame.TextBox
 	local scroll = frame.ScrollingFrame
-	local players = frame.PlayerList
+	local autoList = frame.AutocompleteList
 	local entry = gui.Entry
 
 	local Settings = Remote.Get("Setting", {"SplitKey", "ConsoleKeyCode", "BatchKey", "Prefix"})
@@ -654,7 +654,7 @@ return function(data, env)
 			scroll.ScrollingEnabled = false
 			frame.Size = UDim2.new(1,0,0,40)
 			scroll.Visible = false
-			players.Visible = false
+			autoList.Visible = false
 			scrollOpen = false
 
 			if Variables.ChatEnabled then
@@ -687,7 +687,7 @@ return function(data, env)
 		service.StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.PlayerList, false)
 
 		scroll.ScrollingEnabled = true
-		players.ScrollingEnabled = true
+		autoList.ScrollingEnabled = true
 
 		hideGuis()
 
@@ -695,7 +695,7 @@ return function(data, env)
 
 		frame.Size = UDim2.new(1, 0, 0, 40)
 		scroll.Visible = false
-		players.Visible = false
+		autoList.Visible = false
 		scrollOpen = false
 		text.Text = ""
 		frame.Visible = true
@@ -728,58 +728,40 @@ return function(data, env)
 
 	text:GetPropertyChangedSignal("Text"):Connect(function()
 		if text.Text ~= "" and openConsole then
-			if string.sub(text.Text, string.len(text.Text)) == "	" then
-				if players:FindFirstChild("Entry 0") then
-					local args = string.split(tostring(text.Text), " ") -- Get command args
+			local tabWhiteSpace = "	"
+			if string.sub(text.Text, string.len(text.Text)) == tabWhiteSpace then
+				if autoList:FindFirstChild("Entry 0") then
+					local args = string.split(text.Text, splitKey) -- Get command args
 					local textWithoutLastArg = string.sub(text.Text, 1, string.len(text.Text) - string.len(args[#args])) -- Remove the last arg
 					
-					text.Text = `{textWithoutLastArg}{players["Entry 0"].Text} ` -- Combine the text witout the last arg and the player name
+					text.Text = `{textWithoutLastArg}{autoList["Entry 0"].Text} ` -- Combine the text witout the last arg and the player name
 				elseif scroll:FindFirstChild("Entry 0") then
 					text.Text = string.split(scroll["Entry 0"].Text, "<")[1]
-				else
-					text.Text = text.Text..prefix
 				end
+				
 				text.CursorPosition = string.len(text.Text) + 1
-				text.Text = string.gsub(text.Text, "	", "")
+				text.Text = string.gsub(text.Text, tabWhiteSpace, "")
 			end
 			scroll:ClearAllChildren()
-			players:ClearAllChildren()
+			autoList:ClearAllChildren()
 
 			local nText = text.Text
-			if string.match(nText, `.*{batchKey}([^']+)`) then
-				nText = string.match(nText, `.*{batchKey}([^']+)`)
-				nText = string.match(nText, "^%s*(.-)%s*$")
+			local fullCmdStr = string.match(nText, `.*{batchKey}([^']+)`)
+			if fullCmdStr then
+				nText = string.match(fullCmdStr, "^%s*(.-)%s*$")
 			end
-
-			local pNum = 0
-			local pMatch = string.match(nText, `.+{splitKey}(.*)$`)
-			for _, v in service.Players:GetPlayers() do
-				if (pMatch and string.sub(string.lower(tostring(v)),1,#pMatch) == string.lower(pMatch)) or string.match(nText,`{splitKey}$`) then
-					local new = entry:Clone()
-					new.Text = tostring(v)
-					new.Name = `Entry {pNum}`
-					new.TextXAlignment = "Right"
-					new.Visible = true
-					new.Parent = players
-					new.Position = UDim2.new(0,0,0,20*pNum)
-					new.MouseButton1Down:Connect(function()
-						text.Text = text.Text..tostring(v)
-						text:CaptureFocus()
-					end)
-					pNum += 1
-				end
-			end
-
-			players.CanvasSize = UDim2.new(0,0,0,pNum*20)
 
 			local num = 0
+			local selectedCmd = ""
 			for _, v in commands do
-				if string.sub(string.lower(v),1,#nText) == string.lower(nText) or string.find(string.lower(v), string.match(string.lower(nText), `^(.-){splitKey}`) or string.lower(nText), 1, true) then
+				local cmdName = string.match(string.lower(nText), `^(.-){splitKey}`) or string.lower(nText)
+				if string.sub(string.lower(v), 1, #nText) == string.lower(nText) or string.find(string.lower(v), cmdName, 1, true) then
+					selectedCmd = v 
 					if not scrollOpen then
 						scrollOpenTween:Play()
 						--frame.Size = UDim2.new(1,0,0,140)
 						scroll.Visible = true
-						players.Visible = true
+						autoList.Visible = true
 						scrollOpen = true
 					end
 					local b = entry:Clone()
@@ -795,13 +777,38 @@ return function(data, env)
 					num += 1
 				end
 			end
-			frame.Size = UDim2.new(1, 0, 0, math.clamp((num*20)+40, 40, 140))
-			scroll.CanvasSize = UDim2.fromOffset(0, num*20)
+			
+			local aNum = 0
+			local fullSplit = string.split(nText, splitKey)
+			if num > 0 and #fullSplit > 1 then
+				local provided = string.match(nText, `.+{splitKey}(.*)$`)
+				local selectedSplit = string.split(selectedCmd, splitKey)
+				
+				local arg = selectedSplit[#fullSplit]
+				for _, v in UI.Autocomplete(provided, arg) do
+					local new = entry:Clone()
+					new.Text = v
+					new.Name = `Entry {aNum}`
+					new.TextXAlignment = "Right"
+					new.Visible = true
+					new.Parent = autoList
+					new.Position = UDim2.new(0, 0, 0, 20 * aNum)
+					new.MouseButton1Down:Connect(function()
+						text.Text = text.Text..tostring(v)
+						text:CaptureFocus()
+					end)
+					
+					aNum += 1
+				end
+			end
+			
+			frame.Size = UDim2.new(1, 0, 0, math.clamp((math.max(num, aNum) * 20) + 40, 40, 140))
+			scroll.CanvasSize = UDim2.fromOffset(0, num * 20)
 		elseif text.Text == "" and opened then
 			scrollCloseTween:Play()
 			--service.SafeTweenSize(frame,UDim2.new(1,0,0,40), nil, nil,0.3, nil,function() if scrollOpen then frame.Size = UDim2.new(1,0,0,140) end end)
 			scroll.Visible = false
-			players.Visible = false
+			autoList.Visible = false
 			scrollOpen = false
 			scroll:ClearAllChildren()
 			scroll.CanvasSize = UDim2.new()


### PR DESCRIPTION
This PR is the first step in addressing #1353. This attempts to mirror the original functionality while addressing issues with how the default theme handles autocomplete suggestions. Primarily:
- Simplified/refactored the existing code
- Fixed an issue where the Frame would not be sized to accommodate the autocomplete suggestions
- Factored out autocomplete to a separate function inside of UI so that plugins can directly manipulate the resulting suggestions
- Fixed an issue where autocomplete suggestions for player names would be provided despite the first argument of a command always expecting a command and not a player
- Fixed an issue where autocomplete would attempt to concatenate the text with the table of command prefixes, resulting in an error

Why only the default theme? Simply put, I'm lazy at the moment. If there are criticisms about how I handled the new autocomplete suggestions in the default theme, I would have to change it in every single theme whenever a problem is brought up in review. This is fine since it doesn't adversely affect other themes that don't support this new functionality (yet).

Proof of functionality:

https://github.com/user-attachments/assets/126500d3-534d-4604-abca-d82218b70805

