### PR TITLE
Make server shutdown use system message title

### DIFF
--- a/MainModule/Server/Plugins/Server-SoftShutdown.luau
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.luau
@@ -105,7 +105,7 @@ return function(Vargs, GetEnv)
 			if #Players:GetPlayers() == 0 then return end
 
 			local newserver = TeleportService:ReserveServer(game.PlaceId)
-			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
+			Functions.Message("Adonis", Settings.SystemTitle, "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
 			
 			task.wait(2)
 

--- a/MainModule/Server/Plugins/Server-SoftShutdown.luau
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.luau
@@ -167,7 +167,7 @@ return function(Vargs, GetEnv)
 			end
 
 			local newserver = TeleportService:ReserveServer(game.PlaceId)
-			Functions.Message("Adonis", "Server Restart", "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
+			Functions.Message("Adonis", Settings.SystemTitle, "The server is restarting, please wait...", 'MatIcon://Hourglass empty', service.GetPlayers(), false, 1000)
 			
 			task.wait(1)
 


### PR DESCRIPTION
Other system messages use this setting as well. This brings it to parity with those.

It also allows using a game desires watermark for soft shutdown as well for more professionalism.