### PR TITLE
Update plugin documentation to include :Connect

### DIFF
--- a/Loader/Config/Plugins/Server-Example Plugin.luau
+++ b/Loader/Config/Plugins/Server-Example Plugin.luau
@@ -8,11 +8,11 @@
 	PlayerJoined will fire after the player finishes initial loading
 	CharacterAdded will also fire after the player is loaded, it does not use the CharacterAdded event.
 
-	service.Events.PlayerAdded(function(p)
+	service.Events.PlayerAdded:Connect(function(p)
 		print(`{p.Name} Joined! Example Plugin`)
 	end)
 
-	service.Events.CharacterAdded(function(p)
+	service.Events.CharacterAdded:Connect(function(p)
 		server.RunCommand('name', plr.Name, 'BobTest Example Plugin')
 	end)
 


### PR DESCRIPTION
The documentation made me go insane for about 30 minutes. I wondered why the `PlayerAdded` event would not fire, and I assume you can imagine why🤦‍♂️.

This PR should (hopefully) prevent the next unfortunate individual who uses this documentation as a reference from suffering the same fate as I did.