### PR TITLE
Security related fixes to Client G_API

### DIFF
--- a/MainModule/Client/Core/Core.luau
+++ b/MainModule/Client/Core/Core.luau
@@ -218,6 +218,10 @@ return function(Vargs, GetEnv)
 
 			local API = {
 				Access = service.MetaFunc(function(...)
+					if not Variables.G_Access_Key then
+						return
+					end
+
 					local args = {...}
 					local key = args[1]
 					local ind = args[2]

--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -1918,7 +1918,9 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
-		SHA256 = require(client.Shared.HashLib).SHA256;
+		SHA256 = function(...)
+			return require(client.Shared.HashLib).SHA256(...)
+		end;
 
 		GetFriendsOnline = function(maxFriends)
 			return service.Players.LocalPlayer:GetFriendsOnline(maxFriends)

--- a/MainModule/Server/Core/Functions.luau
+++ b/MainModule/Server/Core/Functions.luau
@@ -1642,7 +1642,9 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
-		SHA256 = require(server.Shared.HashLib).SHA256;
+		SHA256 = function(...)
+			return require(server.Shared.HashLib).SHA256(...)
+		end;
 
 		ParseBrickColor = function(str: string, allowNil: boolean?)
 			if not str and allowNil then

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -81,7 +81,10 @@ return function(Vargs, GetEnv)
 			end
 		end)
 
-		Remote._globalAccessHash = Functions.SHA256(Settings.G_Access_Key..game.GameId)
+		if Settings.G_Access_Key ~= "Example_Key" and Settings.Allowed_API_Calls.Client then
+			Remote._globalAccessHash = Functions.SHA256(Settings.G_Access_Key..game.GameId)
+		end
+
 		Process.Init = nil
 		AddLog("Script", "Processing Module Initialized")
 	end;


### PR DESCRIPTION
Does some QoL changes related to the recent Client G_API re-addition:
- Only calls require on SHA256 module when actually called
- Prevent Example_Key from being used in client
- Don't send a globalAccessHash if Client is disabled
- Check if G_Access_Key actually exists to prevent it from being nil and letting free access