### PR TITLE
Rename `:return` to `:back`

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -4839,7 +4839,7 @@ return function(Vargs, env)
 		
 		Back = {
 			Prefix = Settings.Prefix;
-			Commands = {"back"};
+			Commands = {"back", "return"};
 			Args = {"player"};
 			Description = "Returns the player to their original position";
 			AdminLevel = "Moderators";

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -4837,9 +4837,9 @@ return function(Vargs, env)
 			end
 		};
 		
-		Back = {
+		Return = {
 			Prefix = Settings.Prefix;
-			Commands = {"back", "return"};
+			Commands = {"return", "back"};
 			Args = {"player"};
 			Description = "Returns the player to their original position";
 			AdminLevel = "Moderators";

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -4837,9 +4837,9 @@ return function(Vargs, env)
 			end
 		};
 		
-		Return = {
+		Back = {
 			Prefix = Settings.Prefix;
-			Commands = {"return"};
+			Commands = {"back"};
 			Args = {"player"};
 			Description = "Returns the player to their original position";
 			AdminLevel = "Moderators";


### PR DESCRIPTION
This renames the `:return` command to `:back`.

`:return` is a more confusing and potentially conflicting name. Also many other command systems, for example [essential commands](https://www.curseforge.com/minecraft/mc-mods/essential-commands) refer it to as back instead of return.

Also return conflicts with Luas return. And the name return is ambigious and may refer to many other things and some games likely already have a command named return. This fixes it.