### PR TITLE
Change warn to print in dumplog

### DIFF
--- a/MainModule/Client/Client.luau
+++ b/MainModule/Client/Client.luau
@@ -142,7 +142,7 @@ end
 local isStudio = game:GetService("RunService"):IsStudio()
 game:GetService("NetworkClient").ChildRemoved:Connect(function(p)
 	if not isStudio then
-		warn("~! PLAYER DISCONNECTED/KICKED! DUMPING ADONIS CLIENT LOG!")
+		print("~! PLAYER DISCONNECTED/KICKED! DUMPING ADONIS CLIENT LOG!")
 		dumplog()
 	end
 end)


### PR DESCRIPTION
Changes missed warn to print to prevent experience output logs from catching an Adonis warn.