### PR TITLE
Made all asset ids work on capes and particles

### DIFF
--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -860,7 +860,7 @@ return function(Vargs, GetEnv)
 				Parent = p;
 				Name = "Decal";
 				Face = 2;
-				Texture = `rbxassetid://{decalId}`;
+				Texture = `rbxthumb://type=Asset&id={decalId}&w=420&h=420`;
 				Transparency = 0;
 			}) else nil
 
@@ -1456,7 +1456,7 @@ return function(Vargs, GetEnv)
 				if decal and decal~=0 then
 					local dec = service.New("Decal", p)
 					dec.Face = 2
-					dec.Texture = `http://www.roblox.com/asset/?id={decal}`
+					dec.Texture = `rbxthumb://type=Asset&id={decal}&w=420&h=420`
 					dec.Transparency=0
 				end
 				p.Size = Vector3.new(.2,.2,.2)

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -681,7 +681,7 @@ return function(data, env)
 
 								local img = pWindow:Add("ImageLabel", {
 									BackgroundTransparency = 1;
-									Image = `rbxassetid://{Functions.GetTexture(currentTexture)}`;
+									Image = `rbxthumb://type=Asset&id={currentTexture}&w=420&h=420`;
 									Size = UDim2.new(1, -10, 1, -80);
 									Position = UDim2.new(0, 5, 0, 35);
 								})
@@ -701,7 +701,7 @@ return function(data, env)
 												local num = tonumber(text)
 												if num then
 													lastValid = num
-													img.Image = `rbxassetid://{Functions.GetTexture(num)}`;
+													img.Image = `rbxthumb://type=Asset&id={num}&w=420&h=420`;
 												else
 													new.Text = lastValid
 												end

--- a/MainModule/Server/Commands/Donors.luau
+++ b/MainModule/Server/Commands/Donors.luau
@@ -227,7 +227,7 @@ return function(Vargs, env)
 					Functions.RemoveParticle(torso, "DONOR_PARTICLE")
 					Functions.NewParticle(torso, "ParticleEmitter", {
 						Name = "DONOR_PARTICLE";
-						Texture = `rbxassetid://{Functions.GetTexture(args[1])}`;
+						Texture = `rbxthumb://type=Asset&id={args[1]}&w=420&h=420`;
 						Size = NumberSequence.new({
 							NumberSequenceKeypoint.new(0,0);
 							NumberSequenceKeypoint.new(.1,.25,.25);


### PR DESCRIPTION
Uses the thumbnail of the asset instead of the asset itself so decals work
textures will continue to work as before
POF Coming i swear,