### PR TITLE
Fix Console not showing if theme has custom Console

### DIFF
--- a/MainModule/Client/UI/Default/Console.rbxmx
+++ b/MainModule/Client/UI/Default/Console.rbxmx
@@ -124,7 +124,7 @@
 					<token name="HorizontalScrollBarInset">0</token>
 					<int name="LayoutOrder">0</int>
 					<Content name="MidImage"><url>http://roblox.com/asset?id=158348114</url></Content>
-					<string name="Name">AutocompleteList</string>
+					<string name="Name">PlayerList</string>
 					<Ref name="NextSelectionDown">null</Ref>
 					<Ref name="NextSelectionLeft">null</Ref>
 					<Ref name="NextSelectionRight">null</Ref>
@@ -560,7 +560,7 @@ return function(data, env)
 	local frame = gui.Frame
 	local text = frame.TextBox
 	local scroll = frame.ScrollingFrame
-	local autoList = frame.AutocompleteList
+	local autoList = frame.PlayerList
 	local entry = gui.Entry
 
 	local Settings = Remote.Get("Setting", {"SplitKey", "ConsoleKeyCode", "BatchKey", "Prefix"})

--- a/MainModule/Client/UI/TransBlack/Console.rbxmx
+++ b/MainModule/Client/UI/TransBlack/Console.rbxmx
@@ -505,7 +505,7 @@
 					<bool name="Interactable">true</bool>
 					<int name="LayoutOrder">0</int>
 					<Content name="MidImage"><url>http://roblox.com/asset?id=158348114</url></Content>
-					<string name="Name">AutocompleteList</string>
+					<string name="Name">PlayerList</string>
 					<Ref name="NextSelectionDown">null</Ref>
 					<Ref name="NextSelectionLeft">null</Ref>
 					<Ref name="NextSelectionRight">null</Ref>

--- a/MainModule/Client/UI/TransBlack/Console.rbxmx
+++ b/MainModule/Client/UI/TransBlack/Console.rbxmx
@@ -505,7 +505,7 @@
 					<bool name="Interactable">true</bool>
 					<int name="LayoutOrder">0</int>
 					<Content name="MidImage"><url>http://roblox.com/asset?id=158348114</url></Content>
-					<string name="Name">PlayerList</string>
+					<string name="Name">AutocompleteList</string>
 					<Ref name="NextSelectionDown">null</Ref>
 					<Ref name="NextSelectionLeft">null</Ref>
 					<Ref name="NextSelectionRight">null</Ref>


### PR DESCRIPTION
Fixed a problem introduced in pull #1853 this has caused one theme as I know to not work properly, this happened because of an unnecessary change of the ScrollingFrame name from `PlayerList` to `AutocompleteList`

There are some games that may not allow chat commands, in this case, if they have a theme that still uses PlayerList, they've essentially been softlocked from using Adonis. (almost every theme I believe with a custom console)

PoF:
![image](https://github.com/user-attachments/assets/d4fd214b-f925-440e-8288-3debe2ffbba0)
