### PR TITLE
Make :clientscript only work when CodeExecution is on

### DIFF
--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -989,6 +989,7 @@ return function(Vargs, env)
 			AdminLevel = "Admins";
 			NoFilter = true;
 			Function = function(plr: Player, args: {string})
+				assert(Settings.CodeExecution, "CodeExecution must be enabled for this command to work")
 				assert(args[2], "Missing LocalScript code (argument #2)")
 
 				local bytecode = Core.Bytecode(args[2])


### PR DESCRIPTION
Idk why this wasn't affected before
PoF:
![image](https://github.com/user-attachments/assets/16e41889-bced-45ae-b7b6-80e83ea5fa31)
