### PR TITLE
Fix CI breakage following change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Cache Roblox Standard Library
       id: cache-roblox-std
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.2
       with:
         path: roblox.yml
         key: roblox-std


### PR DESCRIPTION
I noticed that the action runner for linting wasn't working in my other PRs, so I updated it to the latest version.

References; [[1]](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) [[2]](https://github.com/actions/cache/discussions/1510)