### PR TITLE
Typo fix for :ScreenVideo not working

### DIFF
--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -1389,7 +1389,7 @@ return function(Vargs, env)
 				local img = tostring(args[2])
 				if not img then error(`{args[2]} is not a valid ID`) end
 				for i, v in service.GetPlayers(plr, args[1]) do
-					Remote.MakeGui(v, "Effect", {Mode = "ScreenVideo"; video = args[2];})
+					Remote.MakeGui(v, "Effect", {Mode = "ScreenVideo"; Video = args[2];})
 				end
 			end
 		};


### PR DESCRIPTION
Fixed a small capitalization typo.

Reasoning: [Effect](https://github.com/Epix-Incorporated/Adonis/blob/master/MainModule/Client/UI/Default/Effect.luau?plain=1#L310) uses a capital V.

POF:
![image](https://github.com/user-attachments/assets/219da618-ce5d-41e6-8b53-63578769e8ba)