### PR TITLE
Add whitelist of character mesh and texture IDs to prevent false anti-cheat detection

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.luau
+++ b/MainModule/Client/Plugins/Anti_Cheat.luau
@@ -296,13 +296,16 @@ return function(Vargs)
 						local screenshotHud = service.GuiService:FindFirstChildOfClass("ScreenshotHud")
 
 						for _, container in {Player.Character, service.StarterPack, Player:FindFirstChildOfClass("Backpack")} do
-							for _, v in ipairs(container:GetChildren()) do
+							for _, v: Instance in ipairs(container:GetChildren()) do
 								if v:IsA("BackpackItem") and service.Trim(v.TextureId) ~= "" then
 									table.insert(coreUrls, service.Trim(v.TextureId))
+								elseif v:IsA("MeshPart") then
+									table.insert(coreUrls, service.Trim(v.MeshId))
+									table.insert(coreUrls, service.Trim(v.TextureID)) -- For some reason, on MeshParts it's TextureID instead of TextureId
 								end
 							end
 						end
-								
+
 						if screenshotHud and service.Trim(screenshotHud.CameraButtonIcon) ~= "" then
 							table.insert(coreUrls, service.Trim(screenshotHud.CameraButtonIcon))
 						end
@@ -315,7 +318,7 @@ return function(Vargs)
 					local rawContentProvider = service.UnWrap(service.ContentProvider)
 					local workspace = service.UnWrap(workspace)
 					local tempDecal = service.UnWrap(Instance.new("Decal"))
-					tempDecal.Texture = "rbxasset://textures/face.png" -- Its a local asset and it's probably likely to never get removed, so it will never fail to load, unless the users PC is corrupted
+					tempDecal.Texture = "rbxasset://textures/face.png" -- It's a local asset and it's likely to never get removed, so it will never fail to load, unless the user's PC is corrupted
 					local coreUrls = getCoreUrls()
 
 					if not (service.GuiService.MenuIsOpen or service.ContentProvider.RequestQueueSize >= 50 or Player:GetNetworkPing() * 1000 >= 750) then
@@ -337,14 +340,14 @@ return function(Vargs)
 								end
 
 								hasDetected = true
-								Detected("Kick", "Disallowed content URL detected in CoreGui")
+								Detected("Kick", "Disallowed content URL detected in CoreGui: " ..url)
 							end
 						end)
 
 						tempDecal:Destroy()
 						task.wait(6)
-						if not activated then -- // Checks for anti-coregui detetection bypasses
-							Detected("kick", "Coregui detection bypass found")
+						if not activated then -- // Checks for Anti-CoreGui detection bypasses
+							Detected("kick", "CoreGui detection bypass found")
 						end
 					end
 
@@ -365,7 +368,7 @@ return function(Vargs)
 					then
 						Detected("kick", "Content provider spoofing detected")
 					end
-					
+
 					-- // GetFocusedTextBox detection
 					local textbox = service.UserInputService:GetFocusedTextBox()
 					local success, value = pcall(service.StarterGui.GetCore, service.StarterGui, "DeveloperConsoleVisible")
@@ -712,7 +715,7 @@ return function(Vargs)
 				if ran then
 					Detected("crash", "RobloxLocked usable")
 				end
-	
+
 				local function getDictionaryLenght(dictionary)
 					local len = 0
 
@@ -789,7 +792,7 @@ return function(Vargs)
 				end, function()
 					Detected("kick", "Tamper Protection 0x16C1D")
 				end)
-	
+
 				if gcinfo() ~= collectgarbage("count") then
 					Detected("kick", "GC spoofing detected")
 				end


### PR DESCRIPTION
Previously, if you opened the self-view menu, sometimes Adonis would detect you for exploiting and kick you for disallowed content url in CoreGui, the detected URLs were actually mesh and texture IDs from your avatar since the self-view appears to be using viewport frames, this pull request resolves the issue with false detection.

I'm not exactly sure if this is the best way to resolve this bug, but it did prevent the issue from happening again in my game.

Without whitelisting:
<img width="491" alt="image" src="https://github.com/user-attachments/assets/efd1f6b3-34fe-4e40-b211-4b29151d2b27" />

I couldn't reproduce this issue on desktop or in Roblox Studio, but my friend Iar505coolLeopard recorded it for me using an alt account
POF:
https://github.com/user-attachments/assets/db62b4ac-241b-419f-ac82-aa5432926105

sorry if this sounds dumb, this is my first pull request