### PR TITLE
Re-enable code execution

### DIFF
--- a/Loader/Config/Settings.luau
+++ b/Loader/Config/Settings.luau
@@ -291,9 +291,9 @@ settings.CommandFeedback = false		-- Should players be notified when commands wi
 settings.CrossServerCommands = true		-- Are commands which affect more than one server enabled?
 settings.ChatCommands = true			-- If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands
 settings.CreatorPowers = true			-- Gives me creator-level admin; This is strictly used for debugging; I can't debug without full access to the script
-settings.CodeExecution = false			-- Enables the use of code execution in Adonis. Scripting related (such as ;s) and a few other commands require this
+settings.CodeExecution = true			-- Enables the use of code execution in Adonis. Scripting related (such as ;s) and a few other commands require this
 settings.SilentCommandDenials = false	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
-settings.OverrideChatCallbacks = true		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
+settings.OverrideChatCallbacks = true	-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
 
 settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is ;slocked


### PR DESCRIPTION
Why was this disabled in the first place?
The disabling will result in unexpected feature breakage for new users, and will probably make @moo1210 angry.
It also makes the main settings to not be up to date with the default settings module.

This fixes it by re-enabling it.