### PR TITLE
Add donor debug commands

### DIFF
--- a/MainModule/Server/Plugins/Debug_Specific.luau
+++ b/MainModule/Server/Plugins/Debug_Specific.luau
@@ -418,7 +418,7 @@ local service = wrappedEnv.Service
 		Hidden = true;
 		Debug = true;
 		NoFilter = true;
-		AdminLevel = "HeadAdmins";
+		AdminLevel = "Moderators";
 		Function = function(plr: Player, args: {string})
 			local useIds = args[2] and string.lower(args[2]) == "true"
 
@@ -436,7 +436,7 @@ local service = wrappedEnv.Service
 		Hidden = true;
 		Debug = true;
 		NoFilter = true;
-		AdminLevel = "HeadAdmins";
+		AdminLevel = "Moderators";
 		Function = function(plr: Player, args: {string})
 			local useIds = args[2] and string.lower(args[2]) == "true"
 

--- a/MainModule/Server/Plugins/Debug_Specific.luau
+++ b/MainModule/Server/Plugins/Debug_Specific.luau
@@ -423,7 +423,7 @@ local service = wrappedEnv.Service
 			local useIds = args[2] and string.lower(args[2]) == "true"
 
 			for _, v in useIds and string.split(args[1], ",") or service.GetPlayers(plr, args[1]) do
-				Variables.CachedDonors[not useIds and v.UserId or tonumber(v))] = os.time()
+				Variables.CachedDonors[not useIds and v.UserId or tonumber(v)] = os.time()
 			end
 		end
 	};
@@ -441,7 +441,7 @@ local service = wrappedEnv.Service
 			local useIds = args[2] and string.lower(args[2]) == "true"
 
 			for _, v in useIds and string.split(args[1], ",") or service.GetPlayers(plr, args[1]) do
-				Variables.CachedDonors[not useIds and v.UserId or tonumber(v))] = nil
+				Variables.CachedDonors[not useIds and v.UserId or tonumber(v)] = nil
 			end
 		end
 	};

--- a/MainModule/Server/Plugins/Debug_Specific.luau
+++ b/MainModule/Server/Plugins/Debug_Specific.luau
@@ -367,7 +367,7 @@ local service = wrappedEnv.Service
 
 	Commands.DebugLoadstring = {
 		Prefix = Settings.Prefix;
-		Commands = {"debugloadstring";};
+		Commands = {"debugloadstring"};
 		Args = {"code";};
 		Description = "DEBUG LOADSTRING";
 		Hidden = true;
@@ -406,6 +406,42 @@ local service = wrappedEnv.Service
 		Function = function(plr: Player, args: {string})
 			for _, v in service.GetPlayers(plr, args[1]) do
 				Anti.Detected(v, table.unpack(args, 2))
+			end
+		end
+	};
+
+	Commands.DebugDonor = {
+		Prefix = Settings.Prefix;
+		Commands = {"debugdonor", "debugadddonor", "debugsetdonor", "debuggetdoor"};
+		Args = {"player", "useids"};
+		Description = "Allows you to temporarily add donors";
+		Hidden = true;
+		Debug = true;
+		NoFilter = true;
+		AdminLevel = "HeadAdmins";
+		Function = function(plr: Player, args: {string})
+			local useIds = args[2] and string.lower(args[2]) == "true"
+
+			for _, v in useIds and string.split(args[1], ",") or service.GetPlayers(plr, args[1]) do
+				Variables.CachedDonors[not useIds and v.UserId or tonumber(v))] = os.time()
+			end
+		end
+	};
+
+	Commands.DebugRemoveDonor = {
+		Prefix = Settings.Prefix;
+		Commands = {"debugremovedonor", "debugdeletedonor", "debugunsetdonor", "debugantidonor"};
+		Args = {"player", "useids"};
+		Description = "Allows you to temporarily remove donors";
+		Hidden = true;
+		Debug = true;
+		NoFilter = true;
+		AdminLevel = "HeadAdmins";
+		Function = function(plr: Player, args: {string})
+			local useIds = args[2] and string.lower(args[2]) == "true"
+
+			for _, v in useIds and string.split(args[1], ",") or service.GetPlayers(plr, args[1]) do
+				Variables.CachedDonors[not useIds and v.UserId or tonumber(v))] = nil
 			end
 		end
 	};

--- a/MainModule/Server/Plugins/Debug_Specific.luau
+++ b/MainModule/Server/Plugins/Debug_Specific.luau
@@ -423,7 +423,7 @@ local service = wrappedEnv.Service
 			local useIds = args[2] and string.lower(args[2]) == "true"
 
 			for _, v in useIds and string.split(args[1], ",") or service.GetPlayers(plr, args[1]) do
-				Variables.CachedDonors[not useIds and v.UserId or tonumber(v)] = os.time()
+				Variables.CachedDonors[tostring(not useIds and v.UserId or tonumber(v))] = os.time()
 			end
 		end
 	};
@@ -441,7 +441,7 @@ local service = wrappedEnv.Service
 			local useIds = args[2] and string.lower(args[2]) == "true"
 
 			for _, v in useIds and string.split(args[1], ",") or service.GetPlayers(plr, args[1]) do
-				Variables.CachedDonors[not useIds and v.UserId or tonumber(v)] = nil
+				Variables.CachedDonors[tostring(not useIds and v.UserId or tonumber(v))] = nil
 			end
 		end
 	};


### PR DESCRIPTION
This adds commands to temporarily remove and add donors to Adonis in the specific server.

This makes debugging donor related stuff a lot easier.
ie. if you have donor and want to test what it is like not to have it or vice versa then you can do it a lot easier because of these commands.
