### PR TITLE
Fix updateStatus for Capes in UserPanel

### DIFF
--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -533,7 +533,7 @@ return function(data, env)
 			local function updateStatus()
 				dStatus.Text = "Updating..."
 
-				if settingsData.DonorCapes and playerData.isDonor then
+				if settingsData.Settings.DonorCapes and playerData.isDonor then
 					if type(donorData) == "table" and donorData.Cape and type(donorData.Cape) == "table" then
 						if donorData.Enabled and service.Players.LocalPlayer.Character then
 							Functions.NewCape({


### PR DESCRIPTION
Fix an issue with the current Release of Adonis affecting every game, the index to check if it should update the Donor Cape status checks if `settingsData.DonorCapes` is true, but `settingsData` doesn't have DonorCapes, it needs to index further to actually be `settingsData.Settings.DonorCapes` I can only assume this occured because further down around likes 1500 they set the variable to `Settings` for the specific data looked at. This also introduced an error that nobody had because they had the error above, this would make their Cape Material set the the Image ID instead which was a typo.

TLDR: Fixed error where it was check for `settingsData.DonorCapes` instead of `settingsData.Settings.DonorCapes`. I aswell fixed a typo when setting a Cape, it was setting the Material to the Image ID not Material.

PoF:
https://github.com/user-attachments/assets/4deccf20-55d4-4a33-9a74-b5645f7e0e40