### PR TITLE
Update :dexnew to silence warnings and improve UI

### DIFF
--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -2,7 +2,7 @@
 	<Meta name="ExplicitAutoJoints">true</Meta>
 	<External>null</External>
 	<External>nil</External>
-	<Item class="ModuleScript" referent="RBXAC493B167BC74652961D2FE361C167DC">
+	<Item class="ModuleScript" referent="RBX5375d266ba3f44ca87a7295b43f868e5">
 		<Properties>
 			<BinaryString name="AttributesSerialize"></BinaryString>
 			<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
@@ -60,8 +60,8 @@
 			end
 			Logs:AddLog("Script", "Successfully loaded reflection metadata to Dex")
 		else
-			Logs:AddLog("Script", "Access to HttpService is not enabled! Dex api dump could not be fetched!")
-			Logs:AddLog("Errors", "Access to HttpService is not enabled! Dex api dump could not be fetched!")
+			Logs:AddLog("Script", "Access to HttpService is not enabled! Dex API dump could not be fetched!")
+			Logs:AddLog("Errors", "Access to HttpService is not enabled! Dex API dump could not be fetched!")
 			--logError("Access to HttpService is not enabled! Dex api dump could not be fetched!")
 		end
 	end)
@@ -220,7 +220,7 @@ end]]></ProtectedString>
 			<int64 name="SourceAssetId">-1</int64>
 			<BinaryString name="Tags"></BinaryString>
 		</Properties>
-		<Item class="ModuleScript" referent="RBXC3ED37EFE03B42EE99BEA48B854420C8">
+		<Item class="ModuleScript" referent="RBXa3306330f67d46c280bf3883326842e6">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
 				<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
@@ -272,7 +272,7 @@ return serviceUtils
 				<BinaryString name="Tags"></BinaryString>
 			</Properties>
 		</Item>
-		<Item class="ScreenGui" referent="RBXA5263AB6EA7B4D1F925DACFAB75470AC">
+		<Item class="ScreenGui" referent="RBXa9d98eae19954747b82652c6397f6502">
 			<Properties>
 				<BinaryString name="AttributesSerialize"></BinaryString>
 				<bool name="AutoLocalize">true</bool>
@@ -295,7 +295,7 @@ return serviceUtils
 				<BinaryString name="Tags"></BinaryString>
 				<token name="ZIndexBehavior">1</token>
 			</Properties>
-			<Item class="LocalScript" referent="RBX708EA7A45863439096C90312B3CEEE7C">
+			<Item class="LocalScript" referent="RBX8b187518408b4395aff6a9e1d0ff03d1">
 				<Properties>
 					<BinaryString name="AttributesSerialize"></BinaryString>
 					<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
@@ -326,8 +326,8 @@ local API, RMD
 local SettingsEditor
 local AboutMenu
 
-local ReplicatedStorage = game:GetService("ReplicatedStorage");
-local Dex_RemoteEvent = ReplicatedStorage:WaitForChild("NewDex_Event");
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Dex_RemoteFunction = ReplicatedStorage:WaitForChild("NewDex_Event") :: RemoteFunction
 -- Default Settings
 DefaultSettings = (function()
 	local rgb = Color3.fromRGB
@@ -409,7 +409,7 @@ DefaultSettings = (function()
 end)()
 
 -- Vars
-local Settings = {}
+local Settings: any = {}
 local Apps = {}
 local env = {}
 local service = setmetatable({},{__index = function(self,name)
@@ -419,13 +419,18 @@ local service = setmetatable({},{__index = function(self,name)
 end})
 local plr = service.Players.LocalPlayer or service.Players.PlayerAdded:wait()
 
-local create = function(data)
-	local insts = {}
-	for i,v in pairs(data) do insts[v[1]] = Instance.new(v[2]) end
+local create = function(data: { [number]: any }): Instance
+	-- now Luau knows insts can be indexed by numbers
+	local insts= {}
 
-	for _,v in pairs(data) do
-		for prop,val in pairs(v[3]) do
-			if type(val) == "table" then
+	for _, v in ipairs(data) do
+		insts[v[1]] = Instance.new(v[2])
+	end
+
+	for _, v in ipairs(data) do
+		for prop, val in pairs(v[3]) do
+			if typeof(val) == "table" then
+				-- val[1] is a number → insts[val[1]] is an Instance
 				insts[v[1]][prop] = insts[val[1]]
 			else
 				insts[v[1]][prop] = val
@@ -433,7 +438,7 @@ local create = function(data)
 		end
 	end
 
-	return insts[1]
+	return insts[1] -- guaranteed to be the root
 end
 
 local createSimple = function(class,props)
@@ -450,12 +455,26 @@ Main = (function()
 	Main.ModuleList = {"Explorer","Properties"}--Main.ModuleList = {"Explorer","Properties","ScriptViewer"}
 	Main.Elevated = false
 	Main.MissingEnv = {}
-	Main.Version = "Beta 1.0.3 Adonis"
+	Main.Version = "Beta 1.0.4 Adonis"
 	Main.Mouse = plr:GetMouse()
 	Main.AppControls = {}
 	Main.Apps = Apps
 	Main.MenuApps = {}
 	Main.GitRepoName = "LorekeeperZinnia/Dex"
+	
+	-- silencer
+	Main.MainGui = nil
+	Main.AppsFrame = nil
+	Main.AppsContainer = nil
+	Main.AppsContainerGrid = nil
+	Main.AppTemplate = nil
+	Main.SettingsGuiButton = nil
+	Main.InformationGuiButton = nil
+	Main.MainGuiOpen = false
+	Main.LargeIcons = nil
+	Main.DepsVersionData = nil
+	Main.ClientVersion = nil
+	Main.MainGuiMouseEvent = nil
 
 	Main.DisplayOrders = {
 		SideWindow = 8,
@@ -484,90 +503,28 @@ Main = (function()
 		}
 	end
 
-	Main.Error = function(str)
-		if rconsoleprint then
-			rconsoleprint("DEX ERROR: "..tostring(str).."\n")
-			wait(9e9)
-		else
-			error(str)
-		end
+	Main.Error = function(str: string)
+		error(str)
 	end
 
 	Main.LoadModule = function(name)
-		if Main.Elevated then -- If you don't have filesystem api then ur outta luck tbh
-			local control
+		local module = script:WaitForChild("Modules"):WaitForChild(name,2)
+		if not module then Main.Error("Cannot find module "..name) end
 
-			if EmbeddedModules then -- Offline Modules
-				control = EmbeddedModules[name]()
+		local control = require(module) :: any
+		Main.AppControls[name] = control
+		control.InitDeps(Main.GetInitDeps())
 
-				-- TODO: Remove when open source
-				if gethsfuncs then
-					control = _G.moduleData
-				end
-
-				if not control then Main.Error("Missing Embedded Module: "..name) end
-			elseif _G.DebugLoadModel then -- Load Debug Model File
-				local model = Main.DebugModel
-				if not model then model = game:GetObjects(getsynasset("AfterModules.rbxm"))[1] end
-
-				control = loadstring(model.Modules[name].Source)()
-				print("Locally Loaded Module",name,control)
-			else
-				-- Get hash data
-				local hashs = Main.ModuleHashData
-				if not hashs then
-					local s,hashDataStr = pcall(game.HttpGet, game, "https://api.github.com/repos/"..Main.GitRepoName.."/ModuleHashs.dat")
-					if not s then Main.Error("Failed to get module hashs") end
-
-					local s,hashData = pcall(service.HttpService.JSONDecode,service.HttpService,hashDataStr)
-					if not s then Main.Error("Failed to decode module hash JSON") end
-
-					hashs = hashData
-					Main.ModuleHashData = hashs
-				end
-
-				-- Check if local copy exists with matching hashs
-				local hashfunc = (syn and syn.crypt.hash) or function() return "" end
-				local filePath = "dex/ModuleCache/"..name..".lua"
-				local s,moduleStr = pcall(env.readfile,filePath)
-
-				if s and hashfunc(moduleStr) == hashs[name] then
-					control = loadstring(moduleStr)()
-				else
-					-- Download and cache
-					local s,moduleStr = pcall(game.HttpGet, game, "https://api.github.com/repos/"..Main.GitRepoName.."/Modules/"..name..".lua")
-					if not s then Main.Error("Failed to get external module data of "..name) end
-
-					env.writefile(filePath,moduleStr)
-					control = loadstring(moduleStr)()
-				end
-			end
-
-			Main.AppControls[name] = control
-			control.InitDeps(Main.GetInitDeps())
-
-			local moduleData = control.Main()
-			Apps[name] = moduleData
-			return moduleData
-		else
-			local module = script:WaitForChild("Modules"):WaitForChild(name,2)
-			if not module then Main.Error("CANNOT FIND MODULE "..name) end
-
-			local control = require(module)
-			Main.AppControls[name] = control
-			control.InitDeps(Main.GetInitDeps())
-
-			local moduleData = control.Main()
-			Apps[name] = moduleData
-			return moduleData
-		end
+		local moduleData = control.Main()
+		Apps[name] = moduleData
+		return moduleData
 	end
 
 	Main.LoadModules = function()
 		for i,v in pairs(Main.ModuleList) do
 			local s,e = pcall(Main.LoadModule,v)
 			if not s then
-				Main.Error("FAILED LOADING " .. v .. " CAUSE " .. e)
+				Main.Error("Failed loading " .. v .. " because " .. e)
 			end
 		end
 
@@ -593,95 +550,59 @@ Main = (function()
 	end
 
 	Main.InitEnv = function()
+		local done = false
 		setmetatable(env,{__newindex = function(self,name,func)
-			if not func then Main.MissingEnv[#Main.MissingEnv+1] = name return end
+			if not done and not func then Main.MissingEnv[#Main.MissingEnv+1] = name return end
 			rawset(self,name,func)
 		end})
 
 		-- file
-		env.readfile = readfile
-		env.writefile = writefile
-		env.appendfile = appendfile
-		env.makefolder = makefolder
-		env.listfiles = listfiles
-		env.loadfile = loadfile
-		env.saveinstance = saveinstance
+		env.readfile = nil
+		env.writefile = nil
+		env.appendfile = nil
+		env.makefolder = nil
+		env.listfiles = nil
+		env.loadfile = nil
+		env.saveinstance = nil
 
 		-- debug
-		env.getupvalues = debug.getupvalues or getupvals
-		env.getconstants = debug.getconstants or getconsts
-		env.islclosure = islclosure or is_l_closure
-		env.checkcaller = checkcaller
-		env.getreg = getreg
-		env.getgc = getgc
+		env.getupvalues = nil
+		env.getconstants = nil
+		env.islclosure = nil
+		env.checkcaller = nil
+		env.getreg = nil
+		env.getgc = nil
 
 		-- other
-		env.setfflag = setfflag
-		env.decompile = decompile
-		env.protectgui = protect_gui or (syn and syn.protect_gui)
-		env.gethui = gethui
-		env.setclipboard = setclipboard
-		env.getnilinstances = getnilinstances or get_nil_instances
-		env.getloadedmodules = getloadedmodules
-
-		if identifyexecutor then
-			Main.Executor = identifyexecutor()
-		end
+		env.setfflag = nil
+		env.decompile = nil
+		env.protectgui = nil
+		env.gethui = nil
+		env.setclipboard = nil
+		env.getnilinstances = nil
+		env.getloadedmodules = nil
 
 		Main.GuiHolder = Main.Elevated and service.CoreGui or plr:FindFirstChildOfClass("PlayerGui")
 
-		setmetatable(env,nil)
+		done = true -- luau typing complains if I try to just reset the new index to rawset
 	end
 
-	--[[
-	Main.IncompatibleTest = function()
-		local function incompatibleMessage(reason)
-			local msg = Instance.new("ScreenGui")
-			local t = Instance.new("TextLabel",msg)
-			t.BackgroundColor3 = Color3.fromRGB(50,50,50)
-			t.Position = UDim2.new(0,0,0,-36)
-			t.Size = UDim2.new(1,0,1,36)
-			t.TextColor3 = Color3.new(1,1,1)
-			t.TextWrapped = true
-			t.TextScaled = true
-			t.Text = "\n\n\n\n\n\n\n\nHello Skidsploit user,\nZinnia and the Secret Service does not approve of Dex being used on your skidsploit.\nPlease consider getting something better.\n\nIncompatible Reason: "..reason.."\n\n\n\n\n\n\n\n"
-			
-			local sound = Instance.new("Sound",msg)
-			sound.SoundId = "rbxassetid://175964948"
-			sound.Volume = 1
-			sound.Looped = true
-			sound.Playing = true
-			Lib.ShowGui(msg)
-			
-			if os and os.execute then pcall(os.execute,'explorer "https://x.synapse.to/"') end
-			while wait() do end
+	Main.ResetSettings = function()
+		local function recur(t,res)
+			for set,val in pairs(t) do
+				if type(val) == "table" and val._Recurse then
+					if type(res[set]) ~= "table" then
+						res[set] = {}
+					end
+					recur(val,res[set])
+				else
+					res[set] = val
+				end
+			end
+			return res
 		end
-		
-		local t = {}
-		t[1] = t
-		local x = unpack(t) or incompatibleMessage("WRAPPER FAILED TO CYCLIC #1")
-		if x[1] ~= t then incompatibleMessage("WRAPPER FAILED TO CYCLIC #2") end
-		
-		if game ~= workspace.Parent then incompatibleMessage("WRAPPER NO CACHE") end
-		
-		if Main.Elevated and not loadstring("for i = 1,1 do continue end") then incompatibleMessage("CAN'T CONTINUE OR NO LOADSTRING") end
-		
-		local obj = newproxy(true)
-		local mt = getmetatable(obj)
-		mt.__index = function() incompatibleMessage("CAN'T NAMECALL") end
-		mt.__namecall = function() end
-		obj:No()
-		
-		local fEnv = setmetatable({zin = 5},{__index = getfenv()})
-		local caller = function(f) f() end
-		setfenv(caller,fEnv)
-		caller(function() if not getfenv(2).zin then incompatibleMessage("RERU WILL BE FILING A LAWSUIT AGAINST YOU SOON") end end)
-		
-		local second = false
-		task.spawn(function() local start = tick() wait(5) if tick() - start < 0.1 or not second then incompatibleMessage("SKIDDED YIELDING") end end)
-		second = true
+		recur(DefaultSettings :: any,Settings)
 	end
-	]]
 
 	Main.LoadSettings = function()
 		local s,data = pcall(env.readfile or error,"DexSettings.json")
@@ -699,26 +620,9 @@ Main = (function()
 		end
 	end
 
-	Main.ResetSettings = function()
-		local function recur(t,res)
-			for set,val in pairs(t) do
-				if type(val) == "table" and val._Recurse then
-					if type(res[set]) ~= "table" then
-						res[set] = {}
-					end
-					recur(val,res[set])
-				else
-					res[set] = val
-				end
-			end
-			return res
-		end
-		recur(DefaultSettings,Settings)
-	end
-
 	Main.FetchAPI = function()
 		local api,rawAPI
-		local didwedoit = Dex_RemoteEvent:InvokeServer("fetchapi")
+		local didwedoit = Dex_RemoteFunction:InvokeServer("fetchapi")
 
 		if didwedoit and type(didwedoit) == "table" then
 			rawAPI = didwedoit
@@ -726,7 +630,7 @@ Main = (function()
 			if script:FindFirstChild("API") then
 				rawAPI = require(script.API)
 			else
-				error("NO API EXISTS")
+				error("No API exists")
 			end
 		end
 
@@ -735,9 +639,9 @@ Main = (function()
 		local success, result = pcall(service.HttpService.JSONDecode, service.HttpService, rawAPI)
 		if not success or type(result) ~= "table" then
 			if type(result) ~= "table" then
-				error(`Error while decoding; Decoded data {result} is not type "table"`)
+				error(`Error while decoding Decoded data {result} is not type "table"`)
 			else
-				error(`Error while decoding; {result}`)
+				error(`Error while decoding {result}`)
 			end
 		else
 			api = result
@@ -871,7 +775,7 @@ Main = (function()
 
 	Main.FetchRMD = function()
 		local rawXML
-		local didwedoit = Dex_RemoteEvent:InvokeServer("fetchrmd")
+		local didwedoit = Dex_RemoteFunction:InvokeServer("fetchrmd")
 
 		if didwedoit then
 			rawXML = didwedoit
@@ -879,7 +783,7 @@ Main = (function()
 			if script:FindFirstChild("RMD") then
 				rawXML = require(script.RMD)
 			else
-				error("NO RMD EXISTS")
+				error("No RMD exists")
 			end
 		end
 
@@ -1374,20 +1278,6 @@ Main = (function()
 			Explorer = 0, Properties = 1, Script_Viewer = 2,
 		})
 
-		-- Fetch version if needed
-		intro.SetProgress("Fetching Roblox Version",0.2)
-		if Main.Elevated then
-			local fileVer = Lib.ReadFile("dex/deps_version.dat")
-			Main.ClientVersion = Version()
-			if fileVer then
-				Main.DepsVersionData = string.split(fileVer,"\n")
-				if Main.LocalDepsUpToDate() then
-					Main.RobloxVersion = Main.DepsVersionData[2]
-				end
-			end
-			Main.RobloxVersion = Main.RobloxVersion or game:HttpGet("http://setup.roblox.com/versionQTStudio")
-		end
-
 		-- Fetch external deps
 		intro.SetProgress("Fetching API",0.35)
 		API = Main.FetchAPI()
@@ -1396,18 +1286,10 @@ Main = (function()
 		RMD = Main.FetchRMD()
 		Lib.FastWait()
 
-		-- Save external deps locally if needed
-		if Main.Elevated and env.writefile and not Main.LocalDepsUpToDate() then
-			env.writefile("dex/deps_version.dat",Main.ClientVersion.."\n"..Main.RobloxVersion)
-			env.writefile("dex/rbx_api.dat",Main.RawAPI)
-			env.writefile("dex/rbx_rmd.dat",Main.RawRMD)
-		end
-
 		-- Load other modules
 		intro.SetProgress("Loading Modules",0.75)
 		SettingsEditor = Main.LoadModule("SettingsEditor")
 		AboutMenu = Main.LoadModule("AboutMenu")
-
 
 		Main.AppControls.Lib.InitDeps(Main.GetInitDeps()) -- Missing deps now available
 		Main.LoadModules()
@@ -1451,7 +1333,7 @@ Main.Init()
 					<int64 name="SourceAssetId">-1</int64>
 					<BinaryString name="Tags"></BinaryString>
 				</Properties>
-				<Item class="Folder" referent="RBX7C8624A570214DEEBCBD8CC4DCB95346">
+				<Item class="Folder" referent="RBX5c0276b788e44c8ea519b8ac4593fe2c">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
@@ -1460,24 +1342,23 @@ Main.Init()
 						<int64 name="SourceAssetId">-1</int64>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
-					<Item class="ModuleScript" referent="RBX852DBC46A43F4717B6B0363A1A255901">
+					<Item class="ModuleScript" referent="RBXe500bff87b2842508a05e3258e1ade4f">
 						<Properties>
 							<BinaryString name="AttributesSerialize"></BinaryString>
 							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
 							<bool name="DefinesCapabilities">false</bool>
 							<Content name="LinkedSource"><null></null></Content>
-							<string name="Name">Explorer</string>
-							<string name="ScriptGuid">{F5B7E89A-4B53-46EF-BB0F-99F053CC79A4}</string>
+							<string name="Name">Properties</string>
+							<string name="ScriptGuid">{7400135A-4B43-49CC-89BE-B0C5AF1AA6E0}</string>
 							<ProtectedString name="Source"><![CDATA[--[[
-	Explorer App Module
+	Properties App Module
 	
-	The main explorer interface
+	The main properties interface
 ]]
 
 -- ADONIS
-local ReplicatedStorage = game:GetService("ReplicatedStorage");
-local Dex_RemoteEvent = ReplicatedStorage:WaitForChild("NewDex_Event");
-
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Dex_RemoteFunction = ReplicatedStorage:WaitForChild("NewDex_Event") :: RemoteFunction
 
 -- Common Locals
 local Main,Lib,Apps,Settings -- Main Containers
@@ -1507,15 +1388,3522 @@ local function initAfterMain()
 end
 
 local function main()
+	local Properties = {}
+
+	local window, toolBar, propsFrame
+	local scrollV, scrollH
+	local categoryOrder
+	local props,viewList,expanded,indexableProps,propEntries,autoUpdateObjs = {},{},{},{},{},{}
+	local inputBox,inputTextBox,inputProp
+	local checkboxes,propCons = {},{}
+	local table,string = table,string
+	local getPropChangedSignal = game.GetPropertyChangedSignal
+	local getAttributeChangedSignal = game.GetAttributeChangedSignal
+	local isa = game.IsA
+	local getAttribute = game.GetAttribute
+	local setAttribute = game.SetAttribute
+
+	Properties.GuiElems = {}
+	Properties.Index = 0
+	Properties.ViewWidth = 0
+	Properties.MinInputWidth = 100
+	Properties.EntryIndent = 16
+	Properties.EntryOffset = 4
+	Properties.NameWidthCache = {}
+	Properties.SubPropCache = {}
+	Properties.ClassLists = {}
+	Properties.SearchText = ""
+
+	Properties.AddAttributeProp = {Category = "Attributes", Class = "", Name = "", SpecialRow = "AddAttribute", Tags = {}}
+	Properties.SoundPreviewProp = {Category = "Data", ValueType = {Name = "SoundPlayer"}, Class = "Sound", Name = "Preview", Tags = {}}
+
+	-- silencer
+	Properties.Refresh = nil
+	Properties.Update = nil
+	Properties.UpdateView = nil
+	Properties.ShowExplorerProps = nil
+	Properties.ComputeConflicts = nil
+	Properties.MakeSubProp = nil
+	Properties.GetExpandedProps = nil
+	Properties.NewPropEntry = nil
+	Properties.GetSoundPreviewEntry = nil
+	Properties.SetSoundPreview = nil
+	Properties.DisplayAttributeContext  = nil
+	Properties.DisplayAddAttributeWindow = nil
+	Properties.IsTextEditable = nil
+	Properties.DisplayEnumDropdown = nil
+	Properties.DisplayBrickColorEditor = nil
+	Properties.DisplayColorEditor = nil
+	Properties.DisplayNumberSequenceEditor = nil
+	Properties.DisplayColorSequenceEditor = nil
+	Properties.GetFirstPropVal = nil
+	Properties.GetPropVal = nil
+	Properties.SelectObject = nil
+	Properties.DisplayProp = nil
+	Properties.SetProp = nil
+	Properties.InitInputBox = nil
+	Properties.SetInputProp = nil
+	Properties.InitSearch = nil
+	Properties.InitEntryStuff = nil
+	Properties.Init = nil
+	Properties.EditingAttribute = nil
+	Properties.EnumContext = nil
+	Properties.BrickColorEditor = nil
+	Properties.ColorEditor = nil
+	Properties.NumberSequenceEditor = nil
+	Properties.ColorSequenceEditor = nil
+	Properties.FullNameFrame = nil
+	Properties.FullNameFrameAttach = nil
+	Properties.Window = nil
+	Properties.EntryTemplate = nil
+	Properties.PreviewSound = nil
+	Properties.AttributeContext = nil
+	Properties.AddAttributeWindow = nil
+
+	Properties.IgnoreProps = {
+		["DataModel"] = {
+			["PrivateServerId"] = true,
+			["PrivateServerOwnerId"] = true,
+			["VIPServerId"] = true,
+			["VIPServerOwnerId"] = true
+		}
+	}
+
+	Properties.ExpandableTypes = {
+		["Vector2"] = true,
+		["Vector3"] = true,
+		["UDim"] = true,
+		["UDim2"] = true,
+		["CFrame"] = true,
+		["Rect"] = true,
+		["PhysicalProperties"] = true,
+		["Ray"] = true,
+		["NumberRange"] = true,
+		["Faces"] = true,
+		["Axes"] = true,
+	}
+
+	Properties.ExpandableProps = {
+		["Sound.SoundId"] = true
+	}
+
+	Properties.CollapsedCategories = {
+		["Surface Inputs"] = true,
+		["Surface"] = true
+	}
+
+	Properties.ConflictSubProps = {
+		["Vector2"] = {"X","Y"},
+		["Vector3"] = {"X","Y","Z"},
+		["UDim"] = {"Scale","Offset"},
+		["UDim2"] = {"X","X.Scale","X.Offset","Y","Y.Scale","Y.Offset"},
+		["CFrame"] = {"Position","Position.X","Position.Y","Position.Z",
+			"RightVector","RightVector.X","RightVector.Y","RightVector.Z",
+			"UpVector","UpVector.X","UpVector.Y","UpVector.Z",
+			"LookVector","LookVector.X","LookVector.Y","LookVector.Z"},
+		["Rect"] = {"Min.X","Min.Y","Max.X","Max.Y"},
+		["PhysicalProperties"] = {"Density","Elasticity","ElasticityWeight","Friction","FrictionWeight"},
+		["Ray"] = {"Origin","Origin.X","Origin.Y","Origin.Z","Direction","Direction.X","Direction.Y","Direction.Z"},
+		["NumberRange"] = {"Min","Max"},
+		["Faces"] = {"Back","Bottom","Front","Left","Right","Top"},
+		["Axes"] = {"X","Y","Z"}
+	}
+
+	Properties.ConflictIgnore = {
+		["BasePart"] = {
+			["ResizableFaces"] = true
+		}
+	}
+
+	Properties.RoundableTypes = {
+		["float"] = true,
+		["double"] = true,
+		["Color3"] = true,
+		["UDim"] = true,
+		["UDim2"] = true,
+		["Vector2"] = true,
+		["Vector3"] = true,
+		["NumberRange"] = true,
+		["Rect"] = true,
+		["NumberSequence"] = true,
+		["ColorSequence"] = true,
+		["Ray"] = true,
+		["CFrame"] = true
+	}
+
+	Properties.TypeNameConvert = {
+		["number"] = "double",
+		["boolean"] = "bool"
+	}
+
+	Properties.ToNumberTypes = {
+		["int"] = true,
+		["int64"] = true,
+		["float"] = true,
+		["double"] = true
+	}
+
+	Properties.DefaultPropValue = {
+		string = "",
+		bool = false,
+		double = 0,
+		UDim = UDim.new(0,0),
+		UDim2 = UDim2.new(0,0,0,0),
+		BrickColor = BrickColor.new("Medium stone grey"),
+		Color3 = Color3.new(1,1,1),
+		Vector2 = Vector2.new(0,0),
+		Vector3 = Vector3.new(0,0,0),
+		NumberSequence = NumberSequence.new(1),
+		ColorSequence = ColorSequence.new(Color3.new(1,1,1)),
+		NumberRange = NumberRange.new(0),
+		Rect = Rect.new(0,0,0,0)
+	}
+
+	Properties.AllowedAttributeTypes = {"string","boolean","number","UDim","UDim2","BrickColor","Color3","Vector2","Vector3","NumberSequence","ColorSequence","NumberRange","Rect"}
+
+	Properties.StringToValue = function(prop,str)
+		local typeData = prop.ValueType
+		local typeName = typeData.Name
+
+		if typeName == "string" or typeName == "Content" then
+			return str
+		elseif Properties.ToNumberTypes[typeName] then
+			return tonumber(str)
+		elseif typeName == "Vector2" then
+			local vals = str:split(",")
+			local x,y = tonumber(vals[1]),tonumber(vals[2])
+			if x and y and #vals >= 2 then return Vector2.new(x,y) end
+		elseif typeName == "Vector3" then
+			local vals = str:split(",")
+			local x,y,z = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3])
+			if x and y and z and #vals >= 3 then return Vector3.new(x,y,z) end
+		elseif typeName == "UDim" then
+			local vals = str:split(",")
+			local scale,offset = tonumber(vals[1]),tonumber(vals[2])
+			if scale and offset and #vals >= 2 then return UDim.new(scale,offset) end
+		elseif typeName == "UDim2" then
+			local vals = str:gsub("[{}]",""):split(",")
+			local xScale,xOffset,yScale,yOffset = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3]),tonumber(vals[4])
+			if xScale and xOffset and yScale and yOffset and #vals >= 4 then return UDim2.new(xScale,xOffset,yScale,yOffset) end
+		elseif typeName == "CFrame" then
+			local vals = str:split(",")
+			local s,result = pcall(CFrame.new,unpack(vals))
+			if s and #vals >= 12 then return result end
+		elseif typeName == "Rect" then
+			local vals = str:split(",")
+			local s,result = pcall(Rect.new,unpack(vals))
+			if s and #vals >= 4 then return result end
+		elseif typeName == "Ray" then
+			local vals = str:gsub("[{}]",""):split(",")
+			local s,origin = pcall(Vector3.new,unpack(vals,1,3))
+			local s2,direction = pcall(Vector3.new,unpack(vals,4,6))
+			if s and s2 and #vals >= 6 then return Ray.new(origin,direction) end
+		elseif typeName == "NumberRange" then
+			local vals = str:split(",")
+			local s,result = pcall(NumberRange.new,unpack(vals))
+			if s and #vals >= 1 then return result end
+		elseif typeName == "Color3" then
+			local vals = str:gsub("[{}]",""):split(",")
+			local s,result = pcall(Color3.fromRGB,unpack(vals))
+			if s and #vals >= 3 then return result end
+		end
+
+		return nil
+	end
+
+	Properties.ValueToString = function(prop,val)
+		local typeData = prop.ValueType
+		local typeName = typeData.Name
+
+		if typeName == "Color3" then
+			return Lib.ColorToBytes(val)
+		elseif typeName == "NumberRange" then
+			return val.Min..", "..val.Max
+		end
+
+		return tostring(val)
+	end
+
+	Properties.GetIndexableProps = function(obj,classData)
+		if not Main.Elevated then
+			if not pcall(function() return obj.ClassName end) then return nil end
+		end
+
+		local ignoreProps = Properties.IgnoreProps[classData.Name] or {}
+
+		local result = {}
+		local count = 1
+		local props = classData.Properties
+		for i = 1,#props do
+			local prop = props[i]
+			if not ignoreProps[prop.Name] then
+				local s = pcall(function() return obj[prop.Name] end)
+				if s then
+					result[count] = prop
+					count = count + 1
+				end
+			end
+		end
+
+		return result
+	end
+
+	Properties.FindFirstObjWhichIsA = function(class)
+		local classList = Properties.ClassLists[class] or {}
+		if classList and #classList > 0 then
+			return classList[1]
+		end
+
+		return nil
+	end
+
+	Properties.ComputeConflicts = function(p)
+		local maxConflictCheck = Settings.Properties.MaxConflictCheck
+		local sList = Explorer.Selection.List
+		local classLists = Properties.ClassLists
+		local stringSplit = string.split
+		local t_clear = table.clear
+		local conflictIgnore = Properties.ConflictIgnore
+		local conflictMap = {}
+		local propList = p and {p} or props
+
+		if p then
+			local gName = p.Class.."."..p.Name
+			autoUpdateObjs[gName] = nil
+			local subProps = Properties.ConflictSubProps[p.ValueType.Name] or {}
+			for i = 1,#subProps do
+				autoUpdateObjs[gName.."."..subProps[i]] = nil
+			end
+		else
+			table.clear(autoUpdateObjs)
+		end
+
+		if #sList > 0 then
+			for i = 1,#propList do
+				local prop = propList[i]
+				local propName,propClass = prop.Name,prop.Class
+				local typeData = prop.RootType or prop.ValueType
+				local typeName = typeData.Name
+				local attributeName = prop.AttributeName
+				local gName = propClass.."."..propName
+
+				local checked = 0
+				local subProps = Properties.ConflictSubProps[typeName] or {}
+				local subPropCount = #subProps
+				local toCheck = subPropCount + 1
+				local conflictsFound = 0
+				local indexNames = {}
+				local ignored = conflictIgnore[propClass] and conflictIgnore[propClass][propName]
+				local truthyCheck = (typeName == "PhysicalProperties")
+				local isAttribute = prop.IsAttribute
+				local isMultiType = prop.MultiType
+
+				t_clear(conflictMap)
+
+				if not isMultiType then
+					local firstVal,firstObj,firstSet
+					local classList = classLists[prop.Class] or {}
+					for c = 1,#classList do
+						local obj = classList[c]
+						if not firstSet then
+							if isAttribute then
+								firstVal = getAttribute(obj,attributeName)
+								if firstVal ~= nil then
+									firstObj = obj
+									firstSet = true
+								end
+							else
+								firstVal = obj[propName]
+								firstObj = obj
+								firstSet = true
+							end
+							if ignored then break end
+						else
+							local propVal,skip
+							if isAttribute then
+								propVal = getAttribute(obj,attributeName)
+								if propVal == nil then skip = true end
+							else
+								propVal = obj[propName]
+							end
+
+							if not skip then
+								if not conflictMap[1] then
+									if truthyCheck then
+										if (firstVal and true or false) ~= (propVal and true or false) then
+											conflictMap[1] = true
+											conflictsFound = conflictsFound + 1
+										end
+									elseif firstVal ~= propVal then
+										conflictMap[1] = true
+										conflictsFound = conflictsFound + 1
+									end
+								end
+
+								if subPropCount > 0 then
+									for sPropInd = 1,subPropCount do
+										local indexes = indexNames[sPropInd]
+										if not indexes then indexes = stringSplit(subProps[sPropInd],".") indexNames[sPropInd] = indexes end
+
+										local firstValSub = firstVal
+										local propValSub = propVal
+
+										for j = 1,#indexes do
+											if not firstValSub or not propValSub then break end -- PhysicalProperties
+											local indexName = indexes[j]
+											firstValSub = firstValSub[indexName]
+											propValSub = propValSub[indexName]
+										end
+
+										local mapInd = sPropInd + 1
+										if not conflictMap[mapInd] and firstValSub ~= propValSub then
+											conflictMap[mapInd] = true
+											conflictsFound = conflictsFound + 1
+										end
+									end
+								end
+
+								if conflictsFound == toCheck then break end
+							end
+						end
+
+						checked = checked + 1
+						if checked == maxConflictCheck then break end
+					end
+
+					if not conflictMap[1] then autoUpdateObjs[gName] = firstObj end
+					for sPropInd = 1,subPropCount do
+						if not conflictMap[sPropInd+1] then
+							autoUpdateObjs[gName.."."..subProps[sPropInd]] = firstObj
+						end
+					end
+				end
+			end
+		end
+
+		if p then
+			Properties.Refresh()
+		end
+	end
+
+	-- Fetches the properties to be displayed based on the explorer selection
+	Properties.ShowExplorerProps = function()
+		local maxConflictCheck = Settings.Properties.MaxConflictCheck
+		local sList = Explorer.Selection.List
+		local foundClasses = {}
+		local propCount = 1
+		local elevated = Main.Elevated
+		local showDeprecated,showHidden = Settings.Properties.ShowDeprecated,Settings.Properties.ShowHidden
+		local Classes = API.Classes
+		local classLists = {}
+		local lower = string.lower
+		local RMDCustomOrders = RMD.PropertyOrders
+		local getAttributes = game.GetAttributes
+		local maxAttrs = Settings.Properties.MaxAttributes
+		local showingAttrs = Settings.Properties.ShowAttributes
+		local foundAttrs = {}
+		local attrCount = 0
+		local typeof = typeof
+		local typeNameConvert = Properties.TypeNameConvert
+
+		table.clear(props)
+
+		for i = 1,#sList do
+			local node = sList[i]
+			local obj = node.Obj
+			local class = node.Class
+			if not class then class = obj.ClassName node.Class = class end
+
+			local apiClass = Classes[class]
+			while apiClass do
+				local APIClassName = apiClass.Name
+				if not foundClasses[APIClassName] then
+					local apiProps = indexableProps[APIClassName]
+					if not apiProps then apiProps = Properties.GetIndexableProps(obj,apiClass) indexableProps[APIClassName] = apiProps end
+
+					for i = 1,#apiProps do
+						local prop = apiProps[i]
+						local tags = prop.Tags
+						if (not tags.Deprecated or showDeprecated) and (not tags.Hidden or showHidden) then
+							props[propCount] = prop
+							propCount = propCount + 1
+						end
+					end
+					foundClasses[APIClassName] = true
+				end
+
+				local classList = classLists[APIClassName]
+				if not classList then classList = {} classLists[APIClassName] = classList end
+				classList[#classList+1] = obj
+
+				apiClass = apiClass.Superclass
+			end
+
+			if showingAttrs and attrCount < maxAttrs then
+				local attrs = getAttributes(obj)
+				for name,val in pairs(attrs) do
+					local typ = typeof(val)
+					if not foundAttrs[name] then
+						local category = (typ == "Instance" and "Class") or (typ == "EnumItem" and "Enum") or "Other"
+						local valType = {Name = typeNameConvert[typ] or typ, Category = category}
+						local attrProp = {IsAttribute = true, Name = "ATTR_"..name, AttributeName = name, DisplayName = name, Class = "Instance", ValueType = valType, Category = "Attributes", Tags = {}}
+						props[propCount] = attrProp
+						propCount = propCount + 1
+						attrCount = attrCount + 1
+						foundAttrs[name] = {typ,attrProp}
+						if attrCount == maxAttrs then break end
+					elseif foundAttrs[name][1] ~= typ then
+						foundAttrs[name][2].MultiType = true
+						foundAttrs[name][2].Tags.ReadOnly = true
+						foundAttrs[name][2].ValueType = {Name = "string"}
+					end
+				end
+			end
+		end
+
+		table.sort(props,function(a,b)
+			if a.Category ~= b.Category then
+				return (categoryOrder[a.Category] or 9999) < (categoryOrder[b.Category] or 9999)
+			else
+				local aOrder = (RMDCustomOrders[a.Class] and RMDCustomOrders[a.Class][a.Name]) or 9999999
+				local bOrder = (RMDCustomOrders[b.Class] and RMDCustomOrders[b.Class][b.Name]) or 9999999
+				if aOrder ~= bOrder then
+					return aOrder < bOrder
+				else
+					return lower(a.Name) < lower(b.Name)
+				end
+			end
+		end)
+
+		-- Find conflicts and get auto-update instances
+		Properties.ClassLists = classLists
+		Properties.ComputeConflicts()
+		--warn("CONFLICT",tick()-start)
+		if #props > 0 then
+			props[#props+1] = Properties.AddAttributeProp
+		end
+
+		Properties.Update()
+		Properties.Refresh()
+	end
+
+	Properties.UpdateView = function()
+		local maxEntries = math.ceil(propsFrame.AbsoluteSize.Y / 23)
+		local maxX = propsFrame.AbsoluteSize.X
+		local totalWidth = Properties.ViewWidth + Properties.MinInputWidth
+
+		scrollV.VisibleSpace = maxEntries
+		scrollV.TotalSpace = #viewList + 1
+		scrollH.VisibleSpace = maxX
+		scrollH.TotalSpace = totalWidth
+
+		scrollV.Gui.Visible = #viewList + 1 > maxEntries
+		scrollH.Gui.Visible = Settings.Properties.ScaleType == 0 and totalWidth > maxX
+
+		local oldSize = propsFrame.Size
+		propsFrame.Size = UDim2.new(1,(scrollV.Gui.Visible and -16 or 0),1,(scrollH.Gui.Visible and -39 or -23))
+		if oldSize ~= propsFrame.Size then
+			Properties.UpdateView()
+		else
+			scrollV:Update()
+			scrollH:Update()
+
+			if scrollV.Gui.Visible and scrollH.Gui.Visible then
+				scrollV.Gui.Size = UDim2.new(0,16,1,-39)
+				scrollH.Gui.Size = UDim2.new(1,-16,0,16)
+				Properties.Window.GuiElems.Content.ScrollCorner.Visible = true
+			else
+				scrollV.Gui.Size = UDim2.new(0,16,1,-23)
+				scrollH.Gui.Size = UDim2.new(1,0,0,16)
+				Properties.Window.GuiElems.Content.ScrollCorner.Visible = false
+			end
+
+			Properties.Index = scrollV.Index
+		end
+	end
+
+	Properties.MakeSubProp = function(prop,subName,valueType,displayName)
+		local subProp = {}
+		for i,v in pairs(prop) do
+			subProp[i] = v
+		end
+		subProp.RootType = subProp.RootType or subProp.ValueType
+		subProp.ValueType = valueType
+		subProp.SubName = subProp.SubName and (subProp.SubName..subName) or subName
+		subProp.DisplayName = displayName
+
+		return subProp
+	end
+
+	Properties.GetExpandedProps = function(prop) -- TODO: Optimize using table
+		local result = {}
+		local typeData = prop.ValueType
+		local typeName = typeData.Name
+		local makeSubProp = Properties.MakeSubProp
+
+		if typeName == "Vector2" then
+			result[1] = makeSubProp(prop,".X",{Name = "float"})
+			result[2] = makeSubProp(prop,".Y",{Name = "float"})
+		elseif typeName == "Vector3" then
+			result[1] = makeSubProp(prop,".X",{Name = "float"})
+			result[2] = makeSubProp(prop,".Y",{Name = "float"})
+			result[3] = makeSubProp(prop,".Z",{Name = "float"})
+		elseif typeName == "CFrame" then
+			result[1] = makeSubProp(prop,".Position",{Name = "Vector3"})
+			result[2] = makeSubProp(prop,".RightVector",{Name = "Vector3"})
+			result[3] = makeSubProp(prop,".UpVector",{Name = "Vector3"})
+			result[4] = makeSubProp(prop,".LookVector",{Name = "Vector3"})
+		elseif typeName == "UDim" then
+			result[1] = makeSubProp(prop,".Scale",{Name = "float"})
+			result[2] = makeSubProp(prop,".Offset",{Name = "int"})
+		elseif typeName == "UDim2" then
+			result[1] = makeSubProp(prop,".X",{Name = "UDim"})
+			result[2] = makeSubProp(prop,".Y",{Name = "UDim"})
+		elseif typeName == "Rect" then
+			result[1] = makeSubProp(prop,".Min.X",{Name = "float"},"X0")
+			result[2] = makeSubProp(prop,".Min.Y",{Name = "float"},"Y0")
+			result[3] = makeSubProp(prop,".Max.X",{Name = "float"},"X1")
+			result[4] = makeSubProp(prop,".Max.Y",{Name = "float"},"Y1")
+		elseif typeName == "PhysicalProperties" then
+			result[1] = makeSubProp(prop,".Density",{Name = "float"})
+			result[2] = makeSubProp(prop,".Elasticity",{Name = "float"})
+			result[3] = makeSubProp(prop,".ElasticityWeight",{Name = "float"})
+			result[4] = makeSubProp(prop,".Friction",{Name = "float"})
+			result[5] = makeSubProp(prop,".FrictionWeight",{Name = "float"})
+		elseif typeName == "Ray" then
+			result[1] = makeSubProp(prop,".Origin",{Name = "Vector3"})
+			result[2] = makeSubProp(prop,".Direction",{Name = "Vector3"})
+		elseif typeName == "NumberRange" then
+			result[1] = makeSubProp(prop,".Min",{Name = "float"})
+			result[2] = makeSubProp(prop,".Max",{Name = "float"})
+		elseif typeName == "Faces" then
+			result[1] = makeSubProp(prop,".Back",{Name = "bool"})
+			result[2] = makeSubProp(prop,".Bottom",{Name = "bool"})
+			result[3] = makeSubProp(prop,".Front",{Name = "bool"})
+			result[4] = makeSubProp(prop,".Left",{Name = "bool"})
+			result[5] = makeSubProp(prop,".Right",{Name = "bool"})
+			result[6] = makeSubProp(prop,".Top",{Name = "bool"})
+		elseif typeName == "Axes" then
+			result[1] = makeSubProp(prop,".X",{Name = "bool"})
+			result[2] = makeSubProp(prop,".Y",{Name = "bool"})
+			result[3] = makeSubProp(prop,".Z",{Name = "bool"})
+		end
+
+		if prop.Name == "SoundId" and prop.Class == "Sound" then
+			result[1] = Properties.SoundPreviewProp
+		end
+
+		return result
+	end
+
+	Properties.Update = function()
+		table.clear(viewList)
+
+		local nameWidthCache = Properties.NameWidthCache
+		local lastCategory
+		local count = 1
+		local maxWidth,maxDepth = 0,1
+
+		local textServ = service.TextService
+		local getTextSize = textServ.GetTextSize
+		local font = Enum.Font.SourceSans
+		local size = Vector2.new(math.huge,20)
+		local stringSplit = string.split
+		local entryIndent = Properties.EntryIndent
+		local isFirstScaleType = Settings.Properties.ScaleType == 0
+		local find,lower = string.find,string.lower
+		local searchText = (#Properties.SearchText > 0 and lower(Properties.SearchText))
+
+		local function recur(props,depth)
+			for i = 1,#props do
+				local prop = props[i]
+				local propName = prop.Name
+				local subName = prop.SubName
+				local category = prop.Category
+
+				local visible
+				if searchText and depth == 1 then
+					if find(lower(propName),searchText,1,true) then
+						visible = true
+					end
+				else
+					visible = true
+				end
+
+				if visible and lastCategory ~= category then
+					viewList[count] = {CategoryName = category}
+					count = count + 1
+					lastCategory = category
+				end
+
+				if (expanded["CAT_"..category] and visible) or prop.SpecialRow then
+					if depth > 1 then prop.Depth = depth if depth > maxDepth then maxDepth = depth end end
+
+					if isFirstScaleType then
+						local nameArr = subName and stringSplit(subName,".")
+						local displayName = prop.DisplayName or (nameArr and nameArr[#nameArr]) or propName
+
+						local nameWidth = nameWidthCache[displayName]
+						if not nameWidth then nameWidth = getTextSize(textServ,displayName,14,font,size).X nameWidthCache[displayName] = nameWidth end
+
+						local totalWidth = nameWidth + entryIndent*depth
+						if totalWidth > maxWidth then
+							maxWidth = totalWidth
+						end
+					end
+
+					viewList[count] = prop
+					count = count + 1
+
+					local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
+					if expanded[fullName] then
+						local nextDepth = depth+1
+						local expandedProps = Properties.GetExpandedProps(prop)
+						if #expandedProps > 0 then
+							recur(expandedProps,nextDepth)
+						end
+					end
+				end
+			end
+		end
+		recur(props,1)
+
+		inputProp = nil
+		Properties.ViewWidth = maxWidth + 9 + Properties.EntryOffset
+		Properties.UpdateView()
+	end
+
+	Properties.NewPropEntry = function(index)
+		local newEntry = Properties.EntryTemplate:Clone()
+		local nameFrame = newEntry.NameFrame
+		local valueFrame = newEntry.ValueFrame
+		local newCheckbox = Lib.Checkbox.new(0)
+		newCheckbox.Gui.Position = UDim2.new(0,3,0,3)
+		newCheckbox.Gui.Parent = valueFrame
+		newCheckbox.OnInput:Connect(function()
+			local prop = viewList[index + Properties.Index]
+			if not prop then return end
+
+			if prop.ValueType.Name == "PhysicalProperties" then
+				Properties.SetProp(prop,newCheckbox.Toggled and true or nil)
+			else
+				Properties.SetProp(prop,newCheckbox.Toggled)
+			end
+		end)
+		checkboxes[index] = newCheckbox
+
+		local iconFrame = Main.MiscIcons:GetLabel()
+		iconFrame.Position = UDim2.new(0,2,0,3)
+		iconFrame.Parent = newEntry.ValueFrame.RightButton
+
+		newEntry.Position = UDim2.new(0,0,0,23*(index-1))
+
+		nameFrame.Expand.InputBegan:Connect(function(input)
+			local prop = viewList[index + Properties.Index]
+			if not prop or input.UserInputType ~= Enum.UserInputType.MouseMovement then return end
+
+			local fullName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
+
+			Main.MiscIcons:DisplayByKey(newEntry.NameFrame.Expand.Icon, expanded[fullName] and "Collapse_Over" or "Expand_Over")
+		end)
+
+		nameFrame.Expand.InputEnded:Connect(function(input)
+			local prop = viewList[index + Properties.Index]
+			if not prop or input.UserInputType ~= Enum.UserInputType.MouseMovement then return end
+
+			local fullName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
+
+			Main.MiscIcons:DisplayByKey(newEntry.NameFrame.Expand.Icon, expanded[fullName] and "Collapse" or "Expand")
+		end)
+
+		nameFrame.Expand.MouseButton1Down:Connect(function()
+			local prop = viewList[index + Properties.Index]
+			if not prop then return end
+
+			local fullName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
+			if not prop.CategoryName and not Properties.ExpandableTypes[prop.ValueType and prop.ValueType.Name] and not Properties.ExpandableProps[fullName] then return end
+
+			expanded[fullName] = not expanded[fullName]
+			Properties.Update()
+			Properties.Refresh()
+		end)
+
+		nameFrame.PropName.InputBegan:Connect(function(input)
+			local prop = viewList[index + Properties.Index]
+			if not prop then return end
+			if input.UserInputType == Enum.UserInputType.MouseMovement and not nameFrame.PropName.TextFits then
+				local fullNameFrame = Properties.FullNameFrame	
+				local nameArr = string.split(prop.Class.."."..prop.Name..(prop.SubName or ""),".")
+				local dispName = prop.DisplayName or nameArr[#nameArr]
+				local sizeX = service.TextService:GetTextSize(dispName,14,Enum.Font.SourceSans,Vector2.new(math.huge,20)).X
+
+				fullNameFrame.TextLabel.Text = dispName
+				--fullNameFrame.Position = UDim2.new(0,Properties.EntryIndent*(prop.Depth or 1) + Properties.EntryOffset,0,23*(index-1))
+				fullNameFrame.Size = UDim2.new(0,sizeX + 4,0,22)
+				fullNameFrame.Visible = true
+				Properties.FullNameFrameIndex = index
+				Properties.FullNameFrameAttach.SetData(fullNameFrame, {Target = nameFrame})
+				Properties.FullNameFrameAttach.Enable()
+			end
+		end)
+
+		nameFrame.PropName.InputEnded:Connect(function(input)
+			if input.UserInputType == Enum.UserInputType.MouseMovement and Properties.FullNameFrameIndex == index then
+				Properties.FullNameFrame.Visible = false
+				Properties.FullNameFrameAttach.Disable()
+			end
+		end)
+
+		valueFrame.ValueBox.MouseButton1Down:Connect(function()
+			local prop = viewList[index + Properties.Index]
+			if not prop then return end
+
+			Properties.SetInputProp(prop,index)
+		end)
+
+		valueFrame.ColorButton.MouseButton1Down:Connect(function()
+			local prop = viewList[index + Properties.Index]
+			if not prop then return end
+
+			Properties.SetInputProp(prop,index,"color")
+		end)
+
+		valueFrame.RightButton.MouseButton1Click:Connect(function()
+			local prop = viewList[index + Properties.Index]
+			if not prop then return end
+
+			local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
+			local inputFullName = inputProp and (inputProp.Class.."."..inputProp.Name..(inputProp.SubName or ""))
+
+			if fullName == inputFullName and inputProp.ValueType.Category == "Class" then
+				inputProp = nil
+				Properties.SetProp(prop,nil)
+			else
+				Properties.SetInputProp(prop,index,"right")
+			end
+		end)
+
+		nameFrame.ToggleAttributes.MouseButton1Click:Connect(function()
+			Settings.Properties.ShowAttributes = not Settings.Properties.ShowAttributes
+			Properties.ShowExplorerProps()
+		end)
+
+		newEntry.RowButton.MouseButton1Click:Connect(function()
+			Properties.DisplayAddAttributeWindow()
+		end)
+
+		newEntry.EditAttributeButton.MouseButton1Down:Connect(function()
+			local prop = viewList[index + Properties.Index]
+			if not prop then return end
+
+			Properties.DisplayAttributeContext(prop)
+		end)
+
+		valueFrame.SoundPreview.ControlButton.MouseButton1Click:Connect(function()
+			if Properties.PreviewSound and Properties.PreviewSound.Playing then
+				Properties.SetSoundPreview(false)
+			else
+				local soundObj = Properties.FindFirstObjWhichIsA("Sound")
+				if soundObj then Properties.SetSoundPreview(soundObj) end
+			end
+		end)
+
+		valueFrame.SoundPreview.InputBegan:Connect(function(input)
+			if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+
+			local releaseEvent,mouseEvent
+			releaseEvent = service.UserInputService.InputEnded:Connect(function(input)
+				if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+				releaseEvent:Disconnect()
+				mouseEvent:Disconnect()
+			end)
+
+			local timeLine = newEntry.ValueFrame.SoundPreview.TimeLine
+			local soundObj = Properties.FindFirstObjWhichIsA("Sound")
+			if soundObj then Properties.SetSoundPreview(soundObj,true) end
+
+			local function update(input)
+				local sound = Properties.PreviewSound
+				if not sound or sound.TimeLength == 0 then return end
+
+				local mouseX = input.Position.X
+				local timeLineSize = timeLine.AbsoluteSize
+				local relaX = mouseX - timeLine.AbsolutePosition.X
+
+				if timeLineSize.X <= 1 then return end
+				if relaX < 0 then relaX = 0 elseif relaX >= timeLineSize.X then relaX = timeLineSize.X-1 end
+
+				local perc = (relaX/(timeLineSize.X-1))
+				sound.TimePosition = perc*sound.TimeLength
+				timeLine.Slider.Position = UDim2.new(perc,-4,0,-8)
+			end
+			update(input)
+
+			mouseEvent = service.UserInputService.InputChanged:Connect(function(input)
+				if input.UserInputType == Enum.UserInputType.MouseMovement then
+					update(input)
+				end
+			end)
+		end)
+
+		newEntry.Parent = propsFrame
+
+		return {
+			Gui = newEntry,
+			GuiElems = {
+				NameFrame = nameFrame,
+				ValueFrame = valueFrame,
+				PropName = nameFrame.PropName,
+				ValueBox = valueFrame.ValueBox,
+				Expand = nameFrame.Expand,
+				ColorButton = valueFrame.ColorButton,
+				ColorPreview = valueFrame.ColorButton.ColorPreview,
+				Gradient = valueFrame.ColorButton.ColorPreview.UIGradient,
+				EnumArrow = valueFrame.EnumArrow,
+				Checkbox = valueFrame.Checkbox,
+				RightButton = valueFrame.RightButton,
+				RightButtonIcon = iconFrame,
+				RowButton = newEntry.RowButton,
+				EditAttributeButton = newEntry.EditAttributeButton,
+				ToggleAttributes = nameFrame.ToggleAttributes,
+				SoundPreview = valueFrame.SoundPreview,
+				SoundPreviewSlider = valueFrame.SoundPreview.TimeLine.Slider
+			}
+		}
+	end
+
+	Properties.GetSoundPreviewEntry = function()
+		for i = 1,#viewList do
+			if viewList[i] == Properties.SoundPreviewProp then
+				return propEntries[i - Properties.Index]
+			end
+		end
+	end
+
+	Properties.SetSoundPreview = function(soundObj:Sound?,noplay:boolean)
+		local sound = Properties.PreviewSound :: Sound
+		if not sound then
+			sound = Instance.new("Sound")
+			sound.Name = "Preview"
+			sound.Paused:Connect(function()
+				local entry = Properties.GetSoundPreviewEntry()
+				if entry then Main.MiscIcons:DisplayByKey(entry.GuiElems.SoundPreview.ControlButton.Icon, "Play") end
+			end)
+			sound.Resumed:Connect(function() Properties.Refresh() end)
+			sound.Ended:Connect(function()
+				local entry = Properties.GetSoundPreviewEntry()
+				if entry then entry.GuiElems.SoundPreviewSlider.Position = UDim2.new(0,-4,0,-8) end
+				Properties.Refresh()
+			end)
+			sound.Parent = window.Gui
+			Properties.PreviewSound = sound
+		end
+
+		if not soundObj then
+			sound:Pause()
+			for i,v in pairs(sound:GetChildren()) do
+				v:Destroy()
+			end
+		else
+			local newId = sound.SoundId ~= soundObj.SoundId
+			sound.SoundId = soundObj.SoundId
+			sound.PlaybackSpeed = soundObj.PlaybackSpeed
+			sound.Volume = soundObj.Volume
+			if newId then
+				for i,v in pairs(sound:GetChildren()) do
+					v:Destroy()
+				end 
+				sound.TimePosition = 0 
+			end
+			for i,v in pairs(soundObj:GetChildren()) do
+				v:Clone().Parent = sound
+			end
+			if not noplay then sound:Resume() end
+
+			task.spawn(function()
+				local previewTime = tick()
+				Properties.SoundPreviewTime = previewTime
+				while previewTime == Properties.SoundPreviewTime and sound.Playing do
+					local entry = Properties.GetSoundPreviewEntry()
+					if entry then
+						local tl = sound.TimeLength
+						local perc = sound.TimePosition/(tl == 0 and 1 or tl)
+						entry.GuiElems.SoundPreviewSlider.Position = UDim2.new(perc,-4,0,-8)
+					end
+					Lib.FastWait()
+				end
+			end)
+			Properties.Refresh()
+		end
+	end
+
+	Properties.DisplayAttributeContext = function(prop)
+		local context = Properties.AttributeContext
+		if not context then
+			context = Lib.ContextMenu.new()
+			context.Iconless = true
+			context.Width = 80
+		end
+		context:Clear()
+
+		context:Add({Name = "Edit", OnClick = function()
+			Properties.DisplayAddAttributeWindow(prop)
+		end})
+		context:Add({Name = "Delete", OnClick = function()
+			Properties.SetProp(prop,nil,true)
+			Properties.ShowExplorerProps()
+		end})
+
+		context:Show()
+	end
+
+	Properties.DisplayAddAttributeWindow = function(editAttr)
+		local win = Properties.AddAttributeWindow
+		if not win then
+			win = Lib.Window.new()
+			win.Alignable = false
+			win.Resizable = false
+			win:SetTitle("Add Attribute")
+			win:SetSize(200,130)
+
+			local saveButton = Lib.Button.new()
+			local nameLabel = Lib.Label.new()
+			nameLabel.Text = "Name"
+			nameLabel.Position = UDim2.new(0,30,0,10)
+			nameLabel.Size = UDim2.new(0,40,0,20)
+			win:Add(nameLabel)
+
+			local nameBox = Lib.ViewportTextBox.new()
+			nameBox.Position = UDim2.new(0,75,0,10)
+			nameBox.Size = UDim2.new(0,120,0,20)
+			win:Add(nameBox,"NameBox")
+			nameBox.TextBox:GetPropertyChangedSignal("Text"):Connect(function()
+				saveButton:SetDisabled(#nameBox:GetText() == 0)
+			end)
+
+			local typeLabel = Lib.Label.new()
+			typeLabel.Text = "Type"
+			typeLabel.Position = UDim2.new(0,30,0,40)
+			typeLabel.Size = UDim2.new(0,40,0,20)
+			win:Add(typeLabel)
+
+			local typeChooser = Lib.DropDown.new()
+			typeChooser.CanBeEmpty = false
+			typeChooser.Position = UDim2.new(0,75,0,40)
+			typeChooser.Size = UDim2.new(0,120,0,20)
+			typeChooser:SetOptions(Properties.AllowedAttributeTypes)
+			win:Add(typeChooser,"TypeChooser")
+
+			local errorLabel = Lib.Label.new()
+			errorLabel.Text = ""
+			errorLabel.Position = UDim2.new(0,5,1,-45)
+			errorLabel.Size = UDim2.new(1,-10,0,20)
+			errorLabel.TextColor3 = Settings.Theme.Important
+			win.ErrorLabel = errorLabel
+			win:Add(errorLabel,"Error")
+
+			local cancelButton = Lib.Button.new()
+			cancelButton.Text = "Cancel"
+			cancelButton.Position = UDim2.new(1,-97,1,-25)
+			cancelButton.Size = UDim2.new(0,92,0,20)
+			cancelButton.OnClick:Connect(function()
+				win:Close()
+			end)
+			win:Add(cancelButton)
+
+			saveButton.Text = "Save"
+			saveButton.Position = UDim2.new(0,5,1,-25)
+			saveButton.Size = UDim2.new(0,92,0,20)
+			saveButton.OnClick:Connect(function()
+				local name = nameBox:GetText()
+				if #name > 100 then
+					errorLabel.Text = "Error: Name over 100 chars"
+					return
+				elseif name:sub(1,3) == "RBX" then
+					errorLabel.Text = "Error: Name begins with 'RBX'"
+					return
+				end
+
+				local typ = typeChooser.Selected
+				local valType = {Name = Properties.TypeNameConvert[typ] or typ, Category = "DataType"}
+				local attrProp = {IsAttribute = true, Name = "ATTR_"..name, AttributeName = name, DisplayName = name, Class = "Instance", ValueType = valType, Category = "Attributes", Tags = {}}
+
+				Settings.Properties.ShowAttributes = true
+				Properties.SetProp(attrProp,Properties.DefaultPropValue[valType.Name],true,Properties.EditingAttribute)
+				Properties.ShowExplorerProps()
+				win:Close()
+			end)
+			win:Add(saveButton,"SaveButton")
+
+			Properties.AddAttributeWindow = win
+		end
+
+		Properties.EditingAttribute = editAttr
+		win:SetTitle(editAttr and "Edit Attribute "..editAttr.AttributeName or "Add Attribute")
+		win.Elements.Error.Text = ""
+		win.Elements.NameBox:SetText("")
+		win.Elements.SaveButton:SetDisabled(true)
+		win.Elements.TypeChooser:SetSelected(1)
+		win:Show()
+	end
+
+	Properties.IsTextEditable = function(prop)
+		local typeData = prop.ValueType
+		local typeName = typeData.Name
+
+		return typeName ~= "bool" and typeData.Category ~= "Enum" and typeData.Category ~= "Class" and typeName ~= "BrickColor"
+	end
+
+	Properties.DisplayEnumDropdown = function(entryIndex)
+		local context = Properties.EnumContext
+		if not context then
+			context = Lib.ContextMenu.new()
+			context.Iconless = true
+			context.MaxHeight = 200
+			context.ReverseYOffset = 22
+			Properties.EnumDropdown = context
+		end
+
+		if not inputProp or inputProp.ValueType.Category ~= "Enum" then return end
+		local prop = inputProp
+
+		local entry = propEntries[entryIndex]
+		local valueFrame = entry.GuiElems.ValueFrame
+
+		local enum = Enum[prop.ValueType.Name]
+		if not enum then return end
+
+		local sorted = {}
+		for name,enum in next,enum:GetEnumItems() do
+			sorted[#sorted+1] = enum
+		end
+		table.sort(sorted,function(a,b) return a.Name < b.Name end)
+
+		context:Clear()
+
+		local function onClick(name)
+			if prop ~= inputProp then return end
+
+			local enumItem = enum[name]
+			inputProp = nil
+			Properties.SetProp(prop,enumItem)
+		end
+
+		for i = 1,#sorted do
+			local enumItem = sorted[i]
+			context:Add({Name = enumItem.Name, OnClick = onClick})
+		end
+
+		context.Width = valueFrame.AbsoluteSize.X
+		context:Show(valueFrame.AbsolutePosition.X, valueFrame.AbsolutePosition.Y + 22)
+	end
+
+	Properties.DisplayBrickColorEditor = function(prop,entryIndex,col)
+		local editor = Properties.BrickColorEditor
+		if not editor then
+			editor = Lib.BrickColorPicker.new()
+			editor.Gui.DisplayOrder = Main.DisplayOrders.Menu
+			editor.ReverseYOffset = 22
+
+			editor.OnSelect:Connect(function(col)
+				if not editor.CurrentProp or editor.CurrentProp.ValueType.Name ~= "BrickColor" then return end
+
+				if editor.CurrentProp == inputProp then inputProp = nil end
+				Properties.SetProp(editor.CurrentProp,BrickColor.new(col))
+			end)
+
+			editor.OnMoreColors:Connect(function() -- TODO: Special Case BasePart.BrickColor to BasePart.Color
+				editor:Close()
+				local colProp
+				for i,v in pairs(API.Classes.BasePart.Properties) do
+					if v.Name == "Color" then
+						colProp = v
+						break
+					end
+				end
+				Properties.DisplayColorEditor(colProp,editor.SavedColor.Color)
+			end)
+
+			Properties.BrickColorEditor = editor
+		end
+
+		local entry = propEntries[entryIndex]
+		local valueFrame = entry.GuiElems.ValueFrame
+
+		editor.CurrentProp = prop
+		editor.SavedColor = col
+		if prop and prop.Class == "BasePart" and prop.Name == "BrickColor" then
+			editor:SetMoreColorsVisible(true)
+		else
+			editor:SetMoreColorsVisible(false)
+		end
+		editor:Show(valueFrame.AbsolutePosition.X, valueFrame.AbsolutePosition.Y + 22)
+	end
+
+	Properties.DisplayColorEditor = function(prop,col)
+		local editor = Properties.ColorEditor
+		if not editor then
+			editor = Lib.ColorPicker.new()
+
+			editor.OnSelect:Connect(function(col)
+				if not editor.CurrentProp then return end
+				local typeName = editor.CurrentProp.ValueType.Name
+				if typeName ~= "Color3" and typeName ~= "BrickColor" then return end
+
+				local colVal = (typeName == "Color3" and col or BrickColor.new(col))
+
+				if editor.CurrentProp == inputProp then inputProp = nil end
+				Properties.SetProp(editor.CurrentProp,colVal)
+			end)
+
+			Properties.ColorEditor = editor
+		end
+
+		editor.CurrentProp = prop
+		if col then
+			editor:SetColor(col)
+		else
+			local firstVal = Properties.GetFirstPropVal(prop)
+			if firstVal then editor:SetColor(firstVal) end
+		end
+		editor:Show()
+	end
+
+	Properties.DisplayNumberSequenceEditor = function(prop,seq)
+		local editor = Properties.NumberSequenceEditor
+		if not editor then
+			editor = Lib.NumberSequenceEditor.new()
+
+			editor.OnSelect:Connect(function(val)
+				if not editor.CurrentProp or editor.CurrentProp.ValueType.Name ~= "NumberSequence" then return end
+
+				if editor.CurrentProp == inputProp then inputProp = nil end
+				Properties.SetProp(editor.CurrentProp,val)
+			end)
+
+			Properties.NumberSequenceEditor = editor
+		end
+
+		editor.CurrentProp = prop
+		if seq then
+			editor:SetSequence(seq)
+		else
+			local firstVal = Properties.GetFirstPropVal(prop)
+			if firstVal then editor:SetSequence(firstVal) end
+		end
+		editor:Show()
+	end
+
+	Properties.DisplayColorSequenceEditor = function(prop,seq)
+		local editor = Properties.ColorSequenceEditor
+		if not editor then
+			editor = Lib.ColorSequenceEditor.new()
+
+			editor.OnSelect:Connect(function(val)
+				if not editor.CurrentProp or editor.CurrentProp.ValueType.Name ~= "ColorSequence" then return end
+
+				if editor.CurrentProp == inputProp then inputProp = nil end
+				Properties.SetProp(editor.CurrentProp,val)
+			end)
+
+			Properties.ColorSequenceEditor = editor
+		end
+
+		editor.CurrentProp = prop
+		if seq then
+			editor:SetSequence(seq)
+		else
+			local firstVal = Properties.GetFirstPropVal(prop)
+			if firstVal then editor:SetSequence(firstVal) end
+		end
+		editor:Show()
+	end
+
+	Properties.GetFirstPropVal = function(prop)
+		local first = Properties.FindFirstObjWhichIsA(prop.Class)
+		if first then
+			return Properties.GetPropVal(prop,first)
+		end
+	end
+
+	Properties.GetPropVal = function(prop,obj)
+		if prop.MultiType then return "<Multiple Types>" end
+		if not obj then return end
+
+		local propVal
+		if prop.IsAttribute then
+			propVal = getAttribute(obj,prop.AttributeName)
+			if propVal == nil then return nil end
+
+			local typ = typeof(propVal)
+			local currentType = Properties.TypeNameConvert[typ] or typ
+			if prop.RootType then
+				if prop.RootType.Name ~= currentType then
+					return nil
+				end
+			elseif prop.ValueType.Name ~= currentType then
+				return nil
+			end
+		else
+			propVal = obj[prop.Name]
+		end
+		if prop.SubName then
+			local indexes = string.split(prop.SubName,".")
+			for i = 1,#indexes do
+				local indexName = indexes[i]
+				if #indexName > 0 and propVal then
+					propVal = propVal[indexName]
+				end
+			end
+		end
+
+		return propVal
+	end
+
+	Properties.SelectObject = function(obj)
+		if inputProp and inputProp.ValueType.Category == "Class" then
+			local prop = inputProp
+			inputProp = nil
+
+			if isa(obj,prop.ValueType.Name) then
+				Properties.SetProp(prop,obj)
+			else
+				Properties.Refresh()
+			end
+
+			return true
+		end
+
+		return false
+	end
+
+	Properties.DisplayProp = function(prop,entryIndex)
+		local propName = prop.Name
+		local typeData = prop.ValueType
+		local typeName = typeData.Name
+		local tags = prop.Tags
+		local gName = prop.Class.."."..prop.Name..(prop.SubName or "")
+		local propObj = autoUpdateObjs[gName]
+		local entryData = propEntries[entryIndex]
+		local UDim2 = UDim2
+
+		local guiElems = entryData.GuiElems
+		local valueFrame = guiElems.ValueFrame
+		local valueBox = guiElems.ValueBox
+		local colorButton = guiElems.ColorButton
+		local colorPreview = guiElems.ColorPreview
+		local gradient = guiElems.Gradient
+		local enumArrow = guiElems.EnumArrow
+		local checkbox = guiElems.Checkbox
+		local rightButton = guiElems.RightButton
+		local soundPreview = guiElems.SoundPreview
+
+		local propVal = Properties.GetPropVal(prop,propObj)
+		local inputFullName = inputProp and (inputProp.Class.."."..inputProp.Name..(inputProp.SubName or ""))
+
+		local offset = 4
+		local endOffset = 6
+
+		-- Offsetting the ValueBox for ValueType specific buttons
+		if (typeName == "Color3" or typeName == "BrickColor" or typeName == "ColorSequence") then
+			colorButton.Visible = true
+			enumArrow.Visible = false
+			if propVal then
+				gradient.Color = (typeName == "Color3" and ColorSequence.new(propVal)) or (typeName == "BrickColor" and ColorSequence.new(propVal.Color)) or propVal
+			else
+				gradient.Color = ColorSequence.new(Color3.new(1,1,1))
+			end
+			colorPreview.BorderColor3 = (typeName == "ColorSequence" and Color3.new(1,1,1) or Color3.new(0,0,0))
+			offset = 22
+			endOffset = 24 + (typeName == "ColorSequence" and 20 or 0)
+		elseif typeData.Category == "Enum" then
+			colorButton.Visible = false
+			enumArrow.Visible = not prop.Tags.ReadOnly
+			endOffset = 22
+		elseif (gName == inputFullName and typeData.Category == "Class") or typeName == "NumberSequence" then
+			colorButton.Visible = false
+			enumArrow.Visible = false
+			endOffset = 26
+		else
+			colorButton.Visible = false
+			enumArrow.Visible = false
+		end
+
+		valueBox.Position = UDim2.new(0,offset,0,0)
+		valueBox.Size = UDim2.new(1,-endOffset,1,0)
+
+		-- Right button
+		if inputFullName == gName and typeData.Category == "Class" then
+			Main.MiscIcons:DisplayByKey(guiElems.RightButtonIcon, "Delete")
+			guiElems.RightButtonIcon.Visible = true
+			rightButton.Text = ""
+			rightButton.Visible = true
+		elseif typeName == "NumberSequence" or typeName == "ColorSequence" then
+			guiElems.RightButtonIcon.Visible = false
+			rightButton.Text = "..."
+			rightButton.Visible = true
+		else
+			rightButton.Visible = false
+		end
+
+		-- Displays the correct ValueBox for the ValueType, and sets it to the prop value
+		if typeName == "bool" or typeName == "PhysicalProperties" then
+			valueBox.Visible = false
+			checkbox.Visible = true
+			soundPreview.Visible = false
+			checkboxes[entryIndex].Disabled = tags.ReadOnly
+			if typeName == "PhysicalProperties" and autoUpdateObjs[gName] then
+				checkboxes[entryIndex]:SetState(propVal and true or false)
+			else
+				checkboxes[entryIndex]:SetState(propVal)
+			end
+		elseif typeName == "SoundPlayer" then
+			valueBox.Visible = false
+			checkbox.Visible = false
+			soundPreview.Visible = true
+			local playing = Properties.PreviewSound and Properties.PreviewSound.Playing
+			Main.MiscIcons:DisplayByKey(soundPreview.ControlButton.Icon, playing and "Pause" or "Play")
+		else
+			valueBox.Visible = true
+			checkbox.Visible = false
+			soundPreview.Visible = false
+
+			if propVal ~= nil then
+				if typeName == "Color3" then
+					valueBox.Text = "["..Lib.ColorToBytes(propVal).."]"
+				elseif typeData.Category == "Enum" then
+					valueBox.Text = propVal.Name
+				elseif Properties.RoundableTypes[typeName] and Settings.Properties.NumberRounding then
+					local rawStr = Properties.ValueToString(prop,propVal)
+					valueBox.Text = rawStr:gsub("-?%d+%.%d+",function(num)
+						return tostring(tonumber(("%."..Settings.Properties.NumberRounding.."f"):format(num)))
+					end)
+				else
+					valueBox.Text = Properties.ValueToString(prop,propVal)
+				end
+			else
+				valueBox.Text = ""
+			end
+
+			valueBox.TextColor3 = tags.ReadOnly and Settings.Theme.PlaceholderText or Settings.Theme.Text
+		end
+	end
+
+	Properties.Refresh = function()
+		local maxEntries = math.max(math.ceil((propsFrame.AbsoluteSize.Y) / 23),0)	
+		local maxX = propsFrame.AbsoluteSize.X
+		local valueWidth = math.max(Properties.MinInputWidth,maxX-Properties.ViewWidth)
+		local inputPropVisible = false
+		local isa = game.IsA
+		local UDim2 = UDim2
+		local stringSplit = string.split
+		local scaleType = Settings.Properties.ScaleType
+
+		-- Clear connections
+		for i = 1,#propCons do
+			propCons[i]:Disconnect()
+		end
+		table.clear(propCons)
+
+		-- Hide full name viewer
+		Properties.FullNameFrame.Visible = false
+		Properties.FullNameFrameAttach.Disable()
+
+		for i = 1,maxEntries do
+			local entryData = propEntries[i]
+			if not propEntries[i] then entryData = Properties.NewPropEntry(i) propEntries[i] = entryData end
+
+			local entry = entryData.Gui
+			local guiElems = entryData.GuiElems
+			local nameFrame = guiElems.NameFrame
+			local propNameLabel = guiElems.PropName
+			local valueFrame = guiElems.ValueFrame
+			local expand = guiElems.Expand
+			local valueBox = guiElems.ValueBox
+			local propNameBox = guiElems.PropName
+			local rightButton = guiElems.RightButton
+			local editAttributeButton = guiElems.EditAttributeButton
+			local toggleAttributes = guiElems.ToggleAttributes
+
+			local prop = viewList[i + Properties.Index]
+			if prop then
+				local entryXOffset = (scaleType == 0 and scrollH.Index or 0)
+				entry.Visible = true
+				entry.Position = UDim2.new(0,-entryXOffset,0,entry.Position.Y.Offset)
+				entry.Size = UDim2.new(scaleType == 0 and 0 or 1, scaleType == 0 and Properties.ViewWidth + valueWidth or 0,0,22)
+
+				if prop.SpecialRow then
+					if prop.SpecialRow == "AddAttribute" then
+						nameFrame.Visible = false
+						valueFrame.Visible = false
+						guiElems.RowButton.Visible = true
+					end
+				else
+					-- Revert special row stuff
+					nameFrame.Visible = true
+					guiElems.RowButton.Visible = false
+
+					local depth = Properties.EntryIndent*(prop.Depth or 1)
+					local leftOffset = depth + Properties.EntryOffset
+					nameFrame.Position = UDim2.new(0,leftOffset,0,0)
+					propNameLabel.Size = UDim2.new(1,-2 - (scaleType == 0 and 0 or 6),1,0)
+
+					local gName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
+
+					if prop.CategoryName then
+						entry.BackgroundColor3 = Settings.Theme.Main1
+						valueFrame.Visible = false
+
+						propNameBox.Text = prop.CategoryName
+						propNameBox.Font = Enum.Font.SourceSansBold
+						expand.Visible = true
+						propNameBox.TextColor3 = Settings.Theme.Text
+						nameFrame.BackgroundTransparency = 1
+						nameFrame.Size = UDim2.new(1,0,1,0)
+						editAttributeButton.Visible = false
+
+						local showingAttrs = Settings.Properties.ShowAttributes
+						toggleAttributes.Position = UDim2.new(1,-85-leftOffset,0,0)
+						toggleAttributes.Text = (showingAttrs and "[Setting: ON]" or "[Setting: OFF]")
+						toggleAttributes.TextColor3 = Settings.Theme.Text
+						toggleAttributes.Visible = (prop.CategoryName == "Attributes")
+					else
+						local propName = prop.Name
+						local typeData = prop.ValueType
+						local typeName = typeData.Name
+						local tags = prop.Tags
+						local propObj = autoUpdateObjs[gName]
+
+						local attributeOffset = (prop.IsAttribute and 20 or 0)
+						editAttributeButton.Visible = (prop.IsAttribute and not prop.RootType)
+						toggleAttributes.Visible = false
+
+						-- Moving around the frames
+						if scaleType == 0 then
+							nameFrame.Size = UDim2.new(0,Properties.ViewWidth - leftOffset - 1,1,0)
+							valueFrame.Position = UDim2.new(0,Properties.ViewWidth,0,0)
+							valueFrame.Size = UDim2.new(0,valueWidth - attributeOffset,1,0)
+						else
+							nameFrame.Size = UDim2.new(0.5,-leftOffset - 1,1,0)
+							valueFrame.Position = UDim2.new(0.5,0,0,0)
+							valueFrame.Size = UDim2.new(0.5,-attributeOffset,1,0)
+						end
+
+						local nameArr = stringSplit(gName,".")
+						propNameBox.Text = prop.DisplayName or nameArr[#nameArr]
+						propNameBox.Font = Enum.Font.SourceSans
+						entry.BackgroundColor3 = Settings.Theme.Main2
+						valueFrame.Visible = true
+
+						expand.Visible = typeData.Category == "DataType" and Properties.ExpandableTypes[typeName] or Properties.ExpandableProps[gName]
+						propNameBox.TextColor3 = tags.ReadOnly and Settings.Theme.PlaceholderText or Settings.Theme.Text
+
+						-- Display property value
+						Properties.DisplayProp(prop,i)
+						if propObj then
+							if prop.IsAttribute then
+								propCons[#propCons+1] = getAttributeChangedSignal(propObj,prop.AttributeName):Connect(function()
+									Properties.DisplayProp(prop,i)
+								end)
+							else
+								propCons[#propCons+1] = getPropChangedSignal(propObj,propName):Connect(function()
+									Properties.DisplayProp(prop,i)
+								end)
+							end
+						end
+
+						-- Position and resize Input Box
+						local beforeVisible = valueBox.Visible
+						local inputFullName = inputProp and (inputProp.Class.."."..inputProp.Name..(inputProp.SubName or ""))
+						if gName == inputFullName then
+							nameFrame.BackgroundColor3 = Settings.Theme.ListSelection
+							nameFrame.BackgroundTransparency = 0
+							if typeData.Category == "Class" or typeData.Category == "Enum" or typeName == "BrickColor" then
+								valueFrame.BackgroundColor3 = Settings.Theme.TextBox
+								valueFrame.BackgroundTransparency = 0
+								valueBox.Visible = true
+							else
+								inputPropVisible = true
+								local scale = (scaleType == 0 and 0 or 0.5)
+								local offset = (scaleType == 0 and Properties.ViewWidth-scrollH.Index or 0)
+								local endOffset = 0
+
+								if typeName == "Color3" or typeName == "ColorSequence" then
+									offset = offset + 22
+								end
+
+								if typeName == "NumberSequence" or typeName == "ColorSequence" then
+									endOffset = 20
+								end
+
+								inputBox.Position = UDim2.new(scale,offset,0,entry.Position.Y.Offset)
+								inputBox.Size = UDim2.new(1-scale,-offset-endOffset-attributeOffset,0,22)
+								inputBox.Visible = true
+								valueBox.Visible = false
+							end
+						else
+							nameFrame.BackgroundColor3 = Settings.Theme.Main1
+							nameFrame.BackgroundTransparency = 1
+							valueFrame.BackgroundColor3 = Settings.Theme.Main1
+							valueFrame.BackgroundTransparency = 1
+							valueBox.Visible = beforeVisible
+						end
+					end
+
+					-- Expand
+					if prop.CategoryName or Properties.ExpandableTypes[prop.ValueType and prop.ValueType.Name] or Properties.ExpandableProps[gName] then
+						if Lib.CheckMouseInGui(expand) then
+							Main.MiscIcons:DisplayByKey(expand.Icon, expanded[gName] and "Collapse_Over" or "Expand_Over")
+						else
+							Main.MiscIcons:DisplayByKey(expand.Icon, expanded[gName] and "Collapse" or "Expand")
+						end
+						expand.Visible = true
+					else
+						expand.Visible = false
+					end
+				end
+				entry.Visible = true
+			else
+				entry.Visible = false
+			end
+		end
+
+		if not inputPropVisible then
+			inputBox.Visible = false
+		end
+
+		for i = maxEntries+1,#propEntries do
+			propEntries[i].Gui:Destroy()
+			propEntries[i] = nil
+			checkboxes[i] = nil
+		end
+	end
+
+	Properties.SetProp = function(prop,val,noupdate,prevAttribute)
+		local sList = Explorer.Selection.List
+		local propName = prop.Name
+		local subName = prop.SubName
+		local propClass = prop.Class
+		local typeData = prop.ValueType
+		local typeName = typeData.Name
+		local attributeName = prop.AttributeName
+		local rootTypeData = prop.RootType
+		local rootTypeName = rootTypeData and rootTypeData.Name
+		local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
+		local Vector3 = Vector3
+
+		for i = 1,#sList do
+			local node = sList[i]
+			local obj = node.Obj
+
+			if isa(obj,propClass) then
+				pcall(function()
+					local setVal = val
+					local root
+					if prop.IsAttribute then
+						root = getAttribute(obj,attributeName)
+					else
+						root = obj[propName]
+					end
+
+					if prevAttribute then
+						if prevAttribute.ValueType.Name == typeName then
+							setVal = getAttribute(obj,prevAttribute.AttributeName) or setVal
+						end
+						setAttribute(obj,prevAttribute.AttributeName,nil)
+
+						-- ADONIS
+						Dex_RemoteFunction:InvokeServer("SetPropertyAttribute", obj, attributeName, setVal)
+					end
+
+					if rootTypeName then
+						if rootTypeName == "Vector2" then
+							setVal = Vector2.new((subName == ".X" and setVal) or root.X, (subName == ".Y" and setVal) or root.Y)
+						elseif rootTypeName == "Vector3" then
+							setVal = Vector3.new((subName == ".X" and setVal) or root.X, (subName == ".Y" and setVal) or root.Y, (subName == ".Z" and setVal) or root.Z)
+						elseif rootTypeName == "UDim" then
+							setVal = UDim.new((subName == ".Scale" and setVal) or root.Scale, (subName == ".Offset" and setVal) or root.Offset)
+						elseif rootTypeName == "UDim2" then
+							local rootX,rootY = root.X,root.Y
+							local X_UDim = (subName == ".X" and setVal) or UDim.new((subName == ".X.Scale" and setVal) or rootX.Scale, (subName == ".X.Offset" and setVal) or rootX.Offset)
+							local Y_UDim = (subName == ".Y" and setVal) or UDim.new((subName == ".Y.Scale" and setVal) or rootY.Scale, (subName == ".Y.Offset" and setVal) or rootY.Offset)
+							setVal = UDim2.new(X_UDim,Y_UDim)
+						elseif rootTypeName == "CFrame" then
+							local rootPos,rootRight,rootUp,rootLook = root.Position,root.RightVector,root.UpVector,root.LookVector
+							local pos = (subName == ".Position" and setVal) or Vector3.new((subName == ".Position.X" and setVal) or rootPos.X, (subName == ".Position.Y" and setVal) or rootPos.Y, (subName == ".Position.Z" and setVal) or rootPos.Z)
+							local rightV = (subName == ".RightVector" and setVal) or Vector3.new((subName == ".RightVector.X" and setVal) or rootRight.X, (subName == ".RightVector.Y" and setVal) or rootRight.Y, (subName == ".RightVector.Z" and setVal) or rootRight.Z)
+							local upV = (subName == ".UpVector" and setVal) or Vector3.new((subName == ".UpVector.X" and setVal) or rootUp.X, (subName == ".UpVector.Y" and setVal) or rootUp.Y, (subName == ".UpVector.Z" and setVal) or rootUp.Z)
+							local lookV = (subName == ".LookVector" and setVal) or Vector3.new((subName == ".LookVector.X" and setVal) or rootLook.X, (subName == ".RightVector.Y" and setVal) or rootLook.Y, (subName == ".RightVector.Z" and setVal) or rootLook.Z)
+							setVal = CFrame.fromMatrix(pos,rightV,upV,-lookV)
+						elseif rootTypeName == "Rect" then
+							local rootMin,rootMax = root.Min,root.Max
+							local min = Vector2.new((subName == ".Min.X" and setVal) or rootMin.X, (subName == ".Min.Y" and setVal) or rootMin.Y)
+							local max = Vector2.new((subName == ".Max.X" and setVal) or rootMax.X, (subName == ".Max.Y" and setVal) or rootMax.Y)
+							setVal = Rect.new(min,max)
+						elseif rootTypeName == "PhysicalProperties" then
+							local rootProps = PhysicalProperties.new(obj.Material)
+							local density = (subName == ".Density" and setVal) or (root and root.Density) or rootProps.Density
+							local friction = (subName == ".Friction" and setVal) or (root and root.Friction) or rootProps.Friction
+							local elasticity = (subName == ".Elasticity" and setVal) or (root and root.Elasticity) or rootProps.Elasticity
+							local frictionWeight = (subName == ".FrictionWeight" and setVal) or (root and root.FrictionWeight) or rootProps.FrictionWeight
+							local elasticityWeight = (subName == ".ElasticityWeight" and setVal) or (root and root.ElasticityWeight) or rootProps.ElasticityWeight
+							setVal = PhysicalProperties.new(density,friction,elasticity,frictionWeight,elasticityWeight)
+						elseif rootTypeName == "Ray" then
+							local rootOrigin,rootDirection = root.Origin,root.Direction
+							local origin = (subName == ".Origin" and setVal) or Vector3.new((subName == ".Origin.X" and setVal) or rootOrigin.X, (subName == ".Origin.Y" and setVal) or rootOrigin.Y, (subName == ".Origin.Z" and setVal) or rootOrigin.Z)
+							local direction = (subName == ".Direction" and setVal) or Vector3.new((subName == ".Direction.X" and setVal) or rootDirection.X, (subName == ".Direction.Y" and setVal) or rootDirection.Y, (subName == ".Direction.Z" and setVal) or rootDirection.Z)
+							setVal = Ray.new(origin,direction)
+						elseif rootTypeName == "Faces" then
+							local faces = {}
+							local faceList = {"Back","Bottom","Front","Left","Right","Top"}
+							for _,face in pairs(faceList) do
+								local val
+								if subName == "."..face then
+									val = setVal
+								else
+									val = root[face]
+								end
+								if val then faces[#faces+1] = Enum.NormalId[face] end
+							end
+							setVal = Faces.new(unpack(faces))
+						elseif rootTypeName == "Axes" then
+							local axes = {}
+							local axesList = {"X","Y","Z"}
+							for _,axe in pairs(axesList) do
+								local val
+								if subName == "."..axe then
+									val = setVal
+								else
+									val = root[axe]
+								end
+								if val then axes[#axes+1] = Enum.Axis[axe] end
+							end
+							setVal = Axes.new(unpack(axes))
+						elseif rootTypeName == "NumberRange" then
+							setVal = NumberRange.new(subName == ".Min" and setVal or root.Min, subName == ".Max" and setVal or root.Max)
+						end
+					end
+
+					if typeName == "PhysicalProperties" and setVal then
+						setVal = root or PhysicalProperties.new(obj.Material)
+					end
+
+					if prop.IsAttribute then
+						setAttribute(obj,attributeName,setVal)
+
+						-- ADONIS
+						Dex_RemoteFunction:InvokeServer("SetPropertyAttribute", obj, attributeName, setVal)
+					else
+						obj[propName] = setVal
+
+						-- ADONIS
+						Dex_RemoteFunction:InvokeServer("SetProperty", obj, propName, setVal)
+					end
+				end)
+			end
+		end
+
+		if not noupdate then
+			Properties.ComputeConflicts(prop)
+		end
+	end
+
+	Properties.InitInputBox = function()
+		inputBox = create({
+			{1,"Frame",{BackgroundColor3=Color3.new(0.14901961386204,0.14901961386204,0.14901961386204),BorderSizePixel=0,Name="InputBox",Size=UDim2.new(0,200,0,22),Visible=false,ZIndex=2,}},
+			{2,"TextBox",{BackgroundColor3=Color3.new(0.17647059261799,0.17647059261799,0.17647059261799),BackgroundTransparency=1,BorderColor3=Color3.new(0.062745101749897,0.51764708757401,1),BorderSizePixel=0,ClearTextOnFocus=false,Font=3,Parent={1},PlaceholderColor3=Color3.new(0.69803923368454,0.69803923368454,0.69803923368454),Position=UDim2.new(0,3,0,0),Size=UDim2.new(1,-6,1,0),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextXAlignment=0,ZIndex=2,}},
+		})
+		inputTextBox = inputBox.TextBox
+		inputBox.BackgroundColor3 = Settings.Theme.TextBox
+		inputBox.Parent = Properties.Window.GuiElems.Content.List
+
+		inputTextBox.FocusLost:Connect(function()
+			if not inputProp then return end
+
+			local prop = inputProp
+			inputProp = nil
+			local val = Properties.StringToValue(prop,inputTextBox.Text)
+			if val then Properties.SetProp(prop,val) else Properties.Refresh() end
+		end)
+
+		inputTextBox.Focused:Connect(function()
+			inputTextBox.SelectionStart = 1
+			inputTextBox.CursorPosition = #inputTextBox.Text + 1
+		end)
+
+		Lib.ViewportTextBox.convert(inputTextBox)
+	end
+
+	Properties.SetInputProp = function(prop,entryIndex,special)
+		local typeData = prop.ValueType
+		local typeName = typeData.Name
+		local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
+		local propObj = autoUpdateObjs[fullName]
+		local propVal = Properties.GetPropVal(prop,propObj)
+
+		if prop.Tags.ReadOnly then return end
+
+		inputProp = prop
+		if special then
+			if special == "color" then
+				if typeName == "Color3" then
+					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
+					Properties.DisplayColorEditor(prop,propVal)
+				elseif typeName == "BrickColor" then
+					Properties.DisplayBrickColorEditor(prop,entryIndex,propVal)
+				elseif typeName == "ColorSequence" then
+					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
+					Properties.DisplayColorSequenceEditor(prop,propVal)
+				end
+			elseif special == "right" then
+				if typeName == "NumberSequence" then
+					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
+					Properties.DisplayNumberSequenceEditor(prop,propVal)
+				elseif typeName == "ColorSequence" then
+					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
+					Properties.DisplayColorSequenceEditor(prop,propVal)
+				end
+			end
+		else
+			if Properties.IsTextEditable(prop) then
+				-- TODO: A setting maybe.
+				--inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
+				local rawStr = propVal and Properties.ValueToString(prop,propVal) or ""
+				inputTextBox.Text = rawStr:gsub("-?%d+%.%d+",function(num)
+					return tostring(tonumber(("%."..Settings.Properties.NumberRounding.."f"):format(num)))
+				end)
+				inputTextBox:CaptureFocus()
+			elseif typeData.Category == "Enum" then
+				Properties.DisplayEnumDropdown(entryIndex)
+			elseif typeName == "BrickColor" then
+				Properties.DisplayBrickColorEditor(prop,entryIndex,propVal)
+			end
+		end
+		Properties.Refresh()
+	end
+
+	Properties.InitSearch = function()
+		local searchBox = Properties.GuiElems.ToolBar.SearchFrame.SearchBox
+
+		Lib.ViewportTextBox.convert(searchBox)
+
+		searchBox:GetPropertyChangedSignal("Text"):Connect(function()
+			Properties.SearchText = searchBox.Text
+			Properties.Update()
+			Properties.Refresh()
+		end)
+	end
+
+	Properties.InitEntryStuff = function()
+		Properties.EntryTemplate = create({
+			{1,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.17647059261799,0.17647059261799,0.17647059261799),BackgroundTransparency=0.2,BorderColor3=Color3.new(0.1294117718935,0.1294117718935,0.1294117718935),Font=3,Name="Entry",Position=UDim2.new(0,1,0,1),Size=UDim2.new(0,250,0,22),Text="",TextSize=14,}},
+			{2,"Frame",{BackgroundColor3=Color3.new(0.04313725605607,0.35294118523598,0.68627452850342),BackgroundTransparency=1,BorderColor3=Color3.new(0.33725491166115,0.49019610881805,0.73725491762161),BorderSizePixel=0,Name="NameFrame",Parent={1},Position=UDim2.new(0,20,0,0),Size=UDim2.new(1,-40,1,0),}},
+			{3,"TextLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Font=3,Name="PropName",Parent={2},Position=UDim2.new(0,2,0,0),Size=UDim2.new(1,-2,1,0),Text="Anchored",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,TextTruncate=1,TextXAlignment=0,}},
+			{4,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,ClipsDescendants=true,Font=3,Name="Expand",Parent={2},Position=UDim2.new(0,-20,0,1),Size=UDim2.new(0,20,0,20),Text="",TextSize=14,Visible=false,}},
+			{5,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5642383285",ImageRectOffset=Vector2.new(144,16),ImageRectSize=Vector2.new(16,16),Name="Icon",Parent={4},Position=UDim2.new(0,2,0,2),ScaleType=4,Size=UDim2.new(0,16,0,16),}},
+			{6,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=4,Name="ToggleAttributes",Parent={2},Position=UDim2.new(1,-85,0,0),Size=UDim2.new(0,85,0,22),Text="[SETTING: OFF]",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,Visible=false,}},
+			{7,"Frame",{BackgroundColor3=Color3.new(0.04313725605607,0.35294118523598,0.68627452850342),BackgroundTransparency=1,BorderColor3=Color3.new(0.33725491166115,0.49019607901573,0.73725491762161),BorderSizePixel=0,Name="ValueFrame",Parent={1},Position=UDim2.new(1,-100,0,0),Size=UDim2.new(0,80,1,0),}},
+			{8,"Frame",{BackgroundColor3=Color3.new(0.14117647707462,0.14117647707462,0.14117647707462),BorderColor3=Color3.new(0.33725491166115,0.49019610881805,0.73725491762161),BorderSizePixel=0,Name="Line",Parent={7},Position=UDim2.new(0,-1,0,0),Size=UDim2.new(0,1,1,0),}},
+			{9,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="ColorButton",Parent={7},Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
+			{10,"Frame",{BackgroundColor3=Color3.new(1,1,1),BorderColor3=Color3.new(0,0,0),Name="ColorPreview",Parent={9},Position=UDim2.new(0,5,0,6),Size=UDim2.new(0,10,0,10),}},
+			{11,"UIGradient",{Parent={10},}},
+			{12,"Frame",{BackgroundTransparency=1,Name="EnumArrow",Parent={7},Position=UDim2.new(1,-16,0,3),Size=UDim2.new(0,16,0,16),Visible=false,}},
+			{13,"Frame",{BackgroundColor3=Color3.new(0.86274510622025,0.86274510622025,0.86274510622025),BorderSizePixel=0,Parent={12},Position=UDim2.new(0,8,0,9),Size=UDim2.new(0,1,0,1),}},
+			{14,"Frame",{BackgroundColor3=Color3.new(0.86274510622025,0.86274510622025,0.86274510622025),BorderSizePixel=0,Parent={12},Position=UDim2.new(0,7,0,8),Size=UDim2.new(0,3,0,1),}},
+			{15,"Frame",{BackgroundColor3=Color3.new(0.86274510622025,0.86274510622025,0.86274510622025),BorderSizePixel=0,Parent={12},Position=UDim2.new(0,6,0,7),Size=UDim2.new(0,5,0,1),}},
+			{16,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Font=3,Name="ValueBox",Parent={7},Position=UDim2.new(0,4,0,0),Size=UDim2.new(1,-8,1,0),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,TextTruncate=1,TextXAlignment=0,}},
+			{17,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="RightButton",Parent={7},Position=UDim2.new(1,-20,0,0),Size=UDim2.new(0,20,0,22),Text="...",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
+			{18,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="SettingsButton",Parent={7},Position=UDim2.new(1,-20,0,0),Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
+			{19,"Frame",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Name="SoundPreview",Parent={7},Size=UDim2.new(1,0,1,0),Visible=false,}},
+			{20,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="ControlButton",Parent={19},Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,}},
+			{21,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5642383285",ImageRectOffset=Vector2.new(144,16),ImageRectSize=Vector2.new(16,16),Name="Icon",Parent={20},Position=UDim2.new(0,2,0,3),ScaleType=4,Size=UDim2.new(0,16,0,16),}},
+			{22,"Frame",{BackgroundColor3=Color3.new(0.3137255012989,0.3137255012989,0.3137255012989),BorderSizePixel=0,Name="TimeLine",Parent={19},Position=UDim2.new(0,26,0.5,-1),Size=UDim2.new(1,-34,0,2),}},
+			{23,"Frame",{BackgroundColor3=Color3.new(0.2352941185236,0.2352941185236,0.2352941185236),BorderColor3=Color3.new(0.1294117718935,0.1294117718935,0.1294117718935),Name="Slider",Parent={22},Position=UDim2.new(0,-4,0,-8),Size=UDim2.new(0,8,0,18),}},
+			{24,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="EditAttributeButton",Parent={1},Position=UDim2.new(1,-20,0,0),Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,}},
+			{25,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5034718180",ImageTransparency=0.20000000298023,Name="Icon",Parent={24},Position=UDim2.new(0,2,0,3),Size=UDim2.new(0,16,0,16),}},
+			{26,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.2352941185236,0.2352941185236,0.2352941185236),BorderSizePixel=0,Font=3,Name="RowButton",Parent={1},Size=UDim2.new(1,0,1,0),Text="Add Attribute",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,Visible=false,}},
+		})
+
+		local fullNameFrame = Lib.Frame.new()
+		local label = Lib.Label.new()
+		label.Parent = fullNameFrame.Gui
+		label.Position = UDim2.new(0,2,0,0)
+		label.Size = UDim2.new(1,-4,1,0)
+		fullNameFrame.Visible = false
+		fullNameFrame.Parent = window.Gui
+
+		Properties.FullNameFrame = fullNameFrame
+		Properties.FullNameFrameAttach = Lib.AttachTo(fullNameFrame)
+	end
+
+	Properties.Init = function() -- TODO: MAKE BETTER
+		local guiItems = create({
+			{1,"Folder",{Name="Items",}},
+			{2,"Frame",{BackgroundColor3=Color3.new(0.20392157137394,0.20392157137394,0.20392157137394),BorderSizePixel=0,Name="ToolBar",Parent={1},Size=UDim2.new(1,0,0,22),}},
+			{3,"Frame",{BackgroundColor3=Color3.new(0.14901961386204,0.14901961386204,0.14901961386204),BorderColor3=Color3.new(0.1176470592618,0.1176470592618,0.1176470592618),BorderSizePixel=0,Name="SearchFrame",Parent={2},Position=UDim2.new(0,3,0,1),Size=UDim2.new(1,-6,0,18),}},
+			{4,"TextBox",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,ClearTextOnFocus=false,Font=3,Name="SearchBox",Parent={3},PlaceholderColor3=Color3.new(0.39215689897537,0.39215689897537,0.39215689897537),PlaceholderText="Search properties",Position=UDim2.new(0,4,0,0),Size=UDim2.new(1,-24,0,18),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextXAlignment=0,}},
+			{5,"UICorner",{CornerRadius=UDim.new(0,2),Parent={3},}},
+			{6,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.12549020349979,0.12549020349979,0.12549020349979),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="Reset",Parent={3},Position=UDim2.new(1,-17,0,1),Size=UDim2.new(0,16,0,16),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,}},
+			{7,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5034718129",ImageColor3=Color3.new(0.39215686917305,0.39215686917305,0.39215686917305),Parent={6},Size=UDim2.new(0,16,0,16),}},
+			{8,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.12549020349979,0.12549020349979,0.12549020349979),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="Refresh",Parent={2},Position=UDim2.new(1,-20,0,1),Size=UDim2.new(0,18,0,18),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
+			{9,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5642310344",Parent={8},Position=UDim2.new(0,3,0,3),Size=UDim2.new(0,12,0,12),}},
+			{10,"Frame",{BackgroundColor3=Color3.new(0.15686275064945,0.15686275064945,0.15686275064945),BorderSizePixel=0,Name="ScrollCorner",Parent={1},Position=UDim2.new(1,-16,1,-16),Size=UDim2.new(0,16,0,16),Visible=false,}},
+			{11,"Frame",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,ClipsDescendants=true,Name="List",Parent={1},Position=UDim2.new(0,0,0,23),Size=UDim2.new(1,0,1,-23),}},
+		})
+
+		-- Vars
+		categoryOrder =  API.CategoryOrder
+		for category,_ in next,categoryOrder do
+			if not Properties.CollapsedCategories[category] then
+				expanded["CAT_"..category] = true
+			end
+		end
+		expanded["Sound.SoundId"] = true
+
+		-- Init window
+		window = Lib.Window.new()
+		Properties.Window = window
+		window:SetTitle("Properties")
+
+		toolBar = guiItems.ToolBar
+		propsFrame = guiItems.List
+
+		Properties.GuiElems.ToolBar = toolBar
+		Properties.GuiElems.PropsFrame = propsFrame
+
+		Properties.InitEntryStuff()
+
+		-- Window events
+		window.GuiElems.Main:GetPropertyChangedSignal("AbsoluteSize"):Connect(function()
+			if Properties.Window:IsContentVisible() then
+				Properties.UpdateView()
+				Properties.Refresh()
+			end
+		end)
+		window.OnActivate:Connect(function()
+			Properties.UpdateView()
+			Properties.Update()
+			Properties.Refresh()
+		end)
+		window.OnRestore:Connect(function()
+			Properties.UpdateView()
+			Properties.Update()
+			Properties.Refresh()
+		end)
+
+		-- Init scrollbars
+		scrollV = Lib.ScrollBar.new()		
+		scrollV.WheelIncrement = 3
+		scrollV.Gui.Position = UDim2.new(1,-16,0,23)
+		scrollV:SetScrollFrame(propsFrame)
+		scrollV.Scrolled:Connect(function()
+			Properties.Index = scrollV.Index
+			Properties.Refresh()
+		end)
+
+		scrollH = Lib.ScrollBar.new(true)
+		scrollH.Increment = 5
+		scrollH.WheelIncrement = 20
+		scrollH.Gui.Position = UDim2.new(0,0,1,-16)
+		scrollH.Scrolled:Connect(function()
+			Properties.Refresh()
+		end)
+
+		-- Setup Gui
+		window.GuiElems.Line.Position = UDim2.new(0,0,0,22)
+		toolBar.Parent = window.GuiElems.Content
+		propsFrame.Parent = window.GuiElems.Content
+		guiItems.ScrollCorner.Parent = window.GuiElems.Content
+		scrollV.Gui.Parent = window.GuiElems.Content
+		scrollH.Gui.Parent = window.GuiElems.Content
+		Properties.InitInputBox()
+		Properties.InitSearch()
+	end
+
+	return Properties
+end
+
+return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}]]></ProtectedString>
+							<int64 name="SourceAssetId">-1</int64>
+							<BinaryString name="Tags"></BinaryString>
+						</Properties>
+					</Item>
+					<Item class="ModuleScript" referent="RBX5543f65be47642228bf8c0824fc0a713">
+						<Properties>
+							<BinaryString name="AttributesSerialize"></BinaryString>
+							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+							<bool name="DefinesCapabilities">false</bool>
+							<Content name="LinkedSource"><null></null></Content>
+							<string name="Name">SettingsEditor</string>
+							<string name="ScriptGuid">{C07EC65A-181C-473C-8839-D90370715008}</string>
+							<ProtectedString name="Source"><![CDATA[--[[
+	Settings Module
+	
+	The Module to configure settings
+]]
+
+-- half of the module was written using ai by someone
+-- why.
+
+-- ADONIS
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Dex_RemoteFunction = ReplicatedStorage:WaitForChild("NewDex_Event") :: RemoteFunction
+
+-- Common Locals
+local Main,Lib,Apps,Settings -- Main Containers
+local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
+local API,RMD,env,service,plr,create,createSimple -- Main Locals
+
+local function initDeps(data)
+	Main = data.Main
+	Lib = data.Lib
+	Apps = data.Apps
+	Settings = data.Settings
+
+	API = data.API
+	RMD = data.RMD
+	env = data.env
+	service = data.service
+	plr = data.plr
+	create = data.create
+	createSimple = data.createSimple
+end
+
+local function initAfterMain()
+	Explorer = Apps.Explorer
+	Properties = Apps.Properties
+	ScriptViewer = Apps.ScriptViewer
+	Notebook = Apps.Notebook
+end
+
+
+local function main()
+	local SettingsEditor = {}
+
+	local scrollV, scrollH
+	local settingsListFrame
+	local expanded, viewList = {}, {}
+
+	local topOffset = 0 --23 for that search bar thingy
+
+	local scrollbarThickness = 6 -- for layout
+
+	SettingsEditor.SettingsInfo = require(script.settingsInfo)
+	-- Pass Vargs
+	SettingsEditor.SettingsInfo.initDeps({
+		Main = Main,
+		Lib = Lib,
+		Apps = Apps,
+		Settings = Settings
+	})
+
+	-- silencer
+	SettingsEditor.ColorEditor = nil
+	SettingsEditor.InfoDescBox = nil
+	SettingsEditor.Window = nil
+
+	SettingsEditor.EntryTemplate = function()
+		local Entry = Instance.new("TextButton")
+		Entry.Name = "Entry"
+		Entry.Size = UDim2.new(1, 0, 0, 22)
+		Entry.BorderColor3 = Color3.fromRGB(33, 33, 33)
+		Entry.BackgroundTransparency = 0.2
+		Entry.Position = UDim2.new(0, 1, 0, 1)
+		Entry.BackgroundColor3 = Color3.fromRGB(45, 45, 45)
+		Entry.AutoButtonColor = false
+		Entry.FontSize = Enum.FontSize.Size14
+		Entry.TextSize = 14
+		Entry.Text = ""
+		Entry.Font = Enum.Font.SourceSans
+
+		local NameFrame = Instance.new("Frame")
+		NameFrame.Name = "NameFrame"
+		NameFrame.Size = UDim2.new(1, -40, 1, 0)
+		NameFrame.BorderColor3 = Color3.fromRGB(86, 125, 188)
+		NameFrame.BackgroundTransparency = 1
+		NameFrame.Position = UDim2.new(0, 20, 0, 0)
+		NameFrame.BorderSizePixel = 0
+		NameFrame.BackgroundColor3 = Color3.fromRGB(11, 90, 175)
+		NameFrame.Parent = Entry
+
+		local PropName = Instance.new("TextLabel")
+		PropName.Name = "PropName"
+		PropName.Size = UDim2.new(1, -2, 1, 0)
+		PropName.BackgroundTransparency = 1
+		PropName.Position = UDim2.new(0, 2, 0, 0)
+		PropName.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		PropName.FontSize = Enum.FontSize.Size14
+		PropName.TextTruncate = Enum.TextTruncate.AtEnd
+		PropName.TextSize = 14
+		PropName.TextColor3 = Color3.fromRGB(255, 255, 255)
+		PropName.Text = "Anchored"
+		PropName.Font = Enum.Font.SourceSans
+		PropName.TextTransparency = 0.1
+		PropName.TextXAlignment = Enum.TextXAlignment.Left
+		PropName.Parent = NameFrame
+
+		local Expand = Instance.new("TextButton")
+		Expand.Name = "Expand"
+		Expand.Visible = false
+		Expand.Size = UDim2.new(0, 20, 0, 20)
+		Expand.ClipsDescendants = true
+		Expand.BackgroundTransparency = 1
+		Expand.Position = UDim2.new(0, -20, 0, 1)
+		Expand.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		Expand.FontSize = Enum.FontSize.Size14
+		Expand.TextSize = 14
+		Expand.Text = ""
+		Expand.Font = Enum.Font.SourceSans
+		Expand.Parent = NameFrame
+
+		local Icon = Instance.new("ImageLabel")
+		Icon.Name = "Icon"
+		Icon.Size = UDim2.new(0, 16, 0, 16)
+		Icon.BackgroundTransparency = 1
+		Icon.Position = UDim2.new(0, 2, 0, 2)
+		Icon.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		Icon.ScaleType = Enum.ScaleType.Crop
+		Icon.ImageRectOffset = Vector2.new(144, 16)
+		Icon.ImageRectSize = Vector2.new(16, 16)
+		Icon.Image = "rbxassetid://5642383285"
+		Icon.Parent = Expand
+
+		local ToggleAttributes = Instance.new("TextButton")
+		ToggleAttributes.Name = "ToggleAttributes"
+		ToggleAttributes.Visible = false
+		ToggleAttributes.Size = UDim2.new(0, 85, 0, 22)
+		ToggleAttributes.BackgroundTransparency = 1
+		ToggleAttributes.Position = UDim2.new(1, -85, 0, 0)
+		ToggleAttributes.BorderSizePixel = 0
+		ToggleAttributes.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		ToggleAttributes.FontSize = Enum.FontSize.Size14
+		ToggleAttributes.TextSize = 14
+		ToggleAttributes.TextColor3 = Color3.fromRGB(255, 255, 255)
+		ToggleAttributes.Text = "[SETTING: OFF]"
+		ToggleAttributes.Font = Enum.Font.SourceSansBold
+		ToggleAttributes.TextTransparency = 0.1
+		ToggleAttributes.Parent = NameFrame
+
+		local ValueFrame = Instance.new("Frame")
+		ValueFrame.Name = "ValueFrame"
+		ValueFrame.Size = UDim2.new(0, 80, 1, 0)
+		ValueFrame.BorderColor3 = Color3.fromRGB(86, 125, 188)
+		ValueFrame.BackgroundTransparency = 1
+		ValueFrame.Position = UDim2.new(1, -100, 0, 0)
+		ValueFrame.BorderSizePixel = 0
+		ValueFrame.BackgroundColor3 = Color3.fromRGB(11, 90, 175)
+		ValueFrame.Parent = Entry
+
+		local Line = Instance.new("Frame")
+		Line.Name = "Line"
+		Line.Size = UDim2.new(0, 1, 1, 0)
+		Line.BorderColor3 = Color3.fromRGB(86, 125, 188)
+		Line.Position = UDim2.new(0, -1, 0, 0)
+		Line.BorderSizePixel = 0
+		Line.BackgroundColor3 = Color3.fromRGB(36, 36, 36)
+		Line.Parent = ValueFrame
+
+		local EnumArrow = Instance.new("Frame")
+		EnumArrow.Name = "EnumArrow"
+		EnumArrow.Visible = false
+		EnumArrow.Size = UDim2.new(0, 16, 0, 16)
+		EnumArrow.BackgroundTransparency = 1
+		EnumArrow.Position = UDim2.new(1, -16, 0, 3)
+		EnumArrow.Parent = ValueFrame
+
+		local Frame = Instance.new("Frame")
+		Frame.Size = UDim2.new(0, 1, 0, 1)
+		Frame.Position = UDim2.new(0, 8, 0, 9)
+		Frame.BorderSizePixel = 0
+		Frame.BackgroundColor3 = Color3.fromRGB(220, 220, 220)
+		Frame.Parent = EnumArrow
+
+		local Frame1 = Instance.new("Frame")
+		Frame1.Size = UDim2.new(0, 3, 0, 1)
+		Frame1.Position = UDim2.new(0, 7, 0, 8)
+		Frame1.BorderSizePixel = 0
+		Frame1.BackgroundColor3 = Color3.fromRGB(220, 220, 220)
+		Frame1.Parent = EnumArrow
+
+		local Frame2 = Instance.new("Frame")
+		Frame2.Size = UDim2.new(0, 5, 0, 1)
+		Frame2.Position = UDim2.new(0, 6, 0, 7)
+		Frame2.BorderSizePixel = 0
+		Frame2.BackgroundColor3 = Color3.fromRGB(220, 220, 220)
+		Frame2.Parent = EnumArrow
+
+		local ValueBox = Instance.new("TextButton")
+		ValueBox.Name = "ValueBox"
+		ValueBox.Size = UDim2.new(1, -8, 1, 0)
+		ValueBox.BackgroundTransparency = 1
+		ValueBox.Position = UDim2.new(0, 4, 0, 0)
+		ValueBox.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		ValueBox.FontSize = Enum.FontSize.Size14
+		ValueBox.TextTruncate = Enum.TextTruncate.AtEnd
+		ValueBox.TextSize = 14
+		ValueBox.TextColor3 = Color3.fromRGB(255, 255, 255)
+		ValueBox.Text = ""
+		ValueBox.Font = Enum.Font.SourceSans
+		ValueBox.TextTransparency = 0.1
+		ValueBox.TextXAlignment = Enum.TextXAlignment.Left
+		ValueBox.Parent = ValueFrame
+
+		local RightButton = Instance.new("TextButton")
+		RightButton.Name = "RightButton"
+		RightButton.Visible = false
+		RightButton.Size = UDim2.new(0, 20, 0, 22)
+		RightButton.BackgroundTransparency = 1
+		RightButton.Position = UDim2.new(1, -20, 0, 0)
+		RightButton.BorderSizePixel = 0
+		RightButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		RightButton.FontSize = Enum.FontSize.Size14
+		RightButton.TextSize = 14
+		RightButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+		RightButton.Text = "..."
+		RightButton.Font = Enum.Font.SourceSans
+		RightButton.Parent = ValueFrame
+
+		local SettingsButton = Instance.new("TextButton")
+		SettingsButton.Name = "SettingsButton"
+		SettingsButton.Visible = false
+		SettingsButton.Size = UDim2.new(0, 20, 0, 22)
+		SettingsButton.BackgroundTransparency = 1
+		SettingsButton.Position = UDim2.new(1, -20, 0, 0)
+		SettingsButton.BorderSizePixel = 0
+		SettingsButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		SettingsButton.FontSize = Enum.FontSize.Size14
+		SettingsButton.TextSize = 14
+		SettingsButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+		SettingsButton.Text = ""
+		SettingsButton.Font = Enum.Font.SourceSans
+		SettingsButton.Parent = ValueFrame
+
+		local SoundPreview = Instance.new("Frame")
+		SoundPreview.Name = "SoundPreview"
+		SoundPreview.Visible = false
+		SoundPreview.Size = UDim2.new(1, 0, 1, 0)
+		SoundPreview.BackgroundTransparency = 1
+		SoundPreview.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		SoundPreview.Parent = ValueFrame
+
+		local ControlButton = Instance.new("TextButton")
+		ControlButton.Name = "ControlButton"
+		ControlButton.Size = UDim2.new(0, 20, 0, 22)
+		ControlButton.BackgroundTransparency = 1
+		ControlButton.BorderSizePixel = 0
+		ControlButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		ControlButton.FontSize = Enum.FontSize.Size14
+		ControlButton.TextSize = 14
+		ControlButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+		ControlButton.Text = ""
+		ControlButton.Font = Enum.Font.SourceSans
+		ControlButton.Parent = SoundPreview
+
+		local Icon1 = Instance.new("ImageLabel")
+		Icon1.Name = "Icon"
+		Icon1.Size = UDim2.new(0, 16, 0, 16)
+		Icon1.BackgroundTransparency = 1
+		Icon1.Position = UDim2.new(0, 2, 0, 3)
+		Icon1.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		Icon1.ScaleType = Enum.ScaleType.Crop
+		Icon1.ImageRectOffset = Vector2.new(144, 16)
+		Icon1.ImageRectSize = Vector2.new(16, 16)
+		Icon1.Image = "rbxassetid://5642383285"
+		Icon1.Parent = ControlButton
+
+		local TimeLine = Instance.new("Frame")
+		TimeLine.Name = "TimeLine"
+		TimeLine.Size = UDim2.new(1, -34, 0, 2)
+		TimeLine.Position = UDim2.new(0, 26, 0.5, -1)
+		TimeLine.BorderSizePixel = 0
+		TimeLine.BackgroundColor3 = Color3.fromRGB(80, 80, 80)
+		TimeLine.Parent = SoundPreview
+
+		local Slider = Instance.new("Frame")
+		Slider.Name = "Slider"
+		Slider.Size = UDim2.new(0, 8, 0, 18)
+		Slider.BorderColor3 = Color3.fromRGB(33, 33, 33)
+		Slider.Position = UDim2.new(0, -4, 0, -8)
+		Slider.BackgroundColor3 = Color3.fromRGB(60, 60, 60)
+		Slider.Parent = TimeLine
+
+		local InfoButton = Instance.new("TextButton")
+		InfoButton.Name = "InfoButton"
+		InfoButton.Size = UDim2.new(0, 20, 0, 22)
+		InfoButton.BackgroundTransparency = 1
+		InfoButton.Position = UDim2.new(1, -20, 0, 0)
+		InfoButton.BorderSizePixel = 0
+		InfoButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		InfoButton.FontSize = Enum.FontSize.Size14
+		InfoButton.TextSize = 14
+		InfoButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+		InfoButton.Text = ""
+		InfoButton.Font = Enum.Font.SourceSans
+		InfoButton.Parent = Entry
+
+		local Icon2 = Instance.new("ImageLabel")
+		Icon2.Name = "Icon"
+		Icon2.Size = UDim2.new(0, 16, 0, 16)
+		Icon2.BackgroundTransparency = 1
+		Icon2.Position = UDim2.new(0, 2, 0, 3)
+		Icon2.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+		Icon2.ImageTransparency = 0.2
+		Icon2.Image = "rbxassetid://6578933307"
+		Icon2.Parent = InfoButton
+
+		return Entry
+	end
+
+
+	SettingsEditor.StringToValue = function(settingInfo, str)
+		local typeName = settingInfo.typeName
+
+		-- For numbers and stuff
+		if Apps.Properties.TypeNameConvert[typeName] then
+			typeName = Apps.Properties.TypeNameConvert[typeName]
+		end
+
+
+		if typeName == "string" or typeName == "Content" then
+			return str
+		elseif Apps.Properties.ToNumberTypes[typeName] then
+			return tonumber(str)
+		elseif typeName == "Vector2" then
+			local vals = str:split(",")
+			local x,y = tonumber(vals[1]),tonumber(vals[2])
+			if x and y and #vals >= 2 then return Vector2.new(x,y) end
+		elseif typeName == "Vector3" then
+			local vals = str:split(",")
+			local x,y,z = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3])
+			if x and y and z and #vals >= 3 then return Vector3.new(x,y,z) end
+		elseif typeName == "UDim" then
+			local vals = str:split(",")
+			local scale,offset = tonumber(vals[1]),tonumber(vals[2])
+			if scale and offset and #vals >= 2 then return UDim.new(scale,offset) end
+		elseif typeName == "UDim2" then
+			local vals = str:gsub("[{}]",""):split(",")
+			local xScale,xOffset,yScale,yOffset = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3]),tonumber(vals[4])
+			if xScale and xOffset and yScale and yOffset and #vals >= 4 then return UDim2.new(xScale,xOffset,yScale,yOffset) end
+		elseif typeName == "CFrame" then
+			local vals = str:split(",")
+			local s,result = pcall(CFrame.new,unpack(vals))
+			if s and #vals >= 12 then return result end
+		elseif typeName == "Rect" then
+			local vals = str:split(",")
+			local s,result = pcall(Rect.new,unpack(vals))
+			if s and #vals >= 4 then return result end
+		elseif typeName == "Ray" then
+			local vals = str:gsub("[{}]",""):split(",")
+			local s,origin = pcall(Vector3.new,unpack(vals,1,3))
+			local s2,direction = pcall(Vector3.new,unpack(vals,4,6))
+			if s and s2 and #vals >= 6 then return Ray.new(origin,direction) end
+		elseif typeName == "NumberRange" then
+			local vals = str:split(",")
+			local s,result = pcall(NumberRange.new,unpack(vals))
+			if s and #vals >= 1 then return result end
+		elseif typeName == "Color3" then
+			local vals = str:gsub("[{}]",""):split(",")
+			local s,result = pcall(Color3.fromRGB,unpack(vals))
+			if s and #vals >= 3 then return result end
+		end
+
+		return nil
+	end
+
+	SettingsEditor.ValueToString = function(val)
+		local typeName = typeof(val)
+
+		if typeName == "Color3" then
+			return Lib.ColorToBytes(val)
+		elseif typeName == "NumberRange" then
+			return val.Min..", "..val.Max
+		end
+
+		return tostring(val)
+	end
+
+	-- InputBox
+	SettingsEditor.CreateInputBox = function(valueBox)
+		local inputBox = create({
+			{1,"Frame",{BackgroundColor3=Color3.new(0.14901961386204,0.14901961386204,0.14901961386204),BorderSizePixel=0,Name="InputBox",Size=UDim2.new(0,200,0,22),Visible=false,ZIndex=2,}},
+			{2,"TextBox",{BackgroundColor3=Color3.new(0.17647059261799,0.17647059261799,0.17647059261799),BackgroundTransparency=1,BorderColor3=Color3.new(0.062745101749897,0.51764708757401,1),BorderSizePixel=0,ClearTextOnFocus=false,Font=3,Parent={1},PlaceholderColor3=Color3.new(0.69803923368454,0.69803923368454,0.69803923368454),Position=UDim2.new(0,3,0,0),Size=UDim2.new(1,-6,1,0),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextXAlignment=0,ZIndex=2,}},
+		})
+		local inputTextBox = inputBox.TextBox
+		inputBox.BackgroundColor3 = Settings.Theme.TextBox
+
+		inputTextBox.FocusLost:Connect(function()
+			valueBox.Visible = true
+			inputBox.Visible = false
+		end)
+
+		inputTextBox.Focused:Connect(function()
+			inputTextBox.SelectionStart = 1
+			inputTextBox.CursorPosition = #inputTextBox.Text + 1
+		end)
+
+		valueBox.Changed:Connect(function(property)
+			if (property == "Text") then
+				inputTextBox.Text = valueBox.Text
+			end
+		end)
+
+		valueBox.MouseButton1Click:Connect(function()
+			inputBox.Visible = true
+			valueBox.Visible = false
+		end)
+
+
+		Lib.ViewportTextBox.convert(inputTextBox)
+
+		return inputBox
+	end
+
+
+	SettingsEditor.DisplayColorEditor = function(obj, currentColor)
+		local editor = SettingsEditor.ColorEditor
+
+		if not editor then
+			editor = Lib.ColorPicker.new()
+
+			SettingsEditor.ColorEditor = editor
+		end
+
+		if (editor) then
+			if (SettingsEditor.ColorEditor.con_OnSelect) then
+				SettingsEditor.ColorEditor.con_OnSelect:Disconnect()
+				SettingsEditor.ColorEditor.con_OnSelect = nil
+			end
+
+			local connection
+			connection = editor.OnSelect:Connect(function(col)
+				if not editor.CurrentProp then return end
+				if not (editor.CurrentProp == obj) then return end
+
+				local colVal = (col or BrickColor.new(col))
+
+				obj:SetColor3Value(colVal)
+
+				obj.OnColorChange:Fire()
+			end)
+
+			SettingsEditor.ColorEditor.con_OnSelect = connection
+		end
+
+		editor.CurrentProp = obj
+		if currentColor then
+			editor:SetColor(currentColor)
+		end
+
+		editor:Show()
+
+		return editor
+	end
+
+
+	SettingsEditor.NewPropEntry = function()
+		local newEntry = SettingsEditor.EntryTemplate():Clone()
+		local nameFrame = newEntry.NameFrame
+		local valueFrame = newEntry.ValueFrame
+
+		local iconFrame = Main.MiscIcons:GetLabel()
+		iconFrame.Position = UDim2.new(0,2,0,3)
+		iconFrame.Parent = newEntry.ValueFrame.RightButton
+
+		return {
+			Gui = newEntry,
+			GuiElems = {
+				NameFrame = nameFrame,
+				ValueFrame = valueFrame,
+				PropName = nameFrame.PropName,
+				ValueBox = valueFrame.ValueBox,
+				Expand = nameFrame.Expand,
+				EnumArrow = valueFrame.EnumArrow,
+				RightButton = valueFrame.RightButton,
+				RightButtonIcon = iconFrame,
+				SoundPreview = valueFrame.SoundPreview,
+				SoundPreviewSlider = valueFrame.SoundPreview.TimeLine.Slider,
+				InfoButton = newEntry.InfoButton
+			}
+		}
+	end
+
+	SettingsEditor.ColorButton = (function()
+		local funcs = {}
+
+		local function createButton()
+			local ColorButton = Instance.new("TextButton")
+			ColorButton.Name = "ColorButton"
+			ColorButton.Visible = false
+			ColorButton.Size = UDim2.new(0, 20, 0, 22)
+			ColorButton.BackgroundTransparency = 1
+			ColorButton.BorderSizePixel = 0
+			ColorButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+			ColorButton.FontSize = Enum.FontSize.Size14
+			ColorButton.TextSize = 14
+			ColorButton.TextColor3 = Color3.fromRGB(255, 255, 255)
+			ColorButton.Text = ""
+			ColorButton.Font = Enum.Font.SourceSans
+
+			local ColorPreview = Instance.new("Frame")
+			ColorPreview.Name = "ColorPreview"
+			ColorPreview.Size = UDim2.new(0, 10, 0, 10)
+			ColorPreview.BorderColor3 = Color3.fromRGB(0, 0, 0)
+			ColorPreview.Position = UDim2.new(0, 5, 0, 6)
+			ColorPreview.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+			ColorPreview.Parent = ColorButton
+
+			local UIGradient = Instance.new("UIGradient")
+			UIGradient.Parent = ColorPreview
+
+
+			return ColorButton
+		end
+
+		function funcs:SetPreviewColor(color)
+			self.GuiElems.Gradient.Color = ColorSequence.new(color)
+		end
+
+		function funcs:SetColor3Value(color)
+			self.CurrentColor3 = color
+			self:SetPreviewColor(color)
+		end
+
+		local mt = {__index = funcs}
+
+		local function new()
+			local colorButton = createButton()
+
+			local obj = setmetatable({
+				Gui = colorButton;
+				GuiElems = {
+					ColorButton = colorButton;
+					ColorPreview = colorButton.ColorPreview;
+					Gradient = colorButton.ColorPreview.UIGradient;
+				};
+
+				OnColorChange = Lib.Signal.new();
+
+			}, mt)
+
+			obj.CurrentColor3 = Color3.fromRGB(255, 255, 255)
+
+
+			colorButton.ZIndex = 2 -- so it's clickable because ColorPreview obstructs it
+
+			colorButton.MouseButton1Click:Connect(function()
+				SettingsEditor.DisplayColorEditor(obj, obj.CurrentColor3)
+			end)
+
+			return obj
+		end
+
+		return {new = new}
+	end)()
+
+	SettingsEditor.Update = function()
+
+	end
+
+	SettingsEditor.UpdateView = function()
+
+	end
+
+	SettingsEditor.Refresh = function()
+
+	end
+
+	SettingsEditor.ScrollBarFrame = function()
+		local ScrollingFrame = Instance.new("ScrollingFrame")
+		ScrollingFrame.Size = UDim2.new(1, 0, 1, 0)
+		ScrollingFrame.BackgroundTransparency = 1
+		ScrollingFrame.BorderSizePixel = 0
+
+		ScrollingFrame.AutomaticCanvasSize = Enum.AutomaticSize.Y
+		ScrollingFrame.ScrollBarImageColor3 = Color3.fromRGB(0, 0, 0)
+		ScrollingFrame.ScrollBarThickness = 6
+
+		local UILIstLayout = Instance.new("UIListLayout")
+		UILIstLayout.SortOrder = Enum.SortOrder.LayoutOrder
+		UILIstLayout.Parent = ScrollingFrame
+
+		return ScrollingFrame
+	end
+
+
+	SettingsEditor.CategoryListFrame = function()
+		local List = Instance.new("Frame")
+		List.Name = "List"
+		List.AutomaticSize = Enum.AutomaticSize.Y
+		List.Size = UDim2.new(1, -6, 0.1, 0)
+		List.ClipsDescendants = true
+		List.BackgroundTransparency = 1
+		List.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+
+
+		local UILIstLayout = Instance.new("UIListLayout")
+		UILIstLayout.SortOrder = Enum.SortOrder.LayoutOrder
+		UILIstLayout.Parent = List
+
+		return List
+	end
+
+
+
+	-- Creates a dropdown
+	SettingsEditor.CategoryDropdown = (function()
+		local funcs = {}
+
+		local function createFrame(self)
+			local Expander = Instance.new("TextButton")
+			Expander.Name = "Expander"
+			Expander.Size = UDim2.new(1, -scrollbarThickness, 0, 22)
+			Expander.BorderColor3 = Color3.fromRGB(33, 33, 33)
+			Expander.BackgroundTransparency = 0.2
+			Expander.Position = UDim2.new(0, 1, 0, 1)
+			Expander.BackgroundColor3 = Color3.fromRGB(45, 45, 45)
+			Expander.AutoButtonColor = false
+			Expander.FontSize = Enum.FontSize.Size14
+			Expander.TextSize = 14
+			Expander.Text = ""
+			Expander.Font = Enum.Font.SourceSans
+
+			local NameFrame = Instance.new("Frame")
+			NameFrame.Name = "NameFrame"
+			NameFrame.Size = UDim2.new(1, -40, 1, 0)
+			NameFrame.BorderColor3 = Color3.fromRGB(86, 125, 188)
+			NameFrame.BackgroundTransparency = 1
+			NameFrame.Position = UDim2.new(0, 20, 0, 0)
+			NameFrame.BorderSizePixel = 0
+			NameFrame.BackgroundColor3 = Color3.fromRGB(11, 90, 175)
+			NameFrame.Parent = Expander
+
+			local PropName = Instance.new("TextLabel")
+			PropName.Name = "PropName"
+			PropName.Size = UDim2.new(1, -2, 1, 0)
+			PropName.BackgroundTransparency = 1
+			PropName.Position = UDim2.new(0, 2, 0, 0)
+			PropName.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+			PropName.FontSize = Enum.FontSize.Size14
+			PropName.TextTruncate = Enum.TextTruncate.AtEnd
+			PropName.TextSize = 14
+			PropName.TextColor3 = Color3.fromRGB(255, 255, 255)
+			PropName.Text = "Category"
+			PropName.Font = Enum.Font.SourceSansBold
+			PropName.TextTransparency = 0.1
+			PropName.TextXAlignment = Enum.TextXAlignment.Left
+			PropName.Parent = NameFrame
+
+			local Expand = Instance.new("TextButton")
+			Expand.Name = "Expand"
+			Expand.Size = UDim2.new(0, 20, 0, 20)
+			Expand.ClipsDescendants = true
+			Expand.BackgroundTransparency = 1
+			Expand.Position = UDim2.new(0, -20, 0, 1)
+			Expand.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+			Expand.FontSize = Enum.FontSize.Size14
+			Expand.TextSize = 14
+			Expand.Text = ""
+			Expand.Font = Enum.Font.SourceSans
+			Expand.Parent = NameFrame
+
+			local Icon = Instance.new("ImageLabel")
+			Icon.Name = "Icon"
+			Icon.Size = UDim2.new(0, 16, 0, 16)
+			Icon.BackgroundTransparency = 1
+			Icon.Position = UDim2.new(0, 2, 0, 2)
+			Icon.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+			Icon.ScaleType = Enum.ScaleType.Crop
+			Icon.ImageRectOffset = Vector2.new(144, 16)
+			Icon.ImageRectSize = Vector2.new(16, 16)
+			Icon.Image = "rbxassetid://5642383285"
+			Icon.Parent = Expand
+
+			return Expander
+		end
+
+		local function setupGuiFuncs(self)
+			local Expander = self.Gui
+
+			local Expand = Expander.NameFrame.Expand
+
+			-- Functions
+			local function updateIcon()
+				Apps.Explorer.MiscIcons:DisplayByKey(self.GuiElems.Icon, self.Expanded and "Collapse" or "Expand")
+			end
+
+			Expand.MouseButton1Click:Connect(function()
+				if (self.ToggleFrame) then
+					self.ToggleFrame.Visible = not self.ToggleFrame.Visible
+				end
+
+				if (self.ToggleFrame.Visible) then
+					self.Expanded = true
+				else
+					self.Expanded = false
+				end
+
+				-- Update Icon
+				updateIcon()
+			end)
+
+			-- Init
+			updateIcon()
+		end
+
+		function funcs:SetDisplayName(displayName)
+			if (self.Gui:FindFirstChild("NameFrame")) then
+				self.Gui.NameFrame.PropName.Text = displayName
+			end	
+		end
+
+		-- Set the frame to toggle
+		function funcs:SetToggleFrame(toggleFrame)
+			self.ToggleFrame = toggleFrame
+
+			return self.ToggleFrame
+		end
+
+
+		local mt = {}
+		mt.__index = funcs
+
+		local function new(toggleFrame, displayName)
+			local obj = setmetatable({}, mt)
+
+			obj.Gui = createFrame(obj)
+
+			obj.GuiElems = {
+				Icon = obj.Gui.NameFrame.Expand.Icon
+			}
+
+			obj.Expanded = true -- Whether expanded
+
+			setupGuiFuncs(obj)
+
+			obj:SetDisplayName(displayName)
+
+			obj:SetToggleFrame(toggleFrame)
+
+
+			return obj
+		end
+
+		return {new = new}
+	end)()
+
+
+	-- Change a setting
+	SettingsEditor.SetSettingValue = function(categoryName, settingName, settingInfo, newValue)
+		if (settingInfo.OnChange) then
+			settingInfo.OnChange(newValue)
+		else
+			Settings[categoryName][settingName] = newValue
+		end
+	end
+
+
+	SettingsEditor.SetupInfoDesc = function()
+		local infoDescBox = SettingsEditor.InfoDescBox
+		-- TODO: Maybe change this
+
+		if not (infoDescBox) then
+			local newFrame = Instance.new("Frame")
+			newFrame.BackgroundColor3 = Color3.fromRGB(0,0,0)
+			newFrame.BackgroundTransparency = 0.2
+			newFrame.BorderSizePixel = 0
+			newFrame.Size = UDim2.new(0,0,0,0)
+			newFrame.AutomaticSize = Enum.AutomaticSize.XY
+			newFrame.Visible = false -- not visible
+
+			local newTextBox = Instance.new("TextBox")
+			newTextBox.BackgroundTransparency = 1
+			newTextBox.TextColor3 = Color3.fromRGB(255, 255, 255)
+			newTextBox.Size = UDim2.new(0,0,0,0)
+			newTextBox.AutomaticSize = Enum.AutomaticSize.XY
+			newTextBox.Parent = newFrame
+
+
+			infoDescBox = newFrame
+			SettingsEditor.InfoDescBox = infoDescBox
+
+
+			infoDescBox.Parent = SettingsEditor.Window.Gui
+		end
+
+		return infoDescBox
+	end
+
+
+	SettingsEditor.CreateSettingEntry = function(categoryName, settingName, settingInfo)
+		local newEntry = SettingsEditor.NewPropEntry()
+		newEntry.Gui.Parent = settingsListFrame
+
+		newEntry.GuiElems.PropName.Text = settingName
+
+		local InfoButton: TextBox = newEntry.GuiElems.InfoButton
+
+		if (settingInfo.desc) then
+			local infoDescBox:Frame = SettingsEditor.InfoDescBox
+			local isEnter = false
+
+			InfoButton.MouseEnter:Connect(function(x, y)
+				isEnter = true
+
+				-- Set setting description
+				(infoDescBox:WaitForChild("TextBox") :: TextBox).Text = settingInfo.desc
+
+				infoDescBox.Position = UDim2.new(0, x, 0, y)
+				infoDescBox.Visible = true
+			end)
+
+			InfoButton.MouseMoved:Connect(function(x, y)
+				infoDescBox.Position = UDim2.new(0, x, 0, y)
+				infoDescBox.Visible = true
+			end)
+
+			InfoButton.MouseLeave:Connect(function(x, y)
+				if (isEnter == true) then
+					isEnter = false
+					infoDescBox.Visible = false
+				end
+			end)
+		else
+			-- Don't show info button, if there's no description.
+			InfoButton.Visible = false
+		end
+
+
+		-- ValueBox
+		local ValueBox: TextButton = newEntry.Gui.ValueFrame.ValueBox
+
+
+		-- Boolean
+		if (settingInfo.typeName == "boolean") then
+			-- Checkbox
+			local newCheckbox = Lib.Checkbox.new()
+
+			-- Set current value
+			newCheckbox:SetState(Settings[categoryName][settingName], false)
+
+
+			-- Whenever Checkbox value changes
+			newCheckbox.OnInput:Connect(function()
+				local newValue = newCheckbox.Toggled
+
+				-- Sets the value
+				SettingsEditor.SetSettingValue(categoryName, settingName, settingInfo, newValue)
+			end)
+
+			newCheckbox.Gui.Parent = newEntry.Gui.ValueFrame
+
+
+			-- Color3
+		elseif (settingInfo.typeName == "Color3") then
+			local colorButton = SettingsEditor.ColorButton.new()
+			colorButton.Gui.Parent = newEntry.Gui.ValueFrame
+
+			-- Set current Color3
+			colorButton:SetColor3Value(Settings[categoryName][settingName])
+
+			colorButton.Gui.Visible = true
+
+
+			-- Fired once color input was changed
+			colorButton.OnColorChange:Connect(function()
+				local newColor = colorButton.CurrentColor3
+
+				SettingsEditor.SetSettingValue(categoryName, settingName, settingInfo, newColor)
+			end)
+
+
+		else
+			-- For anything else
+			local inputBox = SettingsEditor.CreateInputBox(ValueBox)
+			local inputTextBox = inputBox.TextBox.Input
+
+			inputBox.Parent = newEntry.Gui.ValueFrame
+
+			inputTextBox.FocusLost:Connect(function()
+				local convertedVal = SettingsEditor.StringToValue(settingInfo, inputTextBox.Text)
+
+				if (convertedVal) then
+					ValueBox.Text = SettingsEditor.ValueToString(convertedVal)
+
+					-- Sets value
+					SettingsEditor.SetSettingValue(categoryName, settingName, settingInfo, convertedVal)
+				end
+			end)
+
+			-- Set current value
+			ValueBox.Text = SettingsEditor.ValueToString(Settings[categoryName][settingName])
+		end
+
+		return newEntry
+	end
+
+
+	-- Set up the settings.
+	SettingsEditor.SetupSettings = function(categoryIndex, parentTo)
+		local infoTable = SettingsEditor.SettingsInfo[categoryIndex]
+
+		for _, settingName in ipairs(infoTable.Order) do
+			if (infoTable.Info[settingName]) then
+				local settingInfo = infoTable.Info[settingName]
+
+				local newEntry = SettingsEditor.CreateSettingEntry(categoryIndex, settingName, settingInfo)
+
+				newEntry.Gui.Parent = parentTo
+			end
+		end
+	end
+
+
+
+	-- Create new Category
+	SettingsEditor.NewCategory = function(indexName, displayName, parentTo)
+		-- indexName, how it should be indexed
+		-- displayName, how the category should show up
+
+		local categoryListFrame = SettingsEditor.CategoryListFrame():Clone()
+		categoryListFrame.Name = indexName
+		--categoryListFrame.Visible = false
+
+		-- Setup settings
+		SettingsEditor.SetupSettings(indexName, categoryListFrame)
+
+
+		local category = SettingsEditor.CategoryDropdown.new(categoryListFrame, displayName)
+		category.Gui.Parent = parentTo
+
+		-- parent category list
+		categoryListFrame.Parent = parentTo
+
+		return category
+	end
+
+
+
+
+	-- Generate Setting buttons and stuff
+	SettingsEditor.RenderSettings = function()
+		for _,categoryName in ipairs(SettingsEditor.SettingsInfo._Categories) do
+			SettingsEditor.NewCategory(categoryName, categoryName, settingsListFrame)
+		end
+	end
+
+
+	-- Init
+	SettingsEditor.Init = function()
+		local window = Lib.Window.new()
+		SettingsEditor.Window = window
+
+		window:SetTitle("Settings")
+		window.Resizable = true
+
+		-- Setup Results ScrollingFrame
+		settingsListFrame = SettingsEditor.ScrollBarFrame()
+
+		SettingsEditor.Window.GuiElems.Main.Parent.Name = "Dex_SettingsWindow" -- Change ScreenGui name
+
+
+		-- Setup Gui
+		SettingsEditor.SetupInfoDesc() -- Hover text description
+
+		SettingsEditor.RenderSettings() -- Sets up UI to change settings
+
+
+		-- Window Add, adds things to the "Content"
+		window:Add(settingsListFrame)
+	end
+
+
+
+	return SettingsEditor
+end
+
+return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}]]></ProtectedString>
+							<int64 name="SourceAssetId">-1</int64>
+							<BinaryString name="Tags"></BinaryString>
+						</Properties>
+						<Item class="ModuleScript" referent="RBX41ee3dbfc005471ba266eaec1e1f8389">
+							<Properties>
+								<BinaryString name="AttributesSerialize"></BinaryString>
+								<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+								<bool name="DefinesCapabilities">false</bool>
+								<Content name="LinkedSource"><null></null></Content>
+								<string name="Name">settingsInfo</string>
+								<string name="ScriptGuid">{4EB7F004-779E-4072-B0FF-A1E6E719E63E}</string>
+								<ProtectedString name="Source"><![CDATA[local settingsInfo = {}
+
+-- Common Locals
+local Main,Lib,Apps,Settings -- Main Containers
+local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
+local API,RMD,env,service,plr,create,createSimple -- Main Locals
+
+
+function settingsInfo.initDeps(data)
+	Main = data.Main
+	Lib = data.Lib
+	Apps = data.Apps
+	Settings = data.Settings
+
+	--API = data.API
+	--RMD = data.RMD
+	--env = data.env
+	--service = data.service
+	--plr = data.plr
+	--create = data.create
+	--createSimple = data.createSimple
+end
+
+
+-- Register Setting
+local function RegisterSetting(categoryTable, settingName, data)
+	categoryTable.Info[settingName] = data
+	
+	table.insert(categoryTable.Order, settingName)
+end
+
+--[[
+Example Settings
+
+-- this is the basic setup
+settingInfo.CategoryName
+
+
+]]
+
+-- The order here, defines the order on how they show up
+settingsInfo._Categories = {
+	--"Main",
+	"Explorer",
+	"Properties",
+	"Theme",
+}
+
+-- TODO: Use "DefaultSettings" for default values perhaps
+
+settingsInfo.Main = {}
+settingsInfo.Main.Info = {}
+settingsInfo.Main.Order = {}
+
+--[[RegisterSetting(settingsInfo["Main"], "ResetOnSpawn", {
+	desc = "Whether to reset the UI on spawn.";
+	defaultVal = true;
+	typeName = "boolean";
+
+	OnChange = function(newValue)
+		Settings.Main.ResetOnSpawn = newValue
+		
+		if (Main.LocalScript_Gui) then
+			Main.LocalScript_Gui.ResetOnSpawn = newValue
+		end
+		
+		if (Main.MainGui) then
+			Main.MainGui.ResetOnSpawn = newValue
+		end
+		
+		if (Lib.SidesGui) then
+			Lib.SidesGui.ResetOnSpawn = newValue
+		end
+		
+		if (Lib.StoredWindows) then
+			for k,v in pairs(Lib.StoredWindows) do
+				if (v.Gui) then
+					v.Gui.ResetOnSpawn = newValue
+				end
+			end
+		end
+	end;
+})]]
+
+
+
+settingsInfo.Explorer = {}
+settingsInfo.Explorer.Info = {}
+settingsInfo.Explorer.Order = {}
+
+
+
+-- Example Setting
+RegisterSetting(settingsInfo.Explorer, "Sorting", {
+	desc = nil;
+	defaultVal = true;
+	typeName = "boolean";
+
+	OnChange = function(newValue)
+		Apps.Explorer.SetSortingEnabled(newValue)
+	end;
+})
+
+
+RegisterSetting(settingsInfo.Explorer, "TeleportToOffset", {
+	desc = "Offset when teleporting to Instances";
+	defaultVal = Vector3.new(0,0,0);
+	typeName = "Vector3";
+})
+
+RegisterSetting(settingsInfo.Explorer, "ClickToSelect", {
+	desc = "Whether clicking will select parts";
+	defaultVal = false;
+	typeName = "boolean";
+	
+	OnChange = function(newValue)
+		Settings.Explorer.ClickToSelect = newValue
+		Apps.Explorer.InitClickToSelect()
+	end,
+})
+
+
+--[[RegisterSetting(settingsInfo.Explorer, "ClickToRename", {
+	desc = "ClickToRename";
+	defaultVal = true;
+	typeName = "boolean";
+})]]
+
+
+RegisterSetting(settingsInfo.Explorer, "AutoUpdateSearch", {
+	desc = nil;
+	defaultVal = true;
+	typeName = "boolean";
+})
+
+
+--[[RegisterSetting(settingsInfo.Explorer, "AutoUpdateMode", {
+	desc = "0 Default, 1 no tree update, 2 no descendant events, 3 frozen";
+	defaultVal = 0;
+	typeName = "number";
+})]]
+
+
+RegisterSetting(settingsInfo.Explorer, "PartSelectionBox", {
+	desc = "Toggle Selection Box on Objects";
+	defaultVal = true;
+	typeName = "boolean";
+})
+
+RegisterSetting(settingsInfo.Explorer, "GuiSelectionBox", {
+	desc = "Toggle Selection Box on GUIs";
+	defaultVal = true;
+	typeName = "boolean";
+})
+
+RegisterSetting(settingsInfo.Explorer, "CopyPathUseGetChildren", {
+	desc = nil;
+	defaultVal = true;
+	typeName = "boolean";
+})
+
+
+
+
+settingsInfo.Properties = {}
+settingsInfo.Properties.Info = {}
+settingsInfo.Properties.Order = {}
+
+RegisterSetting(settingsInfo.Properties, "MaxConflictCheck", {
+	desc = nil;
+	defaultVal = 50;
+	typeName = "number";
+})
+
+
+RegisterSetting(settingsInfo.Properties, "ShowDeprecated", {
+	desc = nil;
+	defaultVal = false;
+	typeName = "boolean";
+})
+
+RegisterSetting(settingsInfo.Properties, "ShowHidden", {
+	desc = nil;
+	defaultVal = false;
+	typeName = "boolean";
+})
+
+
+RegisterSetting(settingsInfo.Properties, "NumberRounding", {
+	desc = nil;
+	defaultVal = 3;
+	typeName = "number";
+})
+
+
+RegisterSetting(settingsInfo.Properties, "ShowAttributes", {
+	desc = nil;
+	defaultVal = false;
+	typeName = "boolean";
+})
+
+
+RegisterSetting(settingsInfo.Properties, "MaxAttributes", {
+	desc = nil;
+	defaultVal = 50;
+	typeName = "number";
+})
+
+
+RegisterSetting(settingsInfo.Properties, "ScaleType", {
+	desc = "0 Full Name Shown, 1 Equal Halves";
+	defaultVal = 1;
+	typeName = "number";
+})
+
+
+settingsInfo.Theme = {}
+settingsInfo.Theme.Info = {}
+settingsInfo.Theme.Order = {}
+
+local rgb = Color3.fromRGB
+
+RegisterSetting(settingsInfo.Theme, "Main1", {
+	desc = nil;
+	defaultVal = rgb(52,52,52);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "Main2", {
+	desc = nil;
+	defaultVal = rgb(45,45,45);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "Outline1", {
+	desc = "Mainly frames";
+	defaultVal = rgb(33,33,33);
+	typeName = "Color3";
+})
+RegisterSetting(settingsInfo.Theme, "Outline2", {
+	desc = "Mainly button";
+	defaultVal = rgb(55,55,55);
+	typeName = "Color3";
+})
+RegisterSetting(settingsInfo.Theme, "Outline3", {
+	desc = "Mainly textbox";
+	defaultVal = rgb(30,30,30);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "TextBox", {
+	desc = nil;
+	defaultVal = rgb(38,38,38);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "Menu", {
+	desc = nil;
+	defaultVal = rgb(32,32,32);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "ListSelection", {
+	desc = nil;
+	defaultVal = rgb(11,90,175);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "Button", {
+	desc = nil;
+	defaultVal = rgb(60,60,60);
+	typeName = "Color3";
+})
+RegisterSetting(settingsInfo.Theme, "ButtonHover", {
+	desc = nil;
+	defaultVal = rgb(68,68,68);
+	typeName = "Color3";
+})
+RegisterSetting(settingsInfo.Theme, "ButtonPress", {
+	desc = nil;
+	defaultVal = rgb(40,40,40);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "Highlight", {
+	desc = nil;
+	defaultVal = rgb(75,75,75);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "Text", {
+	desc = nil;
+	defaultVal = rgb(255,255,255);
+	typeName = "Color3";
+})
+RegisterSetting(settingsInfo.Theme, "PlaceholderText", {
+	desc = nil;
+	defaultVal = rgb(100,100,100);
+	typeName = "Color3";
+})
+
+RegisterSetting(settingsInfo.Theme, "Important", {
+	desc = nil;
+	defaultVal = rgb(255,0,0);
+	typeName = "Color3";
+})
+
+
+
+return settingsInfo]]></ProtectedString>
+								<int64 name="SourceAssetId">-1</int64>
+								<BinaryString name="Tags"></BinaryString>
+							</Properties>
+						</Item>
+					</Item>
+					<Item class="ModuleScript" referent="RBXce4b9ac3deee40baa8ae46a2ea4075a0">
+						<Properties>
+							<BinaryString name="AttributesSerialize"></BinaryString>
+							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+							<bool name="DefinesCapabilities">false</bool>
+							<Content name="LinkedSource"><null></null></Content>
+							<string name="Name">AboutMenu</string>
+							<string name="ScriptGuid">{715204E4-4F9D-4816-98B0-B96946C53ED2}</string>
+							<ProtectedString name="Source"><![CDATA[--[[
+	Settings Module
+	
+	The Module to configure settings
+]]
+
+-- ADONIS
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Dex_RemoteFunction = ReplicatedStorage:WaitForChild("NewDex_Event") :: RemoteFunction
+
+-- Common Locals
+local Main,Lib,Apps,Settings -- Main Containers
+local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
+local API,RMD,env,service,plr,create,createSimple -- Main Locals
+
+local function initDeps(data)
+	Main = data.Main
+	Lib = data.Lib
+	Apps = data.Apps
+	Settings = data.Settings
+
+	API = data.API
+	RMD = data.RMD
+	env = data.env
+	service = data.service
+	plr = data.plr
+	create = data.create
+	createSimple = data.createSimple
+end
+
+local function initAfterMain()
+	Explorer = Apps.Explorer
+	Properties = Apps.Properties
+	ScriptViewer = Apps.ScriptViewer
+	Notebook = Apps.Notebook
+end
+
+
+local function main()
+	local AboutMenu = {}
+	
+	local scrollV, scrollH
+	local settingsListFrame
+	local expanded, viewList = {}, {}
+	
+	local aboutFrame
+	
+	
+	AboutMenu.AboutFrame = function()
+		local aboutFrame = create({
+			{1,'Frame',{Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Name='AboutFrame',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
+			{2,'Frame',{Parent={1},Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Name='Container',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
+			{3,'UIListLayout',{Parent={2},VerticalAlignment=Enum.VerticalAlignment.Center,SortOrder=Enum.SortOrder.LayoutOrder,HorizontalAlignment=Enum.HorizontalAlignment.Center,}}
+		})
+		
+		--local Container = aboutFrame.Container
+		
+		return aboutFrame
+	end
+	
+	
+	AboutMenu.CreditsEntry = (function()
+		local funcs = {}
+		
+		local function createGui()
+			local creditsEntry = create({
+				{1,'Frame',{Size=UDim2.new(1, 0, 0, 10),BorderColor3=Color3.fromRGB(0, 0, 0),Name='TextEntry',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
+				{2,'TextBox',{Parent={1},BorderSizePixel=0,RichText=true,BackgroundColor3=Color3.fromRGB(255, 255, 255),TextWrapped=true,TextSize=20,TextColor3=Color3.fromRGB(255, 255, 255),Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Text='text',Font=Enum.Font.SourceSans,BackgroundTransparency=1,ClearTextOnFocus=false,TextEditable=false,}}
+			})
+			
+			return creditsEntry
+		end
+		
+		
+		function funcs:ChangeText(text)
+			self.GuiElems.TextBox.Text = text
+		end
+		
+		
+		local mt = {__index = funcs}
+		local function new(text)
+			local obj = setmetatable({}, mt)
+			
+			obj.Gui = createGui()
+			
+			obj.GuiElems = {
+				TextBox = obj.Gui.TextBox
+			}
+			
+			if (text) then
+				obj:ChangeText(text)
+			end
+			
+			
+			-- Parent
+			obj.Gui.Parent = aboutFrame.Container
+			
+			return obj
+		end
+		
+		
+		return {new = new}
+	end)()
+	
+	
+	AboutMenu.AddCreditsEntry = function(text, properties)
+		local creditsEntry = create({
+			{1,'Frame',{Size=UDim2.new(1, 0, 0, 10),AutomaticSize=Enum.AutomaticSize.XY,BorderColor3=Color3.fromRGB(0, 0, 0),Name='TextEntry',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
+			{2,'TextLabel',{Parent={1},AutomaticSize=Enum.AutomaticSize.XY,BorderSizePixel=0,RichText=true,BackgroundColor3=Color3.fromRGB(255, 255, 255),TextWrapped=true,TextSize=14,TextColor3=Color3.fromRGB(255, 255, 255),Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Text='text',Font=Enum.Font.SourceSans,BackgroundTransparency=1,}}
+		})
+		
+		local entryText = creditsEntry.TextLabel
+		entryText.Text = text
+		
+		-- Default text size
+		entryText.TextSize = 16
+		
+		if (properties) then
+			for property, val in pairs(properties) do
+				entryText[property] = val
+			end
+		end
+		
+		
+		creditsEntry.Parent = aboutFrame.Container
+		
+
+		return creditsEntry
+	end
+	
+	-- Init
+	AboutMenu.Init = function()
+		local window = Lib.Window.new()
+		AboutMenu.Window = window
+
+		window:SetTitle("About")
+		window.Resizable = true
+		
+		-- Setup Results ScrollingFrame
+		AboutMenu.Window.GuiElems.Main.Parent.Name = "Dex_AboutWindow" -- Change ScreenGui name
+		
+		
+		-- Create Gui
+		aboutFrame = AboutMenu.AboutFrame()
+		
+		AboutMenu.AddCreditsEntry("<b>About Dex</b>", {
+			TextSize = 30,
+		})
+		
+		AboutMenu.AddCreditsEntry("<b>Version:</b> ".. Main.Version)
+		AboutMenu.AddCreditsEntry("\n", {TextSize = 5})
+		AboutMenu.AddCreditsEntry("Developed by Moon aka. LorekeeperZinnia")
+		AboutMenu.AddCreditsEntry("This version is modified, the official release was never finished.", {
+			TextSize = 12,
+		})
+		AboutMenu.AddCreditsEntry("\n\n", {TextSize = 10})
+		AboutMenu.AddCreditsEntry("<b>Additional Contributors:</b>", {TextSize = 17})
+		AboutMenu.AddCreditsEntry("SnowyShiro", {TextSize = 17})
+		AboutMenu.AddCreditsEntry("<i>Modified GuiToLuaAE</i>")
+		AboutMenu.AddCreditsEntry("")
+		AboutMenu.AddCreditsEntry("karl-police", {TextSize = 17})
+		AboutMenu.AddCreditsEntry("EasternBloxxer", {TextSize = 17})
+		AboutMenu.AddCreditsEntry("xs4u", {TextSize = 17})
+		AboutMenu.AddCreditsEntry("<i>Added additional features, Adonis Plugin</i>")
+		
+		-- Window Add, adds things to the "Content"
+		window:Add(aboutFrame)
+	end
+	
+	return AboutMenu
+end
+
+return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}]]></ProtectedString>
+							<int64 name="SourceAssetId">-1</int64>
+							<BinaryString name="Tags"></BinaryString>
+						</Properties>
+					</Item>
+					<Item class="ModuleScript" referent="RBX13c112342045493f8f8a1f8f8a21e36f">
+						<Properties>
+							<BinaryString name="AttributesSerialize"></BinaryString>
+							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
+							<bool name="DefinesCapabilities">false</bool>
+							<Content name="LinkedSource"><null></null></Content>
+							<string name="Name">Explorer</string>
+							<string name="ScriptGuid">{F5B7E89A-4B53-46EF-BB0F-99F053CC79A4}</string>
+							<ProtectedString name="Source"><![CDATA[--[[
+	Explorer App Module
+	
+	The main explorer interface
+]]
+
+-- ADONIS
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+local Dex_RemoteFunction = ReplicatedStorage:WaitForChild("NewDex_Event") :: RemoteFunction
+
+-- Common Locals
+local Main,Lib,Apps,Settings -- Main Containers
+local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
+local API,RMD,env,service,plr,create,createSimple -- Main Locals
+
+local function tweenInEntry(entry, fromPos, toPos)
+	entry.Position = fromPos
+	entry.Indent.EntryName.TextTransparency = 1
+	entry.Indent.Icon.ImageTransparency = 1
+	entry.Visible = true
+
+	local lengthScale = 1 -- for fun while I test, e.g 10 for 10 times slower
+
+	TweenService:Create(entry, TweenInfo.new(0.2*lengthScale, Enum.EasingStyle.Sine), { Position = toPos }):Play()
+	TweenService:Create(entry.Indent.EntryName, TweenInfo.new(0.15*lengthScale), { TextTransparency = 0 }):Play()
+	TweenService:Create(entry.Indent.Icon, TweenInfo.new(0.15*lengthScale), { ImageTransparency = 0 }):Play()
+end
+
+
+
+local function initDeps(data)
+	Main = data.Main
+	Lib = data.Lib
+	Apps = data.Apps
+	Settings = data.Settings
+
+	API = data.API
+	RMD = data.RMD
+	env = data.env
+	service = data.service
+	plr = data.plr
+	create = data.create
+	createSimple = data.createSimple
+end
+
+local function initAfterMain()
+	Explorer = Apps.Explorer
+	Properties = Apps.Properties
+	ScriptViewer = Apps.ScriptViewer
+	Notebook = Apps.Notebook
+end
+
+local function main()
 	local Explorer = {}
 	local nodes,tree,listEntries,explorerOrders,searchResults,specResults = {},{},{},{},{},{}
 	local expanded
-	local entryTemplate,treeFrame,toolBar,descendantAddedCon,descendantRemovingCon,itemChangedCon
+	local entryTemplate,treeFrame:Frame,toolBar,descendantAddedCon,descendantRemovingCon,itemChangedCon
 	local ffa = game.FindFirstAncestorWhichIsA
 	local getDescendants = game.GetDescendants
 	local getTextSize = service.TextService.GetTextSize
 	local updateDebounce,refreshDebounce = false,false
-	local nilNode = {Obj = Instance.new("Folder")}
+	local nilNode = {Obj = Instance.new("Folder")} :: any
 	local idCounter = 0
 	local scrollV,scrollH,selection,clipboard
 	local renameBox,renamingNode,searchFunc
@@ -1524,6 +4912,64 @@ local function main()
 	local nilMap,nilCons = {},{}
 	local connectSignal = game.DescendantAdded.Connect
 	local addObject,removeObject,moveObject = nil,nil,nil
+
+	-- silencer, absolute hell!!!
+	Explorer.NodeSorter = nil
+	Explorer.IsNodeVisible = nil
+	Explorer.PerformUpdate = nil
+	Explorer.PerformRefresh = nil
+	Explorer.Window = nil
+	Explorer.InitRenameBox = nil
+	Explorer.SetRenamingNode = nil
+	Explorer.SetSortingEnabled = nil
+	Explorer.UpdateView = nil
+	Explorer.Update = nil
+	Explorer.StartDrag = nil
+	Explorer.NewListEntry = nil
+	Explorer.Refresh = nil
+	Explorer.ForceUpdate = nil
+	Explorer.NodeDepth = nil
+	Explorer.SetupConnections = nil
+	Explorer.ViewNode = nil
+	Explorer.ViewObj = nil
+	Explorer.MakeNodeVisible = nil
+	Explorer.ShowRightClick = nil
+	Explorer.InitRightClick = nil
+	Explorer.HideNilInstances = nil
+	Explorer.RefreshNilInstances = nil
+	Explorer.GetInstancePath = nil
+	Explorer.InitInsertObject = nil
+	Explorer.InitClickToSelect = nil
+	Explorer.BuildSearchFunc = nil
+	Explorer.DoSearch = nil
+	Explorer.ClearSearch = nil
+	Explorer.InitSearch = nil
+	Explorer.InitEntryTemplate = nil
+	Explorer.InitDelCleaner = nil
+	Explorer.UpdateSelectionVisuals = nil
+	Explorer.Init = nil
+	Explorer.ClassIcons = nil
+	Explorer.MiscIcons = nil
+	Explorer.Selection = nil
+	Explorer.ClickSystem = nil
+	Explorer.SelectionVisualsHolder = nil
+	Explorer.SelectionVisualCons = nil
+	Explorer.SelectionVisualGui = nil
+	Explorer.SelectionVisualBox = nil
+	Explorer.Clipboard = nil
+	Explorer.SearchFilters = nil
+	Explorer.SearchExpanded = nil
+	Explorer.Expanded = nil
+	Explorer.Active = nil
+	Explorer.Dragging = nil
+	Explorer.ViewWidth = nil
+	Explorer.Index = nil
+	Explorer.EntryIndent = nil
+	Explorer.FreeWidth = nil
+	Explorer.GuiElems = nil
+	Explorer.RightClickContext = nil
+	Explorer.InsertObjectContext = nil
+	Explorer.ClickToSelect_Connection = nil
 
 	addObject = function(root)
 		if nodes[root] then return end
@@ -1756,10 +5202,10 @@ local function main()
 			if not renamingNode then return end
 
 			pcall(function() renamingNode.Obj.Name = renameBox.Text end)
-			
+
 			-- ADONIS
-			Dex_RemoteEvent:InvokeServer("SetProperty", renamingNode.Obj, "Name", renameBox.Text)
-			
+			Dex_RemoteFunction:InvokeServer("SetProperty", renamingNode.Obj, "Name", renameBox.Text)
+
 			renamingNode = nil
 			Explorer.Refresh()
 		end)
@@ -1830,7 +5276,7 @@ local function main()
 		local aOrder = explorerOrders[aClass]
 		local bOrder = explorerOrders[bClass]
 		if not aOrder then aOrder = RMD.Classes[aClass] and tonumber(RMD.Classes[aClass].ExplorerOrder) or 9999 explorerOrders[aClass] = aOrder end
-		if not bOrder then bOrder = RMD.Classes[bClass] and tonumber(RMD.Classes[bClass].ExplorerOrder) or 9999 explorerOrders[bClass] = bOrder end
+		if not bOrder then bOrder = RMD.Classes	[bClass] and tonumber(RMD.Classes[bClass].ExplorerOrder) or 9999 explorerOrders[bClass] = bOrder end
 
 		if aOrder ~= bOrder then
 			return aOrder < bOrder
@@ -1995,9 +5441,9 @@ local function main()
 								local n = sList[i]
 								pcall(function()
 									n.Obj.Parent = newPar
-									
+
 									-- ADONIS
-									Dex_RemoteEvent:InvokeServer("SetProperty", n.Obj, "Parent", newPar)
+									Dex_RemoteFunction:InvokeServer("SetProperty", n.Obj, "Parent", newPar)
 								end)
 							end
 							Explorer.ViewNode(sList[1])
@@ -2099,6 +5545,33 @@ local function main()
 			expanded[node] = not expanded[node]
 			Explorer.Update()
 			Explorer.Refresh()
+
+			if expanded[node] then
+				local arrowPos = newEntry.Indent.Expand.AbsolutePosition
+				local framePos = treeFrame.AbsolutePosition
+
+				for _, v in ipairs(node) do
+					local i = table.find(tree, v)
+					if i then
+						local listIndex = i - Explorer.Index
+						local entry= listEntries[listIndex]
+						if entry then
+							local X = arrowPos.X - framePos.X
+							local Y = arrowPos.Y - framePos.Y
+							local from = UDim2.new(0, X, 0, Y)
+							local to   = entry.Position
+							tweenInEntry(entry, from, to)
+						end
+					end
+				end
+			end
+
+			local targetAngle = expanded[node] and 360 or 0 -- don't ask.
+			TweenService:Create(
+				newEntry.Indent.Expand,
+				TweenInfo.new(0.15, Enum.EasingStyle.Quad),
+				{Rotation = targetAngle}
+			):Play()
 		end)
 
 		newEntry.Parent = treeFrame
@@ -2354,10 +5827,13 @@ local function main()
 		end
 		context:AddRegistered("INSERT_OBJECT")
 		--context:AddRegistered("SAVE_INST")
-		context:AddRegistered("CALL_FUNCTION")
+		if presentClasses["RemoteEvent"] or presentClasses["RemoteFunction"] or presentClasses["BindableEvent"] or presentClasses["BindableFunction"] then
+			context:AddRegistered("CALL_FUNCTION")
+		end
 		--context:AddRegistered("VIEW_CONNECTIONS")
 		--context:AddRegistered("GET_REFERENCES")
 		--context:AddRegistered("VIEW_API")
+		context:AddRegistered("VIEW_DESCRIPTION")
 
 		context:QueueDivider()
 
@@ -2389,46 +5865,178 @@ local function main()
 		context:Register("CUT",{Name = "Cut", IconMap = Explorer.MiscIcons, Icon = "Cut", DisabledIcon = "Cut_Disabled", Shortcut = "Ctrl+Z", OnClick = function()
 			local destroy,clone = game.Destroy,game.Clone
 			local sList,newClipboard = selection.List,{}
-			Dex_RemoteEvent:InvokeServer("ClearClipboard") -- ADONIS
-			
+			Dex_RemoteFunction:InvokeServer("ClearClipboard") -- ADONIS
+
 			local count = 1
 			for i = 1,#sList do
 				local inst = sList[i].Obj
-				
+
 				-- ADONIS
-				Dex_RemoteEvent:InvokeServer("Copy", inst)
+				Dex_RemoteFunction:InvokeServer("Copy", inst)
 				if (inst) then -- Improvise
 					newClipboard[count] = inst
 					count = count + 1
 				end
-				
+
 				--[[local s,cloned = pcall(clone,inst)
 				if s and cloned then
 					newClipboard[count] = cloned
 					count = count + 1
 				end
 				pcall(destroy,inst)]]
-				
+
 				-- ADONIS
-				Dex_RemoteEvent:InvokeServer("Destroy", inst)
+				Dex_RemoteFunction:InvokeServer("Destroy", inst)
 			end
 			clipboard = newClipboard
 			selection:Clear()
 		end})
+		
+		local CallFunctionWindow = Lib.Window.new()
+		CallFunctionWindow:SetTitle("Call: Unknown")
+		CallFunctionWindow:Resize(300,130)
+		CallFunctionWindow.Resizable = false
+		CallFunctionWindow.GuiElems.Main.Position = UDim2.new(0.5, -300/2, 0.5, -130/2)
+
+		local content = CallFunctionWindow.GuiElems.Content
+		local layout = Instance.new("UIListLayout", content)
+		layout.SortOrder = Enum.SortOrder.LayoutOrder
+		layout.Padding = UDim.new(0, 6)
+		layout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+		layout.VerticalAlignment = Enum.VerticalAlignment.Top
+
+		local lbl = Instance.new("TextLabel")
+		lbl.Size = UDim2.new(1, -16, 0, 20)
+		lbl.BackgroundTransparency = 1
+		lbl.TextColor3 = Settings.Theme.TextPrimary or Color3.new(1,1,1)
+		lbl.Font = Enum.Font.SourceSansBold
+		lbl.TextSize = 14
+		lbl.TextXAlignment = Enum.TextXAlignment.Left
+		lbl.Text = "Arguments:"
+		lbl.LayoutOrder = 1
+		lbl.Parent = content
+
+		local tb = Instance.new("TextBox")
+		tb.Size = UDim2.new(1, -16, 0, 30)
+		tb.BackgroundColor3 = Settings.Theme.InputBackground or Color3.fromRGB(30,30,30)
+		tb.TextColor3 = Settings.Theme.TextPrimary or Color3.new(1,1,1)
+		tb.Font = Enum.Font.SourceSans
+		tb.PlaceholderText = [[e.g. "player1", 42, true]]
+		tb.Text = ""
+		tb.ClearTextOnFocus = false
+		tb.TextXAlignment = Enum.TextXAlignment.Left
+		tb.TextSize  = 14
+		tb.LayoutOrder = 2
+		tb.Parent = content
+
+		local uiCorner = Instance.new("UICorner", tb)
+		uiCorner.CornerRadius = UDim.new(0, 4)
+
+		local buttoncontainer = Instance.new("Frame")
+		buttoncontainer.Size = UDim2.new(1, -16, 0, 30)
+		buttoncontainer.BackgroundTransparency = 1
+		buttoncontainer.LayoutOrder = 3
+		buttoncontainer.Parent = content
+
+		local filler = Instance.new("Frame", buttoncontainer)
+		filler.Size = UDim2.new(1, -80, 1, 0)
+		filler.BackgroundTransparency = 1
+
+		local call = Instance.new("TextButton")
+		call.Size = UDim2.new(0,80,1,0)
+		call.Position = UDim2.new(1, -80, 0, 0)
+		call.BackgroundColor3 = Settings.Theme.ButtonPrimary or Color3.fromRGB(0, 120, 215)
+		call.TextColor3 = Settings.Theme.TextButton or Color3.new(1,1,1)
+		call.Font = Enum.Font.SourceSansBold
+		call.TextSize = 14
+		call.Text = "Call"
+		call.Parent = buttoncontainer
+		
+		local btnCorner = Instance.new("UICorner", call)
+		btnCorner.CornerRadius = UDim.new(0,4)
+
+		local function activate()
+			local obj =  CallFunctionWindow.currentObj
+			local text = tb.Text or ""
+			
+			local argv = {}
+			for token in string.gmatch(text, "[^,]+") do
+				local t = token:match("^%s*(.-)%s*$")
+				local n = tonumber(t)
+				if n then
+					argv[#argv+1] = n
+				elseif t:lower() == "true" then
+					argv[#argv+1] = true
+				elseif t:lower() == "false" then
+					argv[#argv+1] = false
+				else
+					local inner = t:match('^"(.-)"$') or t:match("^'(.-)'$")
+					argv[#argv+1] = inner or t
+				end
+			end
+
+			local ok,err = pcall(function()
+				if obj:IsA("RemoteFunction") then obj:InvokeServer(unpack(argv))
+				elseif obj:IsA("BindableFunction") then obj:Invoke(unpack(argv))
+				elseif obj:IsA("RemoteEvent") then obj:FireServer(unpack(argv))
+				elseif obj:IsA("BindableEvent") then obj:Fire(unpack(argv))
+				end
+			end)
+			if not ok then
+				
+				warn("Failed to call "..obj:GetFullName()..":",err)
+			end
+
+			CallFunctionWindow:Hide()
+		end
+
+		tb.FocusLost:Connect(function(enterPressed)
+			if enterPressed then
+				activate()
+			end
+		end)
+
+		call.MouseButton1Click:Connect(activate)
+		
+		local InstanceInfoWindow = Lib.Window.new()  
+		InstanceInfoWindow:SetTitle("Unknown")  
+		InstanceInfoWindow:Resize(280,120)
+		InstanceInfoWindow.Resizable = false  
+		InstanceInfoWindow.GuiElems.Main.Position = UDim2.new(0.5, -280/2, 0.5, -120/2)
+
+		local content = InstanceInfoWindow.GuiElems.Content
+
+		local layout = Instance.new("UIListLayout", content)  
+		layout.SortOrder = Enum.SortOrder.LayoutOrder  
+		layout.Padding = UDim.new(0, 4)  
+		layout.HorizontalAlignment = Enum.HorizontalAlignment.Center  
+		layout.VerticalAlignment   = Enum.VerticalAlignment.Top  
+
+		local description = Instance.new("TextLabel")  
+		description.Size = UDim2.new(1, -16, 0, 80)  
+		description.BackgroundTransparency = 1  
+		description.Font = Enum.Font.SourceSans  
+		description.TextSize = 14  
+		description.TextWrapped = true  
+		description.TextXAlignment = Enum.TextXAlignment.Left  
+		description.TextYAlignment = Enum.TextYAlignment.Top  
+		description.TextColor3 = Settings.Theme.TextSecondary or Color3.fromRGB(200,200,200)  
+		description.LayoutOrder = 2  
+		description.Parent = content  
 
 		context:Register("COPY",{Name = "Copy", IconMap = Explorer.MiscIcons, Icon = "Copy", DisabledIcon = "Copy_Disabled", Shortcut = "Ctrl+C", OnClick = function()
 			local clone = game.Clone
 			local sList,newClipboard = selection.List,{}
-			Dex_RemoteEvent:InvokeServer("ClearClipboard") -- ADONIS
-			
+			Dex_RemoteFunction:InvokeServer("ClearClipboard") -- ADONIS
+
 			local count = 1
 			for i = 1,#sList do
 				local inst = sList[i].Obj
 				local s,cloned = pcall(clone,inst)
-				
+
 				-- ADONIS
-				Dex_RemoteEvent:InvokeServer("Copy", inst)
-				
+				Dex_RemoteFunction:InvokeServer("Copy", inst)
+
 				if s and cloned then
 					newClipboard[count] = cloned
 					count = count + 1
@@ -2445,18 +6053,17 @@ local function main()
 				local node = sList[i]
 				local inst = node.Obj
 				Explorer.MakeNodeVisible(node,true)
-				
+
 				-- ADONIS
-				local pastedObjects = Dex_RemoteEvent:InvokeServer("Paste", inst)
-				
-				-- Select the pasted objects.
+				local pastedObjects = Dex_RemoteFunction:InvokeServer("Paste", inst)
+
 				for k,v in ipairs(pastedObjects) do
 					local cloned = v
-					
+
 					local clonedNode = nodes[cloned]
 					if clonedNode then newSelection[count] = clonedNode count = count + 1 end
 				end
-				
+
 				--[[for c = 1,#clipboard do
 					local cloned = clipboard[c]:Clone()
 					if cloned then
@@ -2483,15 +6090,15 @@ local function main()
 				local inst = node.Obj
 				local instPar = node.Parent and node.Parent.Obj
 				Explorer.MakeNodeVisible(node)
-				
+
 				-- ADONIS
-				local cloned = Dex_RemoteEvent:InvokeServer("Duplicate", inst, instPar)
-				
+				local cloned = Dex_RemoteFunction:InvokeServer("Duplicate", inst, instPar)
+
 				if (cloned) then
 					local clonedNode = nodes[cloned]
 					if clonedNode then newSelection[count] = clonedNode count = count + 1 end
 				end
-				
+
 				--[[local s,cloned = pcall(clone,inst)
 				if s and cloned then
 					cloned.Parent = instPar
@@ -2511,9 +6118,9 @@ local function main()
 			local sList = selection.List
 			for i = 1,#sList do
 				pcall(destroy,sList[i].Obj)
-				
+
 				-- ADONIS
-				Dex_RemoteEvent:InvokeServer("Destroy", sList[i].Obj)
+				Dex_RemoteFunction:InvokeServer("Destroy", sList[i].Obj)
 			end
 			selection:Clear()
 		end})
@@ -2530,11 +6137,11 @@ local function main()
 			if #sList == 0 then return end
 
 			--local model = Instance.new("Model",sList[#sList].Obj.Parent)
-			local model = Dex_RemoteEvent:InvokeServer("InstanceNew", "Model", sList[#sList].Obj.Parent) or Instance.new("Model",sList[#sList].Obj.Parent)
+			local model = Dex_RemoteFunction:InvokeServer("InstanceNew", "Model", sList[#sList].Obj.Parent) or Instance.new("Model",sList[#sList].Obj.Parent)
 			for i = 1,#sList do
 				pcall(function() sList[i].Obj.Parent = model end)
-				
-				Dex_RemoteEvent:InvokeServer("SetProperty", sList[i].Obj, "Parent", model)
+
+				Dex_RemoteFunction:InvokeServer("SetProperty", sList[i].Obj, "Parent", model)
 			end
 
 			if nodes[model] then
@@ -2563,8 +6170,8 @@ local function main()
 
 				for i = 1,#ch do
 					pcall(function() ch[i].Obj.Parent = par end)
-					
-					Dex_RemoteEvent:InvokeServer("SetProperty", ch[i].Obj, "Parent", par or workspace)
+
+					Dex_RemoteFunction:InvokeServer("SetProperty", ch[i].Obj, "Parent", par or workspace)
 				end
 
 				node.Obj:Destroy()
@@ -2734,9 +6341,24 @@ local function main()
 			Explorer.InsertObjectContext:Show(x,y)
 		end})
 
-		context:Register("CALL_FUNCTION",{Name = "Call Function", IconMap = Explorer.ClassIcons, Icon = 66, OnClick = function()
+		context:Register("CALL_FUNCTION",{
+			Name      = "Call Function",
+			IconMap   = Explorer.ClassIcons,
+			Icon      = 66,
+			OnClick   = function()
+				local node = selection.List[1]
+				if not node then return end
+				local obj = node.Obj
 
-		end})
+				if not (obj:IsA("RemoteFunction") or obj:IsA("RemoteEvent") or obj:IsA("BindableFunction") or obj:IsA("BindableEvent")) then
+					return
+				end
+
+				CallFunctionWindow.currentObj = obj
+				CallFunctionWindow:SetTitle("Call: " ..obj:GetFullName():sub(1,40))
+				CallFunctionWindow:Show()				
+			end
+		})
 
 		context:Register("GET_REFERENCES",{Name = "Get Lua References", IconMap = Explorer.ClassIcons, Icon = 34, OnClick = function()
 
@@ -2752,6 +6374,30 @@ local function main()
 
 		context:Register("VIEW_API",{Name = "View API Page", IconMap = Explorer.MiscIcons, Icon = "Reference", OnClick = function()
 
+		end})
+		
+		context:Register("VIEW_DESCRIPTION",{Name = "View Description", IconMap = Explorer.MiscIcons, Icon = 34, OnClick = function()
+			local node = selection.List[1]
+			if not node then return end
+			local obj = node.Obj
+			local className = obj.ClassName
+
+			local name = RMD.Classes[className].Name
+			local summary = RMD.Classes[className].summary
+			local additionalDocs = {
+				Model = "A Model is a container object, it groups objects together and it's best used to hold collections of BaseParts.",
+				BasePart = "BasePart is an abstract base class for in-world objects that render and are physically simulated while in the Workspace.",
+				Part = "The Part object is a type of BasePart. It comes in five different primitive shapes: Ball, Block, Cylinder, Wedge, and CornerWedge.",
+				MeshPart = "MeshPart is a form of BasePart that includes a physically simulated custom mesh. Unlike with other mesh classes, such as SpecialMesh and BlockMesh, they are not parented to a BasePart but rather behave as a BasePart in their own right.",
+				Workspace = "Workspace is a service that holds objects that exist in the 3D world, effectively BaseParts and Attachments. While such objects are descendant of Workspace, they will be active."
+			}
+			
+			InstanceInfoWindow:SetTitle(name .." \"".. obj.Name .."\"")
+			
+			-- as far as I checked, only a few classes have summary for some reason
+			description.Text = summary or additionalDocs[className] or "No description available for this class. The RMD may be missing some information."
+			
+			InstanceInfoWindow:Show()
 		end})
 
 		context:Register("VIEW_OBJECT",{Name = "View Object (Right click to reset)", IconMap = Explorer.ClassIcons, Icon = 5, OnClick = function()
@@ -2978,8 +6624,8 @@ local function main()
 				local obj = node.Obj
 				Explorer.MakeNodeVisible(node,true)
 				--pcall(instNew,className,obj)
-				
-				Dex_RemoteEvent:InvokeServer("InstanceNew", className, obj)
+
+				Dex_RemoteFunction:InvokeServer("InstanceNew", className, obj)
 			end
 		end
 
@@ -2999,15 +6645,15 @@ local function main()
 
 		Explorer.InsertObjectContext = context
 	end
-	
+
 	--[[
 	]]
 	Explorer.InitClickToSelect = function()
 		local connection = Explorer.ClickToSelect_Connection
-		
+
 		-- If Setting is ON
 		if (Settings.Explorer.ClickToSelect == true) then
-			
+
 			if not (connection) then
 				local mouse: Mouse = Main.Mouse or service.Players.LocalPlayer:GetMouse()
 				connection = mouse.Button1Down:Connect(function()
@@ -3015,7 +6661,7 @@ local function main()
 
 					-- Create a ray from the 2D mouse location
 					local screenToWorldRay = workspace.CurrentCamera:ViewportPointToRay(mouseLocation.X, mouseLocation.Y)
-					
+
 					local DISTANCE_LIMIT = 900000
 					local dirVector = screenToWorldRay.Direction * (DISTANCE_LIMIT)
 
@@ -3023,15 +6669,15 @@ local function main()
 
 					if (raycastResult) then
 						local node = nodes[raycastResult.Instance]
-						
+
 						if (node) then
 							selection:Set(node)
-							
+
 							Explorer.ViewObj(node.Obj) -- Show in Explorer
 						end
 					end
 				end)
-				
+
 				-- Set connection into the table
 				Explorer.ClickToSelect_Connection = connection
 			end
@@ -3040,12 +6686,12 @@ local function main()
 			if (connection) then
 				-- Disconnect
 				connection:Disconnect()
-				
+
 				Explorer.ClickToSelect_Connection = nil
 			end
 		end
 	end
-	
+
 	--[[
 		Headers, Setups, Predicate, ObjectDefs
 	]]
@@ -3287,52 +6933,7 @@ local function main()
 		for header,_ in next,headers do finalHeaders = finalHeaders..header.."\n" end
 		for oDef,_ in next,objectDefs do finalObjectDefs = finalObjectDefs..oDef.."\n" end
 
-		local template = [==[
-local searchResults = searchResults
-local nodes = nodes
-local expandTable = Explorer.SearchExpanded
-local specResults = specResults
-local service = service
-
-%s
-local function search(root)	
-%s
-	
-	local expandedpar = false
-	for i = 1,#root do
-		local node = root[i]
-		local obj = node.Obj
-		
-%s
-		
-		if %s then
-			expandTable[node] = 0
-			searchResults[node] = true
-			if not expandedpar then
-				local parnode = node.Parent
-				while parnode and (not searchResults[parnode] or expandTable[parnode] == 0) do
-					expandTable[parnode] = true
-					searchResults[parnode] = true
-					parnode = parnode.Parent
-				end
-				expandedpar = true
-			end
-		end
-		
-		if #node > 0 then search(node) end
-	end
-end
-return search]==]
-
-		local funcStr = template:format(finalHeaders,finalSetups,finalObjectDefs,finalPredicate)
-		local s,func = pcall(loadstring,funcStr)
-		if not s or not func then return nil,specFilterList end
-
-		local env = setmetatable({["searchResults"] = searchResults, ["nodes"] = nodes, ["Explorer"] = Explorer, ["specResults"] = specResults,
-			["service"] = service},{__index = getfenv()})
-		setfenv(func,env)
-
-		return func(),specFilterList
+		return nil,specFilterList
 	end
 
 	Explorer.DoSearch = function(query)
@@ -3670,9 +7271,9 @@ return search]==]
 
 		Explorer.InitRightClick()
 		Explorer.InitInsertObject()
-		
+
 		Explorer.InitClickToSelect()
-		
+
 		Explorer.SetSortingEnabled(Settings.Explorer.Sorting)
 		Explorer.Expanded = setmetatable({},{__mode = "k"})
 		Explorer.SearchExpanded = setmetatable({},{__mode = "k"})
@@ -3805,17 +7406,12 @@ return search]==]
 	return Explorer
 end
 
--- TODO: Remove when open source
-if gethsfuncs then
-	_G.moduleData = {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-else
-	return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-end]]></ProtectedString>
+return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}]]></ProtectedString>
 							<int64 name="SourceAssetId">-1</int64>
 							<BinaryString name="Tags"></BinaryString>
 						</Properties>
 					</Item>
-					<Item class="ModuleScript" referent="RBXF961AD6B4A9E4C76B7D2E2B7E8A8513F">
+					<Item class="ModuleScript" referent="RBX2a04fdc5ba6d46a0aa2e58c6594bc614">
 						<Properties>
 							<BinaryString name="AttributesSerialize"></BinaryString>
 							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
@@ -3858,7 +7454,10 @@ end
 
 local function main()
 	local Lib = {}
-	
+
+	-- silencer
+	Lib.ViewportTextBox = nil
+
 	--Lib.StoredWindows = {}
 	--Lib.SidesGui = nil
 
@@ -4003,11 +7602,28 @@ local function main()
 			local D = string.byte('D', 1)
 			local E = string.byte('E', 1)
 
-			function parse(s, evalEntities)
+			local function defaultEntityTable()
+				return { quot='"', apos='\'', lt='<', gt='>', amp='&', tab='\t', nbsp=' ', }
+			end
+
+			local function replaceEntities(s, entities)
+				return s:gsub('&([^;]+);', entities)
+			end
+
+			local function createEntityTable(docEntities, resultEntities)
+				local entities = resultEntities or defaultEntityTable()
+				for _,e in pairs(docEntities) do
+					e.value = replaceEntities(e.value, entities)
+					entities[e.name] = e.value
+				end
+				return entities
+			end
+
+			local function parse(s, evalEntities)
 				-- remove comments
 				s = s:gsub('<!%-%-(.-)%-%->', '')
 
-				local entities, tentities = {}
+				local entities, tentities = {}, nil
 
 				if evalEntities then
 					local pos = s:find('<[_%w]')
@@ -4078,25 +7694,8 @@ local function main()
 				return {children=t, entities=entities, tentities=tentities}
 			end
 
-			function parseText(txt)
+			local function parseText(txt)
 				return parse(txt)
-			end
-
-			function defaultEntityTable()
-				return { quot='"', apos='\'', lt='<', gt='>', amp='&', tab='\t', nbsp=' ', }
-			end
-
-			function replaceEntities(s, entities)
-				return s:gsub('&([^;]+);', entities)
-			end
-
-			function createEntityTable(docEntities, resultEntities)
-				entities = resultEntities or defaultEntityTable()
-				for _,e in pairs(docEntities) do
-					e.value = replaceEntities(e.value, entities)
-					entities[e.name] = e.value
-				end
-				return entities
 			end
 
 			return parseText
@@ -4267,7 +7866,7 @@ local function main()
 		signalWait(renderStepped)
 		return f(...)
 	end
-	
+
 	Lib.LoadCustomAsset = function(filepath)
 		if not env.getcustomasset or not env.isfile or not env.isfile(filepath) then return end
 
@@ -4610,7 +8209,7 @@ local function main()
 			--local thumbSelectColor = Color3.new(140/255,140/255,140/255)
 			button1.InputBegan:Connect(function(input)
 				if input.UserInputType == Enum.UserInputType.MouseMovement and not buttonPress and self:CanScrollUp() then button1.BackgroundTransparency = 0.8 end
-				if input.UserInputType ~= Enum.UserInputType.MouseButton1 or not self:CanScrollUp() then return end
+				if input.UserInputType ~= Enum.UserInputType.MouseButton1 and input.UserInputType ~= Enum.UserInputType.Touch or not self:CanScrollUp() then return end
 				buttonPress = true
 				button1.BackgroundTransparency = 0.5
 				if self:CanScrollUp() then self:ScrollUp() self.Scrolled:Fire() end
@@ -4635,7 +8234,7 @@ local function main()
 			end)
 			button2.InputBegan:Connect(function(input)
 				if input.UserInputType == Enum.UserInputType.MouseMovement and not buttonPress and self:CanScrollDown() then button2.BackgroundTransparency = 0.8 end
-				if input.UserInputType ~= Enum.UserInputType.MouseButton1 or not self:CanScrollDown() then return end
+				if input.UserInputType ~= Enum.UserInputType.MouseButton1 and input.UserInputType ~= Enum.UserInputType.Touch or not self:CanScrollDown() then return end
 				buttonPress = true
 				button2.BackgroundTransparency = 0.5
 				if self:CanScrollDown() then self:ScrollDown() self.Scrolled:Fire() end
@@ -4660,8 +8259,14 @@ local function main()
 			end)
 
 			scrollThumb.InputBegan:Connect(function(input)
-				if input.UserInputType == Enum.UserInputType.MouseMovement and not thumbPress then scrollThumb.BackgroundTransparency = 0.2 scrollThumb.BackgroundColor3 = self.ThumbSelectColor end
-				if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+				if input.UserInputType == Enum.UserInputType.MouseMovement and not thumbPress then
+					scrollThumb.BackgroundTransparency = 0.2
+					scrollThumb.BackgroundColor3 = self.ThumbSelectColor
+				end
+				if input.UserInputType ~= Enum.UserInputType.MouseButton1
+					and input.UserInputType ~= Enum.UserInputType.Touch then
+					return
+				end
 
 				local dir = self.Horizontal and "X" or "Y"
 				local lastThumbPos = nil
@@ -4704,7 +8309,7 @@ local function main()
 				if input.UserInputType == Enum.UserInputType.MouseMovement and not thumbPress then scrollThumb.BackgroundTransparency = 0 scrollThumb.BackgroundColor3 = self.ThumbColor end
 			end)
 			scrollThumbFrame.InputBegan:Connect(function(input)
-				if input.UserInputType ~= Enum.UserInputType.MouseButton1 or checkMouseInGui(scrollThumb) then return end
+				if (input.UserInputType ~= Enum.UserInputType.MouseButton1 and input.UserInputType ~= Enum.UserInputType.Touch) or checkMouseInGui(scrollThumb) then return end
 
 				local dir = self.Horizontal and "X" or "Y"
 				local scrollDir = 0
@@ -4899,12 +8504,12 @@ local function main()
 
 	Lib.Window = (function()
 		local funcs = {}
-		local static = {MinWidth = 200, FreeWidth = 200}
+		local static = {MinWidth = 200, FreeWidth = 200, ShowWindow = nil,  SetSideVisible = nil}
 		local mouse = plr:GetMouse()
 		local sidesGui,alignIndicator
 		local visibleWindows = {}
-		local leftSide = {Width = 300, Windows = {}, ResizeCons = {}, Hidden = true}
-		local rightSide = {Width = 300, Windows = {}, ResizeCons = {}, Hidden = true}
+		local leftSide = {Width = 300, Windows = {}, ResizeCons = {}, Hidden = true, Resizing = false}
+		local rightSide = {Width = 300, Windows = {}, ResizeCons = {}, Hidden = true, Resizing = false}
 
 		local displayOrderStart
 		local sideDisplayOrder
@@ -5091,7 +8696,7 @@ local function main()
 
 					local alignInsertPos,alignInsertSide
 
-					guiDragging = true
+					local guiDragging = true
 
 					releaseEvent = game:GetService("UserInputService").InputEnded:Connect(function(input)
 						if input.UserInputType == Enum.UserInputType.MouseButton1 then
@@ -5840,7 +9445,7 @@ local function main()
 			Lib.ShowGui(sidesGui)
 			updateSideFrames()
 		end
-		
+
 		local mt = {__index = funcs}
 		static.new = function()
 			local obj = setmetatable({
@@ -5868,10 +9473,10 @@ local function main()
 				OnRestore = Lib.Signal.new()
 			},mt)
 			obj.Gui = createGui(obj)
-			
+
 			-- Add to stored windows
 			--Lib.StoredWindows[obj] = obj
-			
+
 			return obj
 		end
 
@@ -5967,7 +9572,7 @@ local function main()
 				OnRightClick = item.OnRightClick
 			}
 			if self.QueuedDivider then
-				local text = self.QueuedDividerText and #self.QueuedDividerText > 0 and self.QueuedDividerText
+				local text = self.QueuedDividerText and #self.QueuedDividerText > 0
 				self:AddDivider(text)
 			end
 			self.Items[#self.Items+1] = newItem
@@ -5976,9 +9581,9 @@ local function main()
 
 		funcs.AddRegistered = function(self,name,disabled)
 			if not self.Registered[name] then error(name.." is not registered") end
-			
+
 			if self.QueuedDivider then
-				local text = self.QueuedDividerText and #self.QueuedDividerText > 0 and self.QueuedDividerText
+				local text = self.QueuedDividerText and #self.QueuedDividerText > 0
 				self:AddDivider(text)
 			end
 			self.Registered[name].Disabled = disabled
@@ -6009,7 +9614,7 @@ local function main()
 			table.insert(self.Items,{Divider = true, Text = text, TextSize = textWidth and textWidth+4})
 			self.Updated = nil
 		end
-		
+
 		funcs.QueueDivider = function(self,text)
 			self.QueuedDivider = true
 			self.QueuedDividerText = text or ""
@@ -6369,19 +9974,19 @@ local function main()
 			[">"] = "&gt;",
 			["&"] = "&amp;"
 		}
-		
+
 		local tabSub = "\205"
 		local tabReplacement = (" %s%s "):format(tabSub,tabSub)
-		
+
 		local tabJumps = {
 			[("[^%s] %s"):format(tabSub,tabSub)] = 0,
 			[(" %s%s"):format(tabSub,tabSub)] = -1,
 			[("%s%s "):format(tabSub,tabSub)] = 2,
 			[("%s [^%s]"):format(tabSub,tabSub)] = 1,
 		}
-		
+
 		local tweenService = service.TweenService
-		local lineTweens = {}
+		local lineTweens = { Invis = nil, Vis = nil }
 
 		local function initBuiltIn()
 			local env = getfenv()
@@ -6407,20 +10012,20 @@ local function main()
 
 			builtInInited = true
 		end
-		
+
 		local function setupEditBox(obj)
 			local editBox = obj.GuiElems.EditBox
-			
+
 			editBox.Focused:Connect(function()
 				obj:ConnectEditBoxEvent()
 				obj.Editing = true
 			end)
-			
+
 			editBox.FocusLost:Connect(function()
 				obj:DisconnectEditBoxEvent()
 				obj.Editing = false
 			end)
-			
+
 			editBox:GetPropertyChangedSignal("Text"):Connect(function()
 				local text = editBox.Text
 				if #text == 0 or obj.EditBoxCopying then return end
@@ -6428,16 +10033,16 @@ local function main()
 				obj:AppendText(text)
 			end)
 		end
-		
+
 		local function setupMouseSelection(obj)
 			local mouse = plr:GetMouse()
 			local codeFrame = obj.GuiElems.LinesFrame
 			local lines = obj.Lines
-			
+
 			codeFrame.InputBegan:Connect(function(input)
 				if input.UserInputType == Enum.UserInputType.MouseButton1 then
 					local fontSizeX,fontSizeY = math.ceil(obj.FontSize/2),obj.FontSize
-					
+
 					local relX = mouse.X - codeFrame.AbsolutePosition.X
 					local relY = mouse.Y - codeFrame.AbsolutePosition.Y
 					local selX = math.round(relX / fontSizeX) + obj.ViewX
@@ -6522,14 +10127,14 @@ local function main()
 				{1,"Frame",{BackgroundColor3=Color3.new(0.15686275064945,0.15686275064945,0.15686275064945),BorderSizePixel = 0,Position=UDim2.new(0.5,-300,0.5,-200),Size=UDim2.new(0,600,0,400),}},
 			})
 			local elems = {}
-			
+
 			local linesFrame = Instance.new("Frame")
 			linesFrame.Name = "Lines"
 			linesFrame.BackgroundTransparency = 1
 			linesFrame.Size = UDim2.new(1,0,1,0)
 			linesFrame.ClipsDescendants = true
 			linesFrame.Parent = frame
-			
+
 			local lineNumbersLabel = Instance.new("TextLabel")
 			lineNumbersLabel.Name = "LineNumbers"
 			lineNumbersLabel.BackgroundTransparency = 1
@@ -6539,47 +10144,47 @@ local function main()
 			lineNumbersLabel.ClipsDescendants = true
 			lineNumbersLabel.RichText = true
 			lineNumbersLabel.Parent = frame
-			
+
 			local cursor = Instance.new("Frame")
 			cursor.Name = "Cursor"
 			cursor.BackgroundColor3 = Color3.fromRGB(220,220,220)
 			cursor.BorderSizePixel = 0
 			cursor.Parent = frame
-			
+
 			local editBox = Instance.new("TextBox")
 			editBox.Name = "EditBox"
 			editBox.MultiLine = true
 			editBox.Visible = false
 			editBox.Parent = frame
-			
+
 			lineTweens.Invis = tweenService:Create(cursor,TweenInfo.new(0.4,Enum.EasingStyle.Quart,Enum.EasingDirection.Out),{BackgroundTransparency = 1})
 			lineTweens.Vis = tweenService:Create(cursor,TweenInfo.new(0.2,Enum.EasingStyle.Quart,Enum.EasingDirection.Out),{BackgroundTransparency = 0})
-			
+
 			elems.LinesFrame = linesFrame
 			elems.LineNumbersLabel = lineNumbersLabel
 			elems.Cursor = cursor
 			elems.EditBox = editBox
 			elems.ScrollCorner = create({{1,"Frame",{BackgroundColor3=Color3.new(0.15686275064945,0.15686275064945,0.15686275064945),BorderSizePixel=0,Name="ScrollCorner",Position=UDim2.new(1,-16,1,-16),Size=UDim2.new(0,16,0,16),Visible=false,}}})
-			
+
 			elems.ScrollCorner.Parent = frame
 			linesFrame.InputBegan:Connect(function(input)
 				if input.UserInputType == Enum.UserInputType.MouseButton1 then
 					obj:SetEditing(true,input)
 				end
 			end)
-			
+
 			obj.Frame = frame
 			obj.Gui = frame
 			obj.GuiElems = elems
 			setupEditBox(obj)
 			setupMouseSelection(obj)
-			
+
 			return frame
 		end
-		
+
 		funcs.GetSelectionText = function(self)
 			if not self:IsValidRange() then return "" end
-			
+
 			local selectionRange = self.SelectionRange
 			local selX,selY = selectionRange[1][1], selectionRange[1][2]
 			local sel2X,sel2Y = selectionRange[2][1], selectionRange[2][2]
@@ -6603,29 +10208,29 @@ local function main()
 
 			return self:ConvertText(result,false)
 		end
-		
+
 		funcs.SetCopyableSelection = function(self)
 			local text = self:GetSelectionText()
 			local editBox = self.GuiElems.EditBox
-			
+
 			self.EditBoxCopying = true
 			editBox.Text = text
 			editBox.SelectionStart = 1
 			editBox.CursorPosition = #editBox.Text + 1
 			self.EditBoxCopying = false
 		end
-		
+
 		funcs.ConnectEditBoxEvent = function(self)
 			if self.EditBoxEvent then
 				self.EditBoxEvent:Disconnect()
 			end
-			
+
 			self.EditBoxEvent = service.UserInputService.InputBegan:Connect(function(input)
 				if input.UserInputType ~= Enum.UserInputType.Keyboard then return end
-				
+
 				local keycodes = Enum.KeyCode
 				local keycode = input.KeyCode
-				
+
 				local function setupMove(key,func)
 					local endCon,finished
 					endCon = service.UserInputService.InputEnded:Connect(function(input)
@@ -6637,7 +10242,7 @@ local function main()
 					Lib.FastWait(0.5)
 					while not finished do func() Lib.FastWait(0.03) end
 				end
-				
+
 				if keycode == keycodes.Down then
 					setupMove(keycodes.Down,function()
 						self.CursorX = self.FloatCursorX
@@ -6686,7 +10291,7 @@ local function main()
 						else
 							endRange = {self.CursorX,self.CursorY}
 						end
-						
+
 						if not startRange then
 							local line = self.Lines[self.CursorY+1] or ""
 							self.CursorX = self.CursorX - 1 - (line:sub(self.CursorX-3,self.CursorX) == tabReplacement and 3 or 0)
@@ -6697,10 +10302,10 @@ local function main()
 							end
 							self.FloatCursorX = self.CursorX
 							self:UpdateCursor()
-						
+
 							startRange = startRange or {self.CursorX,self.CursorY}
 						end
-						
+
 						self:DeleteRange({startRange,endRange},false,true)
 						self:ResetSelection(true)
 						self:JumpToCursor()
@@ -6741,18 +10346,18 @@ local function main()
 				end
 			end)
 		end
-		
+
 		funcs.DisconnectEditBoxEvent = function(self)
 			if self.EditBoxEvent then
 				self.EditBoxEvent:Disconnect()
 			end
 		end
-		
+
 		funcs.ResetSelection = function(self,norefresh)
 			self.SelectionRange = {{-1,-1},{-1,-1}}
 			if not norefresh then self:Refresh() end
 		end
-		
+
 		funcs.IsValidRange = function(self,range)
 			local selectionRange = range or self.SelectionRange
 			local selX,selY = selectionRange[1][1], selectionRange[1][2]
@@ -6762,82 +10367,82 @@ local function main()
 
 			return true
 		end
-		
+
 		funcs.DeleteRange = function(self,range,noprocess,updatemouse)
 			range = range or self.SelectionRange
 			if not self:IsValidRange(range) then return end
-			
+
 			local lines = self.Lines
 			local selX,selY = range[1][1], range[1][2]
 			local sel2X,sel2Y = range[2][1], range[2][2]
 			local deltaLines = sel2Y-selY
-			
+
 			if not lines[selY+1] or not lines[sel2Y+1] then return end
-			
+
 			local leftSub = lines[selY+1]:sub(1,selX)
 			local rightSub = lines[sel2Y+1]:sub(sel2X+1)
 			lines[selY+1] = leftSub..rightSub
-			
+
 			local remove = table.remove
 			for i = 1,deltaLines do
 				remove(lines,selY+2)
 			end
-			
+
 			if range == self.SelectionRange then self.SelectionRange = {{-1,-1},{-1,-1}} end
 			if updatemouse then
 				self.CursorX = selX
 				self.CursorY = selY
 				self:UpdateCursor()
 			end
-			
+
 			if not noprocess then
 				self:ProcessTextChange()
 			end
 		end
-		
+
 		funcs.AppendText = function(self,text)
 			self:DeleteRange(nil,true,true)
 			local lines,cursorX,cursorY = self.Lines,self.CursorX,self.CursorY
 			local line = lines[cursorY+1]
 			local before = line:sub(1,cursorX)
 			local after = line:sub(cursorX+1)
-			
+
 			text = text:gsub("\r\n","\n")
 			text = self:ConvertText(text,true) -- Tab Convert
-			
+
 			local textLines = text:split("\n")
 			local insert = table.insert
-			
+
 			for i = 1,#textLines do
 				local linePos = cursorY+i
 				if i > 1 then insert(lines,linePos,"") end
-				
+
 				local textLine = textLines[i]
 				local newBefore = (i == 1 and before or "")
 				local newAfter = (i == #textLines and after or "")
-			
+
 				lines[linePos] = newBefore..textLine..newAfter
 			end
-			
+
 			if #textLines > 1 then cursorX = 0 end
-			
+
 			self:ProcessTextChange()
 			self.CursorX = cursorX + #textLines[#textLines]
 			self.CursorY = cursorY + #textLines-1
 			self:UpdateCursor()
 		end
-		
+
 		funcs.ScrollDelta = function(self,x,y)
 			self.ScrollV:ScrollTo(self.ScrollV.Index + y)
 			self.ScrollH:ScrollTo(self.ScrollH.Index + x)
 		end
-		
+
 		-- x and y starts at 0
 		funcs.TabAdjust = function(self,x,y)
 			local lines = self.Lines
 			local line = lines[y+1]
 			x=x+1
-			
+
 			if line then
 				local left = line:sub(x-1,x-1)
 				local middle = line:sub(x,x)
@@ -6852,10 +10457,10 @@ local function main()
 			end
 			return 0
 		end
-		
+
 		funcs.SetEditing = function(self,on,input)			
 			self:UpdateCursor(input)
-			
+
 			if on then
 				if self.Editable then
 					self.GuiElems.EditBox.Text = ""
@@ -6865,18 +10470,18 @@ local function main()
 				self.GuiElems.EditBox:ReleaseFocus()
 			end
 		end
-		
+
 		funcs.CursorAnim = function(self,on)
 			local cursor = self.GuiElems.Cursor
 			local animTime = tick()
 			self.LastAnimTime = animTime
-			
+
 			if not on then return end
-			
+
 			lineTweens.Invis:Cancel()
 			lineTweens.Vis:Cancel()
 			cursor.BackgroundTransparency = 0
-			
+
 			task.spawn(function()
 				while self.Editable do
 					Lib.FastWait(0.5)
@@ -6889,18 +10494,18 @@ local function main()
 				end
 			end)
 		end
-		
+
 		funcs.MoveCursor = function(self,x,y)
 			self.CursorX = x
 			self.CursorY = y
 			self:UpdateCursor()
 			self:JumpToCursor()
 		end
-		
+
 		funcs.JumpToCursor = function(self)
 			self:Refresh()
 		end
-		
+
 		funcs.UpdateCursor = function(self,input)
 			local linesFrame = self.GuiElems.LinesFrame
 			local cursor = self.GuiElems.Cursor			
@@ -6912,7 +10517,7 @@ local function main()
 			local totalLinesStr = tostring(#self.Lines)
 			local fontWidth = math.ceil(self.FontSize / 2)
 			local linesOffset = #totalLinesStr*fontWidth + 4*fontWidth
-			
+
 			if input then
 				local linesFrame = self.GuiElems.LinesFrame
 				local frameX,frameY = linesFrame.AbsolutePosition.X,linesFrame.AbsolutePosition.Y
@@ -6922,25 +10527,25 @@ local function main()
 				self.CursorX = self.ViewX + math.round((mouseX - frameX) / fontSizeX)
 				self.CursorY = self.ViewY + math.floor((mouseY - frameY) / fontSizeY)
 			end
-			
+
 			local cursorX,cursorY = self.CursorX,self.CursorY
-			
+
 			local line = self.Lines[cursorY+1] or ""
 			if cursorX > #line then cursorX = #line
 			elseif cursorX < 0 then cursorX = 0 end
-			
+
 			if cursorY >= #self.Lines then
 				cursorY = math.max(0,#self.Lines-1)
 			elseif cursorY < 0 then
 				cursorY = 0
 			end
-			
+
 			cursorX = cursorX + self:TabAdjust(cursorX,cursorY)
-			
+
 			-- Update modified
 			self.CursorX = cursorX
 			self.CursorY = cursorY
-			
+
 			local cursorVisible = (cursorX >= viewX) and (cursorY >= viewY) and (cursorX <= viewX + maxCols) and (cursorY <= viewY + maxLines)
 			if cursorVisible then
 				local offX = (cursorX - viewX)
@@ -7229,13 +10834,13 @@ local function main()
 					lineFrame.Size = UDim2.new(1,0,0,self.FontSize)
 					lineFrame.BorderSizePixel = 0
 					lineFrame.BackgroundTransparency = 1
-					
+
 					local selectionHighlight = Instance.new("Frame")
 					selectionHighlight.Name = "SelectionHighlight"
 					selectionHighlight.BorderSizePixel = 0
 					selectionHighlight.BackgroundColor3 = Settings.Theme.Syntax.SelectionBack
 					selectionHighlight.Parent = lineFrame
-					
+
 					local label = Instance.new("TextLabel")
 					label.Name = "Label"
 					label.BackgroundTransparency = 1
@@ -7247,7 +10852,7 @@ local function main()
 					label.TextColor3 = self.Colors.Text
 					label.ZIndex = 2
 					label.Parent = lineFrame
-					
+
 					lineFrame.Parent = linesFrame
 					self.LineFrames[row] = lineFrame
 				end
@@ -7263,7 +10868,7 @@ local function main()
 				local selectionTemplate = richTemplates.Selection
 				local curType = highlights[colStart]
 				local curTemplate = richTemplates[typeMap[curType]] or textTemplate
-				
+
 				-- Selection Highlight
 				local selectionRange = self.SelectionRange
 				local selPos1 = selectionRange[1]
@@ -7271,7 +10876,7 @@ local function main()
 				local selRow,selColumn = selPos1[2],selPos1[1]
 				local sel2Row,sel2Column = selPos2[2],selPos2[1]
 				local selRelaX,selRelaY = viewX,relaY-1
-				
+
 				if selRelaY >= selPos1[2] and selRelaY <= selPos2[2] then
 					local fontSizeX = math.ceil(self.FontSize/2)
 					local posX = (selRelaY == selPos1[2] and selPos1[1] or 0) - viewX
@@ -7283,28 +10888,28 @@ local function main()
 				else
 					lineFrame.SelectionHighlight.Visible = false
 				end
-				
+
 				-- Selection Text Color for first char
 				local inSelection = selRelaY >= selRow and selRelaY <= sel2Row and (selRelaY == selRow and viewX >= selColumn or selRelaY ~= selRow) and (selRelaY == sel2Row and viewX < sel2Column or selRelaY ~= sel2Row)
 				if inSelection then
 					curType = -999
 					curTemplate = selectionTemplate
 				end
-				
+
 				for col = 2,maxCols do
 					local relaX = viewX + col
 					local selRelaX = relaX-1
 					local posType = highlights[relaX]
-					
+
 					-- Selection Text Color
 					local inSelection = selRelaY >= selRow and selRelaY <= sel2Row and (selRelaY == selRow and selRelaX >= selColumn or selRelaY ~= selRow) and (selRelaY == sel2Row and selRelaX < sel2Column or selRelaY ~= sel2Row)
 					if inSelection then
 						posType = -999
 					end
-					
+
 					if posType ~= curType then
 						local template = (inSelection and selectionTemplate) or richTemplates[typeMap[posType]] or textTemplate
-						
+
 						if template ~= curTemplate then
 							local nextText = gsub(sub(lineText,colStart,relaX-1),"['\"<>&]",richReplace)
 							resText = resText .. (curTemplate ~= textTemplate and (curTemplate .. nextText .. "</font>") or nextText)
@@ -7391,14 +10996,14 @@ local function main()
 		funcs.ProcessTextChange = function(self)
 			local maxCols = 0
 			local lines = self.Lines
-			
+
 			for i = 1,#lines do
 				local lineLen = #lines[i]
 				if lineLen > maxCols then
 					maxCols = lineLen
 				end
 			end
-			
+
 			self.MaxTextCols = maxCols
 			self:UpdateView()	
 			self.Text = table.concat(self.Lines,"\n")
@@ -7407,7 +11012,7 @@ local function main()
 			self:Refresh()
 			--self.TextChanged:Fire()
 		end
-		
+
 		funcs.ConvertText = function(self,text,toEditor)
 			if toEditor then
 				return text:gsub("\t",(" %s%s "):format(tabSub,tabSub))
@@ -7432,7 +11037,7 @@ local function main()
 				lines[count] = line
 				count = count + 1
 			end
-			
+
 			self:ProcessTextChange()
 		end
 
@@ -8287,7 +11892,7 @@ local function main()
 				if num then
 					red = math.clamp(math.floor(num),0,255)/255
 					local newColor = Color3.new(red,green,blue)
-					hue,sat,val = Color3.toHSV(newColor)
+					hue,sat,val = newColor:ToHSV()
 					redInput.Text = tostring(red*255)
 					updateColor(2)
 				end
@@ -8299,7 +11904,7 @@ local function main()
 				if num then
 					green = math.clamp(math.floor(num),0,255)/255
 					local newColor = Color3.new(red,green,blue)
-					hue,sat,val = Color3.toHSV(newColor)
+					hue,sat,val = newColor:ToHSV()
 					greenInput.Text = tostring(green*255)
 					updateColor(2)
 				end
@@ -8311,7 +11916,7 @@ local function main()
 				if num then
 					blue = math.clamp(math.floor(num),0,255)/255
 					local newColor = Color3.new(red,green,blue)
-					hue,sat,val = Color3.toHSV(newColor)
+					hue,sat,val = newColor:ToHSV()
 					blueInput.Text = tostring(blue*255)
 					updateColor(2)
 				end
@@ -8335,7 +11940,7 @@ local function main()
 				newColor.MouseButton1Click:Connect(function()
 					red,green,blue = v.r,v.g,v.b
 					local newColor = Color3.new(red,green,blue)
-					hue,sat,val = Color3.toHSV(newColor)
+					hue,sat,val = newColor:toHSV()
 					updateColor()
 				end)	
 
@@ -8353,9 +11958,9 @@ local function main()
 				newColor.Position = UDim2.new(0,1 + 30*column,0,20 + 23*row)
 
 				newColor.MouseButton1Click:Connect(function()
-					local curColor = customColors[i] or Color3.new(0,0,0)
+					local curColor = (customColors[i] or Color3.new(0,0,0)) :: Color3
 					red,green,blue = curColor.r,curColor.g,curColor.b
-					hue,sat,val = Color3.toHSV(curColor)
+					hue,sat,val = curColor:ToHSV()
 					updateColor()
 				end)
 
@@ -8379,9 +11984,9 @@ local function main()
 
 			updateColor()
 
-			newMt.SetColor = function(self,color)
-				red,green,blue = color.r,color.g,color.b
-				hue,sat,val = Color3.toHSV(color)
+			newMt.SetColor = function(self,color: Color3)
+				red,green,blue = color.R,color.G,color.B
+				hue,sat,val = color:ToHSV()
 				updateColor()
 			end
 
@@ -9588,3511 +13193,13 @@ local function main()
 	return Lib
 end
 
--- TODO: Remove when open source
-if gethsfuncs then
-	_G.moduleData = {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-else
-	return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-end]]></ProtectedString>
-							<int64 name="SourceAssetId">-1</int64>
-							<BinaryString name="Tags"></BinaryString>
-						</Properties>
-					</Item>
-					<Item class="ModuleScript" referent="RBX708F497BF00740BB99254243FCE36140">
-						<Properties>
-							<BinaryString name="AttributesSerialize"></BinaryString>
-							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-							<bool name="DefinesCapabilities">false</bool>
-							<Content name="LinkedSource"><null></null></Content>
-							<string name="Name">Properties</string>
-							<string name="ScriptGuid">{7400135A-4B43-49CC-89BE-B0C5AF1AA6E0}</string>
-							<ProtectedString name="Source"><![CDATA[--[[
-	Properties App Module
-	
-	The main properties interface
-]]
-
--- ADONIS
-local ReplicatedStorage = game:GetService("ReplicatedStorage");
-local Dex_RemoteEvent = ReplicatedStorage:WaitForChild("NewDex_Event");
-
-
--- Common Locals
-local Main,Lib,Apps,Settings -- Main Containers
-local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
-local API,RMD,env,service,plr,create,createSimple -- Main Locals
-
-local function initDeps(data)
-	Main = data.Main
-	Lib = data.Lib
-	Apps = data.Apps
-	Settings = data.Settings
-
-	API = data.API
-	RMD = data.RMD
-	env = data.env
-	service = data.service
-	plr = data.plr
-	create = data.create
-	createSimple = data.createSimple
-end
-
-local function initAfterMain()
-	Explorer = Apps.Explorer
-	Properties = Apps.Properties
-	ScriptViewer = Apps.ScriptViewer
-	Notebook = Apps.Notebook
-end
-
-local function main()
-	local Properties = {}
-
-	local window, toolBar, propsFrame
-	local scrollV, scrollH
-	local categoryOrder
-	local props,viewList,expanded,indexableProps,propEntries,autoUpdateObjs = {},{},{},{},{},{}
-	local inputBox,inputTextBox,inputProp
-	local checkboxes,propCons = {},{}
-	local table,string = table,string
-	local getPropChangedSignal = game.GetPropertyChangedSignal
-	local getAttributeChangedSignal = game.GetAttributeChangedSignal
-	local isa = game.IsA
-	local getAttribute = game.GetAttribute
-	local setAttribute = game.SetAttribute
-
-	Properties.GuiElems = {}
-	Properties.Index = 0
-	Properties.ViewWidth = 0
-	Properties.MinInputWidth = 100
-	Properties.EntryIndent = 16
-	Properties.EntryOffset = 4
-	Properties.NameWidthCache = {}
-	Properties.SubPropCache = {}
-	Properties.ClassLists = {}
-	Properties.SearchText = ""
-
-	Properties.AddAttributeProp = {Category = "Attributes", Class = "", Name = "", SpecialRow = "AddAttribute", Tags = {}}
-	Properties.SoundPreviewProp = {Category = "Data", ValueType = {Name = "SoundPlayer"}, Class = "Sound", Name = "Preview", Tags = {}}
-
-	Properties.IgnoreProps = {
-		["DataModel"] = {
-			["PrivateServerId"] = true,
-			["PrivateServerOwnerId"] = true,
-			["VIPServerId"] = true,
-			["VIPServerOwnerId"] = true
-		}
-	}
-
-	Properties.ExpandableTypes = {
-		["Vector2"] = true,
-		["Vector3"] = true,
-		["UDim"] = true,
-		["UDim2"] = true,
-		["CFrame"] = true,
-		["Rect"] = true,
-		["PhysicalProperties"] = true,
-		["Ray"] = true,
-		["NumberRange"] = true,
-		["Faces"] = true,
-		["Axes"] = true,
-	}
-
-	Properties.ExpandableProps = {
-		["Sound.SoundId"] = true
-	}
-
-	Properties.CollapsedCategories = {
-		["Surface Inputs"] = true,
-		["Surface"] = true
-	}
-
-	Properties.ConflictSubProps = {
-		["Vector2"] = {"X","Y"},
-		["Vector3"] = {"X","Y","Z"},
-		["UDim"] = {"Scale","Offset"},
-		["UDim2"] = {"X","X.Scale","X.Offset","Y","Y.Scale","Y.Offset"},
-		["CFrame"] = {"Position","Position.X","Position.Y","Position.Z",
-			"RightVector","RightVector.X","RightVector.Y","RightVector.Z",
-			"UpVector","UpVector.X","UpVector.Y","UpVector.Z",
-			"LookVector","LookVector.X","LookVector.Y","LookVector.Z"},
-		["Rect"] = {"Min.X","Min.Y","Max.X","Max.Y"},
-		["PhysicalProperties"] = {"Density","Elasticity","ElasticityWeight","Friction","FrictionWeight"},
-		["Ray"] = {"Origin","Origin.X","Origin.Y","Origin.Z","Direction","Direction.X","Direction.Y","Direction.Z"},
-		["NumberRange"] = {"Min","Max"},
-		["Faces"] = {"Back","Bottom","Front","Left","Right","Top"},
-		["Axes"] = {"X","Y","Z"}
-	}
-
-	Properties.ConflictIgnore = {
-		["BasePart"] = {
-			["ResizableFaces"] = true
-		}
-	}
-
-	Properties.RoundableTypes = {
-		["float"] = true,
-		["double"] = true,
-		["Color3"] = true,
-		["UDim"] = true,
-		["UDim2"] = true,
-		["Vector2"] = true,
-		["Vector3"] = true,
-		["NumberRange"] = true,
-		["Rect"] = true,
-		["NumberSequence"] = true,
-		["ColorSequence"] = true,
-		["Ray"] = true,
-		["CFrame"] = true
-	}
-
-	Properties.TypeNameConvert = {
-		["number"] = "double",
-		["boolean"] = "bool"
-	}
-
-	Properties.ToNumberTypes = {
-		["int"] = true,
-		["int64"] = true,
-		["float"] = true,
-		["double"] = true
-	}
-
-	Properties.DefaultPropValue = {
-		string = "",
-		bool = false,
-		double = 0,
-		UDim = UDim.new(0,0),
-		UDim2 = UDim2.new(0,0,0,0),
-		BrickColor = BrickColor.new("Medium stone grey"),
-		Color3 = Color3.new(1,1,1),
-		Vector2 = Vector2.new(0,0),
-		Vector3 = Vector3.new(0,0,0),
-		NumberSequence = NumberSequence.new(1),
-		ColorSequence = ColorSequence.new(Color3.new(1,1,1)),
-		NumberRange = NumberRange.new(0),
-		Rect = Rect.new(0,0,0,0)
-	}
-
-	Properties.AllowedAttributeTypes = {"string","boolean","number","UDim","UDim2","BrickColor","Color3","Vector2","Vector3","NumberSequence","ColorSequence","NumberRange","Rect"}
-
-	Properties.StringToValue = function(prop,str)
-		local typeData = prop.ValueType
-		local typeName = typeData.Name
-
-		if typeName == "string" or typeName == "Content" then
-			return str
-		elseif Properties.ToNumberTypes[typeName] then
-			return tonumber(str)
-		elseif typeName == "Vector2" then
-			local vals = str:split(",")
-			local x,y = tonumber(vals[1]),tonumber(vals[2])
-			if x and y and #vals >= 2 then return Vector2.new(x,y) end
-		elseif typeName == "Vector3" then
-			local vals = str:split(",")
-			local x,y,z = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3])
-			if x and y and z and #vals >= 3 then return Vector3.new(x,y,z) end
-		elseif typeName == "UDim" then
-			local vals = str:split(",")
-			local scale,offset = tonumber(vals[1]),tonumber(vals[2])
-			if scale and offset and #vals >= 2 then return UDim.new(scale,offset) end
-		elseif typeName == "UDim2" then
-			local vals = str:gsub("[{}]",""):split(",")
-			local xScale,xOffset,yScale,yOffset = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3]),tonumber(vals[4])
-			if xScale and xOffset and yScale and yOffset and #vals >= 4 then return UDim2.new(xScale,xOffset,yScale,yOffset) end
-		elseif typeName == "CFrame" then
-			local vals = str:split(",")
-			local s,result = pcall(CFrame.new,unpack(vals))
-			if s and #vals >= 12 then return result end
-		elseif typeName == "Rect" then
-			local vals = str:split(",")
-			local s,result = pcall(Rect.new,unpack(vals))
-			if s and #vals >= 4 then return result end
-		elseif typeName == "Ray" then
-			local vals = str:gsub("[{}]",""):split(",")
-			local s,origin = pcall(Vector3.new,unpack(vals,1,3))
-			local s2,direction = pcall(Vector3.new,unpack(vals,4,6))
-			if s and s2 and #vals >= 6 then return Ray.new(origin,direction) end
-		elseif typeName == "NumberRange" then
-			local vals = str:split(",")
-			local s,result = pcall(NumberRange.new,unpack(vals))
-			if s and #vals >= 1 then return result end
-		elseif typeName == "Color3" then
-			local vals = str:gsub("[{}]",""):split(",")
-			local s,result = pcall(Color3.fromRGB,unpack(vals))
-			if s and #vals >= 3 then return result end
-		end
-
-		return nil
-	end
-
-	Properties.ValueToString = function(prop,val)
-		local typeData = prop.ValueType
-		local typeName = typeData.Name
-
-		if typeName == "Color3" then
-			return Lib.ColorToBytes(val)
-		elseif typeName == "NumberRange" then
-			return val.Min..", "..val.Max
-		end
-
-		return tostring(val)
-	end
-
-	Properties.GetIndexableProps = function(obj,classData)
-		if not Main.Elevated then
-			if not pcall(function() return obj.ClassName end) then return nil end
-		end
-
-		local ignoreProps = Properties.IgnoreProps[classData.Name] or {}
-
-		local result = {}
-		local count = 1
-		local props = classData.Properties
-		for i = 1,#props do
-			local prop = props[i]
-			if not ignoreProps[prop.Name] then
-				local s = pcall(function() return obj[prop.Name] end)
-				if s then
-					result[count] = prop
-					count = count + 1
-				end
-			end
-		end
-
-		return result
-	end
-
-	Properties.FindFirstObjWhichIsA = function(class)
-		local classList = Properties.ClassLists[class] or {}
-		if classList and #classList > 0 then
-			return classList[1]
-		end
-
-		return nil
-	end
-
-	Properties.ComputeConflicts = function(p)
-		local maxConflictCheck = Settings.Properties.MaxConflictCheck
-		local sList = Explorer.Selection.List
-		local classLists = Properties.ClassLists
-		local stringSplit = string.split
-		local t_clear = table.clear
-		local conflictIgnore = Properties.ConflictIgnore
-		local conflictMap = {}
-		local propList = p and {p} or props
-
-		if p then
-			local gName = p.Class.."."..p.Name
-			autoUpdateObjs[gName] = nil
-			local subProps = Properties.ConflictSubProps[p.ValueType.Name] or {}
-			for i = 1,#subProps do
-				autoUpdateObjs[gName.."."..subProps[i]] = nil
-			end
-		else
-			table.clear(autoUpdateObjs)
-		end
-
-		if #sList > 0 then
-			for i = 1,#propList do
-				local prop = propList[i]
-				local propName,propClass = prop.Name,prop.Class
-				local typeData = prop.RootType or prop.ValueType
-				local typeName = typeData.Name
-				local attributeName = prop.AttributeName
-				local gName = propClass.."."..propName
-
-				local checked = 0
-				local subProps = Properties.ConflictSubProps[typeName] or {}
-				local subPropCount = #subProps
-				local toCheck = subPropCount + 1
-				local conflictsFound = 0
-				local indexNames = {}
-				local ignored = conflictIgnore[propClass] and conflictIgnore[propClass][propName]
-				local truthyCheck = (typeName == "PhysicalProperties")
-				local isAttribute = prop.IsAttribute
-				local isMultiType = prop.MultiType
-
-				t_clear(conflictMap)
-
-				if not isMultiType then
-					local firstVal,firstObj,firstSet
-					local classList = classLists[prop.Class] or {}
-					for c = 1,#classList do
-						local obj = classList[c]
-						if not firstSet then
-							if isAttribute then
-								firstVal = getAttribute(obj,attributeName)
-								if firstVal ~= nil then
-									firstObj = obj
-									firstSet = true
-								end
-							else
-								firstVal = obj[propName]
-								firstObj = obj
-								firstSet = true
-							end
-							if ignored then break end
-						else
-							local propVal,skip
-							if isAttribute then
-								propVal = getAttribute(obj,attributeName)
-								if propVal == nil then skip = true end
-							else
-								propVal = obj[propName]
-							end
-
-							if not skip then
-								if not conflictMap[1] then
-									if truthyCheck then
-										if (firstVal and true or false) ~= (propVal and true or false) then
-											conflictMap[1] = true
-											conflictsFound = conflictsFound + 1
-										end
-									elseif firstVal ~= propVal then
-										conflictMap[1] = true
-										conflictsFound = conflictsFound + 1
-									end
-								end
-
-								if subPropCount > 0 then
-									for sPropInd = 1,subPropCount do
-										local indexes = indexNames[sPropInd]
-										if not indexes then indexes = stringSplit(subProps[sPropInd],".") indexNames[sPropInd] = indexes end
-
-										local firstValSub = firstVal
-										local propValSub = propVal
-
-										for j = 1,#indexes do
-											if not firstValSub or not propValSub then break end -- PhysicalProperties
-											local indexName = indexes[j]
-											firstValSub = firstValSub[indexName]
-											propValSub = propValSub[indexName]
-										end
-
-										local mapInd = sPropInd + 1
-										if not conflictMap[mapInd] and firstValSub ~= propValSub then
-											conflictMap[mapInd] = true
-											conflictsFound = conflictsFound + 1
-										end
-									end
-								end
-
-								if conflictsFound == toCheck then break end
-							end
-						end
-
-						checked = checked + 1
-						if checked == maxConflictCheck then break end
-					end
-
-					if not conflictMap[1] then autoUpdateObjs[gName] = firstObj end
-					for sPropInd = 1,subPropCount do
-						if not conflictMap[sPropInd+1] then
-							autoUpdateObjs[gName.."."..subProps[sPropInd]] = firstObj
-						end
-					end
-				end
-			end
-		end
-
-		if p then
-			Properties.Refresh()
-		end
-	end
-
-	-- Fetches the properties to be displayed based on the explorer selection
-	Properties.ShowExplorerProps = function()
-		local maxConflictCheck = Settings.Properties.MaxConflictCheck
-		local sList = Explorer.Selection.List
-		local foundClasses = {}
-		local propCount = 1
-		local elevated = Main.Elevated
-		local showDeprecated,showHidden = Settings.Properties.ShowDeprecated,Settings.Properties.ShowHidden
-		local Classes = API.Classes
-		local classLists = {}
-		local lower = string.lower
-		local RMDCustomOrders = RMD.PropertyOrders
-		local getAttributes = game.GetAttributes
-		local maxAttrs = Settings.Properties.MaxAttributes
-		local showingAttrs = Settings.Properties.ShowAttributes
-		local foundAttrs = {}
-		local attrCount = 0
-		local typeof = typeof
-		local typeNameConvert = Properties.TypeNameConvert
-
-		table.clear(props)
-
-		for i = 1,#sList do
-			local node = sList[i]
-			local obj = node.Obj
-			local class = node.Class
-			if not class then class = obj.ClassName node.Class = class end
-
-			local apiClass = Classes[class]
-			while apiClass do
-				local APIClassName = apiClass.Name
-				if not foundClasses[APIClassName] then
-					local apiProps = indexableProps[APIClassName]
-					if not apiProps then apiProps = Properties.GetIndexableProps(obj,apiClass) indexableProps[APIClassName] = apiProps end
-
-					for i = 1,#apiProps do
-						local prop = apiProps[i]
-						local tags = prop.Tags
-						if (not tags.Deprecated or showDeprecated) and (not tags.Hidden or showHidden) then
-							props[propCount] = prop
-							propCount = propCount + 1
-						end
-					end
-					foundClasses[APIClassName] = true
-				end
-
-				local classList = classLists[APIClassName]
-				if not classList then classList = {} classLists[APIClassName] = classList end
-				classList[#classList+1] = obj
-
-				apiClass = apiClass.Superclass
-			end
-
-			if showingAttrs and attrCount < maxAttrs then
-				local attrs = getAttributes(obj)
-				for name,val in pairs(attrs) do
-					local typ = typeof(val)
-					if not foundAttrs[name] then
-						local category = (typ == "Instance" and "Class") or (typ == "EnumItem" and "Enum") or "Other"
-						local valType = {Name = typeNameConvert[typ] or typ, Category = category}
-						local attrProp = {IsAttribute = true, Name = "ATTR_"..name, AttributeName = name, DisplayName = name, Class = "Instance", ValueType = valType, Category = "Attributes", Tags = {}}
-						props[propCount] = attrProp
-						propCount = propCount + 1
-						attrCount = attrCount + 1
-						foundAttrs[name] = {typ,attrProp}
-						if attrCount == maxAttrs then break end
-					elseif foundAttrs[name][1] ~= typ then
-						foundAttrs[name][2].MultiType = true
-						foundAttrs[name][2].Tags.ReadOnly = true
-						foundAttrs[name][2].ValueType = {Name = "string"}
-					end
-				end
-			end
-		end
-
-		table.sort(props,function(a,b)
-			if a.Category ~= b.Category then
-				return (categoryOrder[a.Category] or 9999) < (categoryOrder[b.Category] or 9999)
-			else
-				local aOrder = (RMDCustomOrders[a.Class] and RMDCustomOrders[a.Class][a.Name]) or 9999999
-				local bOrder = (RMDCustomOrders[b.Class] and RMDCustomOrders[b.Class][b.Name]) or 9999999
-				if aOrder ~= bOrder then
-					return aOrder < bOrder
-				else
-					return lower(a.Name) < lower(b.Name)
-				end
-			end
-		end)
-
-		-- Find conflicts and get auto-update instances
-		Properties.ClassLists = classLists
-		Properties.ComputeConflicts()
-		--warn("CONFLICT",tick()-start)
-		if #props > 0 then
-			props[#props+1] = Properties.AddAttributeProp
-		end
-
-		Properties.Update()
-		Properties.Refresh()
-	end
-
-	Properties.UpdateView = function()
-		local maxEntries = math.ceil(propsFrame.AbsoluteSize.Y / 23)
-		local maxX = propsFrame.AbsoluteSize.X
-		local totalWidth = Properties.ViewWidth + Properties.MinInputWidth
-
-		scrollV.VisibleSpace = maxEntries
-		scrollV.TotalSpace = #viewList + 1
-		scrollH.VisibleSpace = maxX
-		scrollH.TotalSpace = totalWidth
-
-		scrollV.Gui.Visible = #viewList + 1 > maxEntries
-		scrollH.Gui.Visible = Settings.Properties.ScaleType == 0 and totalWidth > maxX
-
-		local oldSize = propsFrame.Size
-		propsFrame.Size = UDim2.new(1,(scrollV.Gui.Visible and -16 or 0),1,(scrollH.Gui.Visible and -39 or -23))
-		if oldSize ~= propsFrame.Size then
-			Properties.UpdateView()
-		else
-			scrollV:Update()
-			scrollH:Update()
-
-			if scrollV.Gui.Visible and scrollH.Gui.Visible then
-				scrollV.Gui.Size = UDim2.new(0,16,1,-39)
-				scrollH.Gui.Size = UDim2.new(1,-16,0,16)
-				Properties.Window.GuiElems.Content.ScrollCorner.Visible = true
-			else
-				scrollV.Gui.Size = UDim2.new(0,16,1,-23)
-				scrollH.Gui.Size = UDim2.new(1,0,0,16)
-				Properties.Window.GuiElems.Content.ScrollCorner.Visible = false
-			end
-
-			Properties.Index = scrollV.Index
-		end
-	end
-
-	Properties.MakeSubProp = function(prop,subName,valueType,displayName)
-		local subProp = {}
-		for i,v in pairs(prop) do
-			subProp[i] = v
-		end
-		subProp.RootType = subProp.RootType or subProp.ValueType
-		subProp.ValueType = valueType
-		subProp.SubName = subProp.SubName and (subProp.SubName..subName) or subName
-		subProp.DisplayName = displayName
-
-		return subProp
-	end
-
-	Properties.GetExpandedProps = function(prop) -- TODO: Optimize using table
-		local result = {}
-		local typeData = prop.ValueType
-		local typeName = typeData.Name
-		local makeSubProp = Properties.MakeSubProp
-
-		if typeName == "Vector2" then
-			result[1] = makeSubProp(prop,".X",{Name = "float"})
-			result[2] = makeSubProp(prop,".Y",{Name = "float"})
-		elseif typeName == "Vector3" then
-			result[1] = makeSubProp(prop,".X",{Name = "float"})
-			result[2] = makeSubProp(prop,".Y",{Name = "float"})
-			result[3] = makeSubProp(prop,".Z",{Name = "float"})
-		elseif typeName == "CFrame" then
-			result[1] = makeSubProp(prop,".Position",{Name = "Vector3"})
-			result[2] = makeSubProp(prop,".RightVector",{Name = "Vector3"})
-			result[3] = makeSubProp(prop,".UpVector",{Name = "Vector3"})
-			result[4] = makeSubProp(prop,".LookVector",{Name = "Vector3"})
-		elseif typeName == "UDim" then
-			result[1] = makeSubProp(prop,".Scale",{Name = "float"})
-			result[2] = makeSubProp(prop,".Offset",{Name = "int"})
-		elseif typeName == "UDim2" then
-			result[1] = makeSubProp(prop,".X",{Name = "UDim"})
-			result[2] = makeSubProp(prop,".Y",{Name = "UDim"})
-		elseif typeName == "Rect" then
-			result[1] = makeSubProp(prop,".Min.X",{Name = "float"},"X0")
-			result[2] = makeSubProp(prop,".Min.Y",{Name = "float"},"Y0")
-			result[3] = makeSubProp(prop,".Max.X",{Name = "float"},"X1")
-			result[4] = makeSubProp(prop,".Max.Y",{Name = "float"},"Y1")
-		elseif typeName == "PhysicalProperties" then
-			result[1] = makeSubProp(prop,".Density",{Name = "float"})
-			result[2] = makeSubProp(prop,".Elasticity",{Name = "float"})
-			result[3] = makeSubProp(prop,".ElasticityWeight",{Name = "float"})
-			result[4] = makeSubProp(prop,".Friction",{Name = "float"})
-			result[5] = makeSubProp(prop,".FrictionWeight",{Name = "float"})
-		elseif typeName == "Ray" then
-			result[1] = makeSubProp(prop,".Origin",{Name = "Vector3"})
-			result[2] = makeSubProp(prop,".Direction",{Name = "Vector3"})
-		elseif typeName == "NumberRange" then
-			result[1] = makeSubProp(prop,".Min",{Name = "float"})
-			result[2] = makeSubProp(prop,".Max",{Name = "float"})
-		elseif typeName == "Faces" then
-			result[1] = makeSubProp(prop,".Back",{Name = "bool"})
-			result[2] = makeSubProp(prop,".Bottom",{Name = "bool"})
-			result[3] = makeSubProp(prop,".Front",{Name = "bool"})
-			result[4] = makeSubProp(prop,".Left",{Name = "bool"})
-			result[5] = makeSubProp(prop,".Right",{Name = "bool"})
-			result[6] = makeSubProp(prop,".Top",{Name = "bool"})
-		elseif typeName == "Axes" then
-			result[1] = makeSubProp(prop,".X",{Name = "bool"})
-			result[2] = makeSubProp(prop,".Y",{Name = "bool"})
-			result[3] = makeSubProp(prop,".Z",{Name = "bool"})
-		end
-
-		if prop.Name == "SoundId" and prop.Class == "Sound" then
-			result[1] = Properties.SoundPreviewProp
-		end
-
-		return result
-	end
-
-	Properties.Update = function()
-		table.clear(viewList)
-
-		local nameWidthCache = Properties.NameWidthCache
-		local lastCategory
-		local count = 1
-		local maxWidth,maxDepth = 0,1
-
-		local textServ = service.TextService
-		local getTextSize = textServ.GetTextSize
-		local font = Enum.Font.SourceSans
-		local size = Vector2.new(math.huge,20)
-		local stringSplit = string.split
-		local entryIndent = Properties.EntryIndent
-		local isFirstScaleType = Settings.Properties.ScaleType == 0
-		local find,lower = string.find,string.lower
-		local searchText = (#Properties.SearchText > 0 and lower(Properties.SearchText))
-
-		local function recur(props,depth)
-			for i = 1,#props do
-				local prop = props[i]
-				local propName = prop.Name
-				local subName = prop.SubName
-				local category = prop.Category
-
-				local visible
-				if searchText and depth == 1 then
-					if find(lower(propName),searchText,1,true) then
-						visible = true
-					end
-				else
-					visible = true
-				end
-
-				if visible and lastCategory ~= category then
-					viewList[count] = {CategoryName = category}
-					count = count + 1
-					lastCategory = category
-				end
-
-				if (expanded["CAT_"..category] and visible) or prop.SpecialRow then
-					if depth > 1 then prop.Depth = depth if depth > maxDepth then maxDepth = depth end end
-
-					if isFirstScaleType then
-						local nameArr = subName and stringSplit(subName,".")
-						local displayName = prop.DisplayName or (nameArr and nameArr[#nameArr]) or propName
-
-						local nameWidth = nameWidthCache[displayName]
-						if not nameWidth then nameWidth = getTextSize(textServ,displayName,14,font,size).X nameWidthCache[displayName] = nameWidth end
-
-						local totalWidth = nameWidth + entryIndent*depth
-						if totalWidth > maxWidth then
-							maxWidth = totalWidth
-						end
-					end
-
-					viewList[count] = prop
-					count = count + 1
-
-					local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
-					if expanded[fullName] then
-						local nextDepth = depth+1
-						local expandedProps = Properties.GetExpandedProps(prop)
-						if #expandedProps > 0 then
-							recur(expandedProps,nextDepth)
-						end
-					end
-				end
-			end
-		end
-		recur(props,1)
-
-		inputProp = nil
-		Properties.ViewWidth = maxWidth + 9 + Properties.EntryOffset
-		Properties.UpdateView()
-	end
-
-	Properties.NewPropEntry = function(index)
-		local newEntry = Properties.EntryTemplate:Clone()
-		local nameFrame = newEntry.NameFrame
-		local valueFrame = newEntry.ValueFrame
-		local newCheckbox = Lib.Checkbox.new(1)
-		newCheckbox.Gui.Position = UDim2.new(0,3,0,3)
-		newCheckbox.Gui.Parent = valueFrame
-		newCheckbox.OnInput:Connect(function()
-			local prop = viewList[index + Properties.Index]
-			if not prop then return end
-
-			if prop.ValueType.Name == "PhysicalProperties" then
-				Properties.SetProp(prop,newCheckbox.Toggled and true or nil)
-			else
-				Properties.SetProp(prop,newCheckbox.Toggled)
-			end
-		end)
-		checkboxes[index] = newCheckbox
-
-		local iconFrame = Main.MiscIcons:GetLabel()
-		iconFrame.Position = UDim2.new(0,2,0,3)
-		iconFrame.Parent = newEntry.ValueFrame.RightButton
-
-		newEntry.Position = UDim2.new(0,0,0,23*(index-1))
-
-		nameFrame.Expand.InputBegan:Connect(function(input)
-			local prop = viewList[index + Properties.Index]
-			if not prop or input.UserInputType ~= Enum.UserInputType.MouseMovement then return end
-
-			local fullName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
-
-			Main.MiscIcons:DisplayByKey(newEntry.NameFrame.Expand.Icon, expanded[fullName] and "Collapse_Over" or "Expand_Over")
-		end)
-
-		nameFrame.Expand.InputEnded:Connect(function(input)
-			local prop = viewList[index + Properties.Index]
-			if not prop or input.UserInputType ~= Enum.UserInputType.MouseMovement then return end
-
-			local fullName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
-
-			Main.MiscIcons:DisplayByKey(newEntry.NameFrame.Expand.Icon, expanded[fullName] and "Collapse" or "Expand")
-		end)
-
-		nameFrame.Expand.MouseButton1Down:Connect(function()
-			local prop = viewList[index + Properties.Index]
-			if not prop then return end
-
-			local fullName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
-			if not prop.CategoryName and not Properties.ExpandableTypes[prop.ValueType and prop.ValueType.Name] and not Properties.ExpandableProps[fullName] then return end
-
-			expanded[fullName] = not expanded[fullName]
-			Properties.Update()
-			Properties.Refresh()
-		end)
-
-		nameFrame.PropName.InputBegan:Connect(function(input)
-			local prop = viewList[index + Properties.Index]
-			if not prop then return end
-			if input.UserInputType == Enum.UserInputType.MouseMovement and not nameFrame.PropName.TextFits then
-				local fullNameFrame = Properties.FullNameFrame	
-				local nameArr = string.split(prop.Class.."."..prop.Name..(prop.SubName or ""),".")
-				local dispName = prop.DisplayName or nameArr[#nameArr]
-				local sizeX = service.TextService:GetTextSize(dispName,14,Enum.Font.SourceSans,Vector2.new(math.huge,20)).X
-
-				fullNameFrame.TextLabel.Text = dispName
-				--fullNameFrame.Position = UDim2.new(0,Properties.EntryIndent*(prop.Depth or 1) + Properties.EntryOffset,0,23*(index-1))
-				fullNameFrame.Size = UDim2.new(0,sizeX + 4,0,22)
-				fullNameFrame.Visible = true
-				Properties.FullNameFrameIndex = index
-				Properties.FullNameFrameAttach.SetData(fullNameFrame, {Target = nameFrame})
-				Properties.FullNameFrameAttach.Enable()
-			end
-		end)
-
-		nameFrame.PropName.InputEnded:Connect(function(input)
-			if input.UserInputType == Enum.UserInputType.MouseMovement and Properties.FullNameFrameIndex == index then
-				Properties.FullNameFrame.Visible = false
-				Properties.FullNameFrameAttach.Disable()
-			end
-		end)
-
-		valueFrame.ValueBox.MouseButton1Down:Connect(function()
-			local prop = viewList[index + Properties.Index]
-			if not prop then return end
-
-			Properties.SetInputProp(prop,index)
-		end)
-
-		valueFrame.ColorButton.MouseButton1Down:Connect(function()
-			local prop = viewList[index + Properties.Index]
-			if not prop then return end
-
-			Properties.SetInputProp(prop,index,"color")
-		end)
-
-		valueFrame.RightButton.MouseButton1Click:Connect(function()
-			local prop = viewList[index + Properties.Index]
-			if not prop then return end
-
-			local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
-			local inputFullName = inputProp and (inputProp.Class.."."..inputProp.Name..(inputProp.SubName or ""))
-
-			if fullName == inputFullName and inputProp.ValueType.Category == "Class" then
-				inputProp = nil
-				Properties.SetProp(prop,nil)
-			else
-				Properties.SetInputProp(prop,index,"right")
-			end
-		end)
-
-		nameFrame.ToggleAttributes.MouseButton1Click:Connect(function()
-			Settings.Properties.ShowAttributes = not Settings.Properties.ShowAttributes
-			Properties.ShowExplorerProps()
-		end)
-
-		newEntry.RowButton.MouseButton1Click:Connect(function()
-			Properties.DisplayAddAttributeWindow()
-		end)
-
-		newEntry.EditAttributeButton.MouseButton1Down:Connect(function()
-			local prop = viewList[index + Properties.Index]
-			if not prop then return end
-
-			Properties.DisplayAttributeContext(prop)
-		end)
-
-		valueFrame.SoundPreview.ControlButton.MouseButton1Click:Connect(function()
-			if Properties.PreviewSound and Properties.PreviewSound.Playing then
-				Properties.SetSoundPreview(false)
-			else
-				local soundObj = Properties.FindFirstObjWhichIsA("Sound")
-				if soundObj then Properties.SetSoundPreview(soundObj) end
-			end
-		end)
-
-		valueFrame.SoundPreview.InputBegan:Connect(function(input)
-			if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
-
-			local releaseEvent,mouseEvent
-			releaseEvent = service.UserInputService.InputEnded:Connect(function(input)
-				if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
-				releaseEvent:Disconnect()
-				mouseEvent:Disconnect()
-			end)
-
-			local timeLine = newEntry.ValueFrame.SoundPreview.TimeLine
-			local soundObj = Properties.FindFirstObjWhichIsA("Sound")
-			if soundObj then Properties.SetSoundPreview(soundObj,true) end
-
-			local function update(input)
-				local sound = Properties.PreviewSound
-				if not sound or sound.TimeLength == 0 then return end
-
-				local mouseX = input.Position.X
-				local timeLineSize = timeLine.AbsoluteSize
-				local relaX = mouseX - timeLine.AbsolutePosition.X
-
-				if timeLineSize.X <= 1 then return end
-				if relaX < 0 then relaX = 0 elseif relaX >= timeLineSize.X then relaX = timeLineSize.X-1 end
-
-				local perc = (relaX/(timeLineSize.X-1))
-				sound.TimePosition = perc*sound.TimeLength
-				timeLine.Slider.Position = UDim2.new(perc,-4,0,-8)
-			end
-			update(input)
-
-			mouseEvent = service.UserInputService.InputChanged:Connect(function(input)
-				if input.UserInputType == Enum.UserInputType.MouseMovement then
-					update(input)
-				end
-			end)
-		end)
-
-		newEntry.Parent = propsFrame
-
-		return {
-			Gui = newEntry,
-			GuiElems = {
-				NameFrame = nameFrame,
-				ValueFrame = valueFrame,
-				PropName = nameFrame.PropName,
-				ValueBox = valueFrame.ValueBox,
-				Expand = nameFrame.Expand,
-				ColorButton = valueFrame.ColorButton,
-				ColorPreview = valueFrame.ColorButton.ColorPreview,
-				Gradient = valueFrame.ColorButton.ColorPreview.UIGradient,
-				EnumArrow = valueFrame.EnumArrow,
-				Checkbox = valueFrame.Checkbox,
-				RightButton = valueFrame.RightButton,
-				RightButtonIcon = iconFrame,
-				RowButton = newEntry.RowButton,
-				EditAttributeButton = newEntry.EditAttributeButton,
-				ToggleAttributes = nameFrame.ToggleAttributes,
-				SoundPreview = valueFrame.SoundPreview,
-				SoundPreviewSlider = valueFrame.SoundPreview.TimeLine.Slider
-			}
-		}
-	end
-
-	Properties.GetSoundPreviewEntry = function()
-		for i = 1,#viewList do
-			if viewList[i] == Properties.SoundPreviewProp then
-				return propEntries[i - Properties.Index]
-			end
-		end
-	end
-
-	Properties.SetSoundPreview = function(soundObj,noplay)
-		local sound = Properties.PreviewSound
-		if not sound then
-			sound = Instance.new("Sound")
-			sound.Name = "Preview"
-			sound.Paused:Connect(function()
-				local entry = Properties.GetSoundPreviewEntry()
-				if entry then Main.MiscIcons:DisplayByKey(entry.GuiElems.SoundPreview.ControlButton.Icon, "Play") end
-			end)
-			sound.Resumed:Connect(function() Properties.Refresh() end)
-			sound.Ended:Connect(function()
-				local entry = Properties.GetSoundPreviewEntry()
-				if entry then entry.GuiElems.SoundPreviewSlider.Position = UDim2.new(0,-4,0,-8) end
-				Properties.Refresh()
-			end)
-			sound.Parent = window.Gui
-			Properties.PreviewSound = sound
-		end
-
-		if not soundObj then
-			sound:Pause()
-		else
-			local newId = sound.SoundId ~= soundObj.SoundId
-			sound.SoundId = soundObj.SoundId
-			sound.PlaybackSpeed = soundObj.PlaybackSpeed
-			sound.Volume = soundObj.Volume
-			if newId then sound.TimePosition = 0 end
-			if not noplay then sound:Resume() end
-
-			task.spawn(function()
-				local previewTime = tick()
-				Properties.SoundPreviewTime = previewTime
-				while previewTime == Properties.SoundPreviewTime and sound.Playing do
-					local entry = Properties.GetSoundPreviewEntry()
-					if entry then
-						local tl = sound.TimeLength
-						local perc = sound.TimePosition/(tl == 0 and 1 or tl)
-						entry.GuiElems.SoundPreviewSlider.Position = UDim2.new(perc,-4,0,-8)
-					end
-					Lib.FastWait()
-				end
-			end)
-			Properties.Refresh()
-		end
-	end
-
-	Properties.DisplayAttributeContext = function(prop)
-		local context = Properties.AttributeContext
-		if not context then
-			context = Lib.ContextMenu.new()
-			context.Iconless = true
-			context.Width = 80
-		end
-		context:Clear()
-
-		context:Add({Name = "Edit", OnClick = function()
-			Properties.DisplayAddAttributeWindow(prop)
-		end})
-		context:Add({Name = "Delete", OnClick = function()
-			Properties.SetProp(prop,nil,true)
-			Properties.ShowExplorerProps()
-		end})
-
-		context:Show()
-	end
-
-	Properties.DisplayAddAttributeWindow = function(editAttr)
-		local win = Properties.AddAttributeWindow
-		if not win then
-			win = Lib.Window.new()
-			win.Alignable = false
-			win.Resizable = false
-			win:SetTitle("Add Attribute")
-			win:SetSize(200,130)
-
-			local saveButton = Lib.Button.new()
-			local nameLabel = Lib.Label.new()
-			nameLabel.Text = "Name"
-			nameLabel.Position = UDim2.new(0,30,0,10)
-			nameLabel.Size = UDim2.new(0,40,0,20)
-			win:Add(nameLabel)
-
-			local nameBox = Lib.ViewportTextBox.new()
-			nameBox.Position = UDim2.new(0,75,0,10)
-			nameBox.Size = UDim2.new(0,120,0,20)
-			win:Add(nameBox,"NameBox")
-			nameBox.TextBox:GetPropertyChangedSignal("Text"):Connect(function()
-				saveButton:SetDisabled(#nameBox:GetText() == 0)
-			end)
-
-			local typeLabel = Lib.Label.new()
-			typeLabel.Text = "Type"
-			typeLabel.Position = UDim2.new(0,30,0,40)
-			typeLabel.Size = UDim2.new(0,40,0,20)
-			win:Add(typeLabel)
-
-			local typeChooser = Lib.DropDown.new()
-			typeChooser.CanBeEmpty = false
-			typeChooser.Position = UDim2.new(0,75,0,40)
-			typeChooser.Size = UDim2.new(0,120,0,20)
-			typeChooser:SetOptions(Properties.AllowedAttributeTypes)
-			win:Add(typeChooser,"TypeChooser")
-
-			local errorLabel = Lib.Label.new()
-			errorLabel.Text = ""
-			errorLabel.Position = UDim2.new(0,5,1,-45)
-			errorLabel.Size = UDim2.new(1,-10,0,20)
-			errorLabel.TextColor3 = Settings.Theme.Important
-			win.ErrorLabel = errorLabel
-			win:Add(errorLabel,"Error")
-
-			local cancelButton = Lib.Button.new()
-			cancelButton.Text = "Cancel"
-			cancelButton.Position = UDim2.new(1,-97,1,-25)
-			cancelButton.Size = UDim2.new(0,92,0,20)
-			cancelButton.OnClick:Connect(function()
-				win:Close()
-			end)
-			win:Add(cancelButton)
-
-			saveButton.Text = "Save"
-			saveButton.Position = UDim2.new(0,5,1,-25)
-			saveButton.Size = UDim2.new(0,92,0,20)
-			saveButton.OnClick:Connect(function()
-				local name = nameBox:GetText()
-				if #name > 100 then
-					errorLabel.Text = "Error: Name over 100 chars"
-					return
-				elseif name:sub(1,3) == "RBX" then
-					errorLabel.Text = "Error: Name begins with 'RBX'"
-					return
-				end
-
-				local typ = typeChooser.Selected
-				local valType = {Name = Properties.TypeNameConvert[typ] or typ, Category = "DataType"}
-				local attrProp = {IsAttribute = true, Name = "ATTR_"..name, AttributeName = name, DisplayName = name, Class = "Instance", ValueType = valType, Category = "Attributes", Tags = {}}
-
-				Settings.Properties.ShowAttributes = true
-				Properties.SetProp(attrProp,Properties.DefaultPropValue[valType.Name],true,Properties.EditingAttribute)
-				Properties.ShowExplorerProps()
-				win:Close()
-			end)
-			win:Add(saveButton,"SaveButton")
-
-			Properties.AddAttributeWindow = win
-		end
-
-		Properties.EditingAttribute = editAttr
-		win:SetTitle(editAttr and "Edit Attribute "..editAttr.AttributeName or "Add Attribute")
-		win.Elements.Error.Text = ""
-		win.Elements.NameBox:SetText("")
-		win.Elements.SaveButton:SetDisabled(true)
-		win.Elements.TypeChooser:SetSelected(1)
-		win:Show()
-	end
-
-	Properties.IsTextEditable = function(prop)
-		local typeData = prop.ValueType
-		local typeName = typeData.Name
-
-		return typeName ~= "bool" and typeData.Category ~= "Enum" and typeData.Category ~= "Class" and typeName ~= "BrickColor"
-	end
-
-	Properties.DisplayEnumDropdown = function(entryIndex)
-		local context = Properties.EnumContext
-		if not context then
-			context = Lib.ContextMenu.new()
-			context.Iconless = true
-			context.MaxHeight = 200
-			context.ReverseYOffset = 22
-			Properties.EnumDropdown = context
-		end
-
-		if not inputProp or inputProp.ValueType.Category ~= "Enum" then return end
-		local prop = inputProp
-
-		local entry = propEntries[entryIndex]
-		local valueFrame = entry.GuiElems.ValueFrame
-
-		local enum = Enum[prop.ValueType.Name]
-		if not enum then return end
-
-		local sorted = {}
-		for name,enum in next,enum:GetEnumItems() do
-			sorted[#sorted+1] = enum
-		end
-		table.sort(sorted,function(a,b) return a.Name < b.Name end)
-
-		context:Clear()
-
-		local function onClick(name)
-			if prop ~= inputProp then return end
-
-			local enumItem = enum[name]
-			inputProp = nil
-			Properties.SetProp(prop,enumItem)
-		end
-
-		for i = 1,#sorted do
-			local enumItem = sorted[i]
-			context:Add({Name = enumItem.Name, OnClick = onClick})
-		end
-
-		context.Width = valueFrame.AbsoluteSize.X
-		context:Show(valueFrame.AbsolutePosition.X, valueFrame.AbsolutePosition.Y + 22)
-	end
-
-	Properties.DisplayBrickColorEditor = function(prop,entryIndex,col)
-		local editor = Properties.BrickColorEditor
-		if not editor then
-			editor = Lib.BrickColorPicker.new()
-			editor.Gui.DisplayOrder = Main.DisplayOrders.Menu
-			editor.ReverseYOffset = 22
-
-			editor.OnSelect:Connect(function(col)
-				if not editor.CurrentProp or editor.CurrentProp.ValueType.Name ~= "BrickColor" then return end
-
-				if editor.CurrentProp == inputProp then inputProp = nil end
-				Properties.SetProp(editor.CurrentProp,BrickColor.new(col))
-			end)
-
-			editor.OnMoreColors:Connect(function() -- TODO: Special Case BasePart.BrickColor to BasePart.Color
-				editor:Close()
-				local colProp
-				for i,v in pairs(API.Classes.BasePart.Properties) do
-					if v.Name == "Color" then
-						colProp = v
-						break
-					end
-				end
-				Properties.DisplayColorEditor(colProp,editor.SavedColor.Color)
-			end)
-
-			Properties.BrickColorEditor = editor
-		end
-
-		local entry = propEntries[entryIndex]
-		local valueFrame = entry.GuiElems.ValueFrame
-
-		editor.CurrentProp = prop
-		editor.SavedColor = col
-		if prop and prop.Class == "BasePart" and prop.Name == "BrickColor" then
-			editor:SetMoreColorsVisible(true)
-		else
-			editor:SetMoreColorsVisible(false)
-		end
-		editor:Show(valueFrame.AbsolutePosition.X, valueFrame.AbsolutePosition.Y + 22)
-	end
-
-	Properties.DisplayColorEditor = function(prop,col)
-		local editor = Properties.ColorEditor
-		if not editor then
-			editor = Lib.ColorPicker.new()
-
-			editor.OnSelect:Connect(function(col)
-				if not editor.CurrentProp then return end
-				local typeName = editor.CurrentProp.ValueType.Name
-				if typeName ~= "Color3" and typeName ~= "BrickColor" then return end
-
-				local colVal = (typeName == "Color3" and col or BrickColor.new(col))
-
-				if editor.CurrentProp == inputProp then inputProp = nil end
-				Properties.SetProp(editor.CurrentProp,colVal)
-			end)
-
-			Properties.ColorEditor = editor
-		end
-
-		editor.CurrentProp = prop
-		if col then
-			editor:SetColor(col)
-		else
-			local firstVal = Properties.GetFirstPropVal(prop)
-			if firstVal then editor:SetColor(firstVal) end
-		end
-		editor:Show()
-	end
-
-	Properties.DisplayNumberSequenceEditor = function(prop,seq)
-		local editor = Properties.NumberSequenceEditor
-		if not editor then
-			editor = Lib.NumberSequenceEditor.new()
-
-			editor.OnSelect:Connect(function(val)
-				if not editor.CurrentProp or editor.CurrentProp.ValueType.Name ~= "NumberSequence" then return end
-
-				if editor.CurrentProp == inputProp then inputProp = nil end
-				Properties.SetProp(editor.CurrentProp,val)
-			end)
-
-			Properties.NumberSequenceEditor = editor
-		end
-
-		editor.CurrentProp = prop
-		if seq then
-			editor:SetSequence(seq)
-		else
-			local firstVal = Properties.GetFirstPropVal(prop)
-			if firstVal then editor:SetSequence(firstVal) end
-		end
-		editor:Show()
-	end
-
-	Properties.DisplayColorSequenceEditor = function(prop,seq)
-		local editor = Properties.ColorSequenceEditor
-		if not editor then
-			editor = Lib.ColorSequenceEditor.new()
-
-			editor.OnSelect:Connect(function(val)
-				if not editor.CurrentProp or editor.CurrentProp.ValueType.Name ~= "ColorSequence" then return end
-
-				if editor.CurrentProp == inputProp then inputProp = nil end
-				Properties.SetProp(editor.CurrentProp,val)
-			end)
-
-			Properties.ColorSequenceEditor = editor
-		end
-
-		editor.CurrentProp = prop
-		if seq then
-			editor:SetSequence(seq)
-		else
-			local firstVal = Properties.GetFirstPropVal(prop)
-			if firstVal then editor:SetSequence(firstVal) end
-		end
-		editor:Show()
-	end
-
-	Properties.GetFirstPropVal = function(prop)
-		local first = Properties.FindFirstObjWhichIsA(prop.Class)
-		if first then
-			return Properties.GetPropVal(prop,first)
-		end
-	end
-
-	Properties.GetPropVal = function(prop,obj)
-		if prop.MultiType then return "<Multiple Types>" end
-		if not obj then return end
-
-		local propVal
-		if prop.IsAttribute then
-			propVal = getAttribute(obj,prop.AttributeName)
-			if propVal == nil then return nil end
-
-			local typ = typeof(propVal)
-			local currentType = Properties.TypeNameConvert[typ] or typ
-			if prop.RootType then
-				if prop.RootType.Name ~= currentType then
-					return nil
-				end
-			elseif prop.ValueType.Name ~= currentType then
-				return nil
-			end
-		else
-			propVal = obj[prop.Name]
-		end
-		if prop.SubName then
-			local indexes = string.split(prop.SubName,".")
-			for i = 1,#indexes do
-				local indexName = indexes[i]
-				if #indexName > 0 and propVal then
-					propVal = propVal[indexName]
-				end
-			end
-		end
-
-		return propVal
-	end
-
-	Properties.SelectObject = function(obj)
-		if inputProp and inputProp.ValueType.Category == "Class" then
-			local prop = inputProp
-			inputProp = nil
-
-			if isa(obj,prop.ValueType.Name) then
-				Properties.SetProp(prop,obj)
-			else
-				Properties.Refresh()
-			end
-
-			return true
-		end
-
-		return false
-	end
-
-	Properties.DisplayProp = function(prop,entryIndex)
-		local propName = prop.Name
-		local typeData = prop.ValueType
-		local typeName = typeData.Name
-		local tags = prop.Tags
-		local gName = prop.Class.."."..prop.Name..(prop.SubName or "")
-		local propObj = autoUpdateObjs[gName]
-		local entryData = propEntries[entryIndex]
-		local UDim2 = UDim2
-
-		local guiElems = entryData.GuiElems
-		local valueFrame = guiElems.ValueFrame
-		local valueBox = guiElems.ValueBox
-		local colorButton = guiElems.ColorButton
-		local colorPreview = guiElems.ColorPreview
-		local gradient = guiElems.Gradient
-		local enumArrow = guiElems.EnumArrow
-		local checkbox = guiElems.Checkbox
-		local rightButton = guiElems.RightButton
-		local soundPreview = guiElems.SoundPreview
-
-		local propVal = Properties.GetPropVal(prop,propObj)
-		local inputFullName = inputProp and (inputProp.Class.."."..inputProp.Name..(inputProp.SubName or ""))
-
-		local offset = 4
-		local endOffset = 6
-
-		-- Offsetting the ValueBox for ValueType specific buttons
-		if (typeName == "Color3" or typeName == "BrickColor" or typeName == "ColorSequence") then
-			colorButton.Visible = true
-			enumArrow.Visible = false
-			if propVal then
-				gradient.Color = (typeName == "Color3" and ColorSequence.new(propVal)) or (typeName == "BrickColor" and ColorSequence.new(propVal.Color)) or propVal
-			else
-				gradient.Color = ColorSequence.new(Color3.new(1,1,1))
-			end
-			colorPreview.BorderColor3 = (typeName == "ColorSequence" and Color3.new(1,1,1) or Color3.new(0,0,0))
-			offset = 22
-			endOffset = 24 + (typeName == "ColorSequence" and 20 or 0)
-		elseif typeData.Category == "Enum" then
-			colorButton.Visible = false
-			enumArrow.Visible = not prop.Tags.ReadOnly
-			endOffset = 22
-		elseif (gName == inputFullName and typeData.Category == "Class") or typeName == "NumberSequence" then
-			colorButton.Visible = false
-			enumArrow.Visible = false
-			endOffset = 26
-		else
-			colorButton.Visible = false
-			enumArrow.Visible = false
-		end
-
-		valueBox.Position = UDim2.new(0,offset,0,0)
-		valueBox.Size = UDim2.new(1,-endOffset,1,0)
-
-		-- Right button
-		if inputFullName == gName and typeData.Category == "Class" then
-			Main.MiscIcons:DisplayByKey(guiElems.RightButtonIcon, "Delete")
-			guiElems.RightButtonIcon.Visible = true
-			rightButton.Text = ""
-			rightButton.Visible = true
-		elseif typeName == "NumberSequence" or typeName == "ColorSequence" then
-			guiElems.RightButtonIcon.Visible = false
-			rightButton.Text = "..."
-			rightButton.Visible = true
-		else
-			rightButton.Visible = false
-		end
-
-		-- Displays the correct ValueBox for the ValueType, and sets it to the prop value
-		if typeName == "bool" or typeName == "PhysicalProperties" then
-			valueBox.Visible = false
-			checkbox.Visible = true
-			soundPreview.Visible = false
-			checkboxes[entryIndex].Disabled = tags.ReadOnly
-			if typeName == "PhysicalProperties" and autoUpdateObjs[gName] then
-				checkboxes[entryIndex]:SetState(propVal and true or false)
-			else
-				checkboxes[entryIndex]:SetState(propVal)
-			end
-		elseif typeName == "SoundPlayer" then
-			valueBox.Visible = false
-			checkbox.Visible = false
-			soundPreview.Visible = true
-			local playing = Properties.PreviewSound and Properties.PreviewSound.Playing
-			Main.MiscIcons:DisplayByKey(soundPreview.ControlButton.Icon, playing and "Pause" or "Play")
-		else
-			valueBox.Visible = true
-			checkbox.Visible = false
-			soundPreview.Visible = false
-
-			if propVal ~= nil then
-				if typeName == "Color3" then
-					valueBox.Text = "["..Lib.ColorToBytes(propVal).."]"
-				elseif typeData.Category == "Enum" then
-					valueBox.Text = propVal.Name
-				elseif Properties.RoundableTypes[typeName] and Settings.Properties.NumberRounding then
-					local rawStr = Properties.ValueToString(prop,propVal)
-					valueBox.Text = rawStr:gsub("-?%d+%.%d+",function(num)
-						return tostring(tonumber(("%."..Settings.Properties.NumberRounding.."f"):format(num)))
-					end)
-				else
-					valueBox.Text = Properties.ValueToString(prop,propVal)
-				end
-			else
-				valueBox.Text = ""
-			end
-
-			valueBox.TextColor3 = tags.ReadOnly and Settings.Theme.PlaceholderText or Settings.Theme.Text
-		end
-	end
-
-	Properties.Refresh = function()
-		local maxEntries = math.max(math.ceil((propsFrame.AbsoluteSize.Y) / 23),0)	
-		local maxX = propsFrame.AbsoluteSize.X
-		local valueWidth = math.max(Properties.MinInputWidth,maxX-Properties.ViewWidth)
-		local inputPropVisible = false
-		local isa = game.IsA
-		local UDim2 = UDim2
-		local stringSplit = string.split
-		local scaleType = Settings.Properties.ScaleType
-
-		-- Clear connections
-		for i = 1,#propCons do
-			propCons[i]:Disconnect()
-		end
-		table.clear(propCons)
-
-		-- Hide full name viewer
-		Properties.FullNameFrame.Visible = false
-		Properties.FullNameFrameAttach.Disable()
-
-		for i = 1,maxEntries do
-			local entryData = propEntries[i]
-			if not propEntries[i] then entryData = Properties.NewPropEntry(i) propEntries[i] = entryData end
-
-			local entry = entryData.Gui
-			local guiElems = entryData.GuiElems
-			local nameFrame = guiElems.NameFrame
-			local propNameLabel = guiElems.PropName
-			local valueFrame = guiElems.ValueFrame
-			local expand = guiElems.Expand
-			local valueBox = guiElems.ValueBox
-			local propNameBox = guiElems.PropName
-			local rightButton = guiElems.RightButton
-			local editAttributeButton = guiElems.EditAttributeButton
-			local toggleAttributes = guiElems.ToggleAttributes
-
-			local prop = viewList[i + Properties.Index]
-			if prop then
-				local entryXOffset = (scaleType == 0 and scrollH.Index or 0)
-				entry.Visible = true
-				entry.Position = UDim2.new(0,-entryXOffset,0,entry.Position.Y.Offset)
-				entry.Size = UDim2.new(scaleType == 0 and 0 or 1, scaleType == 0 and Properties.ViewWidth + valueWidth or 0,0,22)
-
-				if prop.SpecialRow then
-					if prop.SpecialRow == "AddAttribute" then
-						nameFrame.Visible = false
-						valueFrame.Visible = false
-						guiElems.RowButton.Visible = true
-					end
-				else
-					-- Revert special row stuff
-					nameFrame.Visible = true
-					guiElems.RowButton.Visible = false
-
-					local depth = Properties.EntryIndent*(prop.Depth or 1)
-					local leftOffset = depth + Properties.EntryOffset
-					nameFrame.Position = UDim2.new(0,leftOffset,0,0)
-					propNameLabel.Size = UDim2.new(1,-2 - (scaleType == 0 and 0 or 6),1,0)
-
-					local gName = (prop.CategoryName and "CAT_"..prop.CategoryName) or prop.Class.."."..prop.Name..(prop.SubName or "")
-
-					if prop.CategoryName then
-						entry.BackgroundColor3 = Settings.Theme.Main1
-						valueFrame.Visible = false
-
-						propNameBox.Text = prop.CategoryName
-						propNameBox.Font = Enum.Font.SourceSansBold
-						expand.Visible = true
-						propNameBox.TextColor3 = Settings.Theme.Text
-						nameFrame.BackgroundTransparency = 1
-						nameFrame.Size = UDim2.new(1,0,1,0)
-						editAttributeButton.Visible = false
-
-						local showingAttrs = Settings.Properties.ShowAttributes
-						toggleAttributes.Position = UDim2.new(1,-85-leftOffset,0,0)
-						toggleAttributes.Text = (showingAttrs and "[Setting: ON]" or "[Setting: OFF]")
-						toggleAttributes.TextColor3 = Settings.Theme.Text
-						toggleAttributes.Visible = (prop.CategoryName == "Attributes")
-					else
-						local propName = prop.Name
-						local typeData = prop.ValueType
-						local typeName = typeData.Name
-						local tags = prop.Tags
-						local propObj = autoUpdateObjs[gName]
-
-						local attributeOffset = (prop.IsAttribute and 20 or 0)
-						editAttributeButton.Visible = (prop.IsAttribute and not prop.RootType)
-						toggleAttributes.Visible = false
-
-						-- Moving around the frames
-						if scaleType == 0 then
-							nameFrame.Size = UDim2.new(0,Properties.ViewWidth - leftOffset - 1,1,0)
-							valueFrame.Position = UDim2.new(0,Properties.ViewWidth,0,0)
-							valueFrame.Size = UDim2.new(0,valueWidth - attributeOffset,1,0)
-						else
-							nameFrame.Size = UDim2.new(0.5,-leftOffset - 1,1,0)
-							valueFrame.Position = UDim2.new(0.5,0,0,0)
-							valueFrame.Size = UDim2.new(0.5,-attributeOffset,1,0)
-						end
-
-						local nameArr = stringSplit(gName,".")
-						propNameBox.Text = prop.DisplayName or nameArr[#nameArr]
-						propNameBox.Font = Enum.Font.SourceSans
-						entry.BackgroundColor3 = Settings.Theme.Main2
-						valueFrame.Visible = true
-
-						expand.Visible = typeData.Category == "DataType" and Properties.ExpandableTypes[typeName] or Properties.ExpandableProps[gName]
-						propNameBox.TextColor3 = tags.ReadOnly and Settings.Theme.PlaceholderText or Settings.Theme.Text
-
-						-- Display property value
-						Properties.DisplayProp(prop,i)
-						if propObj then
-							if prop.IsAttribute then
-								propCons[#propCons+1] = getAttributeChangedSignal(propObj,prop.AttributeName):Connect(function()
-									Properties.DisplayProp(prop,i)
-								end)
-							else
-								propCons[#propCons+1] = getPropChangedSignal(propObj,propName):Connect(function()
-									Properties.DisplayProp(prop,i)
-								end)
-							end
-						end
-
-						-- Position and resize Input Box
-						local beforeVisible = valueBox.Visible
-						local inputFullName = inputProp and (inputProp.Class.."."..inputProp.Name..(inputProp.SubName or ""))
-						if gName == inputFullName then
-							nameFrame.BackgroundColor3 = Settings.Theme.ListSelection
-							nameFrame.BackgroundTransparency = 0
-							if typeData.Category == "Class" or typeData.Category == "Enum" or typeName == "BrickColor" then
-								valueFrame.BackgroundColor3 = Settings.Theme.TextBox
-								valueFrame.BackgroundTransparency = 0
-								valueBox.Visible = true
-							else
-								inputPropVisible = true
-								local scale = (scaleType == 0 and 0 or 0.5)
-								local offset = (scaleType == 0 and Properties.ViewWidth-scrollH.Index or 0)
-								local endOffset = 0
-
-								if typeName == "Color3" or typeName == "ColorSequence" then
-									offset = offset + 22
-								end
-
-								if typeName == "NumberSequence" or typeName == "ColorSequence" then
-									endOffset = 20
-								end
-
-								inputBox.Position = UDim2.new(scale,offset,0,entry.Position.Y.Offset)
-								inputBox.Size = UDim2.new(1-scale,-offset-endOffset-attributeOffset,0,22)
-								inputBox.Visible = true
-								valueBox.Visible = false
-							end
-						else
-							nameFrame.BackgroundColor3 = Settings.Theme.Main1
-							nameFrame.BackgroundTransparency = 1
-							valueFrame.BackgroundColor3 = Settings.Theme.Main1
-							valueFrame.BackgroundTransparency = 1
-							valueBox.Visible = beforeVisible
-						end
-					end
-
-					-- Expand
-					if prop.CategoryName or Properties.ExpandableTypes[prop.ValueType and prop.ValueType.Name] or Properties.ExpandableProps[gName] then
-						if Lib.CheckMouseInGui(expand) then
-							Main.MiscIcons:DisplayByKey(expand.Icon, expanded[gName] and "Collapse_Over" or "Expand_Over")
-						else
-							Main.MiscIcons:DisplayByKey(expand.Icon, expanded[gName] and "Collapse" or "Expand")
-						end
-						expand.Visible = true
-					else
-						expand.Visible = false
-					end
-				end
-				entry.Visible = true
-			else
-				entry.Visible = false
-			end
-		end
-
-		if not inputPropVisible then
-			inputBox.Visible = false
-		end
-
-		for i = maxEntries+1,#propEntries do
-			propEntries[i].Gui:Destroy()
-			propEntries[i] = nil
-			checkboxes[i] = nil
-		end
-	end
-
-	Properties.SetProp = function(prop,val,noupdate,prevAttribute)
-		local sList = Explorer.Selection.List
-		local propName = prop.Name
-		local subName = prop.SubName
-		local propClass = prop.Class
-		local typeData = prop.ValueType
-		local typeName = typeData.Name
-		local attributeName = prop.AttributeName
-		local rootTypeData = prop.RootType
-		local rootTypeName = rootTypeData and rootTypeData.Name
-		local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
-		local Vector3 = Vector3
-
-		for i = 1,#sList do
-			local node = sList[i]
-			local obj = node.Obj
-
-			if isa(obj,propClass) then
-				pcall(function()
-					local setVal = val
-					local root
-					if prop.IsAttribute then
-						root = getAttribute(obj,attributeName)
-					else
-						root = obj[propName]
-					end
-
-					if prevAttribute then
-						if prevAttribute.ValueType.Name == typeName then
-							setVal = getAttribute(obj,prevAttribute.AttributeName) or setVal
-						end
-						setAttribute(obj,prevAttribute.AttributeName,nil)
-						
-						-- ADONIS
-						Dex_RemoteEvent:InvokeServer("SetPropertyAttribute", obj, attributeName, setVal)
-					end
-
-					if rootTypeName then
-						if rootTypeName == "Vector2" then
-							setVal = Vector2.new((subName == ".X" and setVal) or root.X, (subName == ".Y" and setVal) or root.Y)
-						elseif rootTypeName == "Vector3" then
-							setVal = Vector3.new((subName == ".X" and setVal) or root.X, (subName == ".Y" and setVal) or root.Y, (subName == ".Z" and setVal) or root.Z)
-						elseif rootTypeName == "UDim" then
-							setVal = UDim.new((subName == ".Scale" and setVal) or root.Scale, (subName == ".Offset" and setVal) or root.Offset)
-						elseif rootTypeName == "UDim2" then
-							local rootX,rootY = root.X,root.Y
-							local X_UDim = (subName == ".X" and setVal) or UDim.new((subName == ".X.Scale" and setVal) or rootX.Scale, (subName == ".X.Offset" and setVal) or rootX.Offset)
-							local Y_UDim = (subName == ".Y" and setVal) or UDim.new((subName == ".Y.Scale" and setVal) or rootY.Scale, (subName == ".Y.Offset" and setVal) or rootY.Offset)
-							setVal = UDim2.new(X_UDim,Y_UDim)
-						elseif rootTypeName == "CFrame" then
-							local rootPos,rootRight,rootUp,rootLook = root.Position,root.RightVector,root.UpVector,root.LookVector
-							local pos = (subName == ".Position" and setVal) or Vector3.new((subName == ".Position.X" and setVal) or rootPos.X, (subName == ".Position.Y" and setVal) or rootPos.Y, (subName == ".Position.Z" and setVal) or rootPos.Z)
-							local rightV = (subName == ".RightVector" and setVal) or Vector3.new((subName == ".RightVector.X" and setVal) or rootRight.X, (subName == ".RightVector.Y" and setVal) or rootRight.Y, (subName == ".RightVector.Z" and setVal) or rootRight.Z)
-							local upV = (subName == ".UpVector" and setVal) or Vector3.new((subName == ".UpVector.X" and setVal) or rootUp.X, (subName == ".UpVector.Y" and setVal) or rootUp.Y, (subName == ".UpVector.Z" and setVal) or rootUp.Z)
-							local lookV = (subName == ".LookVector" and setVal) or Vector3.new((subName == ".LookVector.X" and setVal) or rootLook.X, (subName == ".RightVector.Y" and setVal) or rootLook.Y, (subName == ".RightVector.Z" and setVal) or rootLook.Z)
-							setVal = CFrame.fromMatrix(pos,rightV,upV,-lookV)
-						elseif rootTypeName == "Rect" then
-							local rootMin,rootMax = root.Min,root.Max
-							local min = Vector2.new((subName == ".Min.X" and setVal) or rootMin.X, (subName == ".Min.Y" and setVal) or rootMin.Y)
-							local max = Vector2.new((subName == ".Max.X" and setVal) or rootMax.X, (subName == ".Max.Y" and setVal) or rootMax.Y)
-							setVal = Rect.new(min,max)
-						elseif rootTypeName == "PhysicalProperties" then
-							local rootProps = PhysicalProperties.new(obj.Material)
-							local density = (subName == ".Density" and setVal) or (root and root.Density) or rootProps.Density
-							local friction = (subName == ".Friction" and setVal) or (root and root.Friction) or rootProps.Friction
-							local elasticity = (subName == ".Elasticity" and setVal) or (root and root.Elasticity) or rootProps.Elasticity
-							local frictionWeight = (subName == ".FrictionWeight" and setVal) or (root and root.FrictionWeight) or rootProps.FrictionWeight
-							local elasticityWeight = (subName == ".ElasticityWeight" and setVal) or (root and root.ElasticityWeight) or rootProps.ElasticityWeight
-							setVal = PhysicalProperties.new(density,friction,elasticity,frictionWeight,elasticityWeight)
-						elseif rootTypeName == "Ray" then
-							local rootOrigin,rootDirection = root.Origin,root.Direction
-							local origin = (subName == ".Origin" and setVal) or Vector3.new((subName == ".Origin.X" and setVal) or rootOrigin.X, (subName == ".Origin.Y" and setVal) or rootOrigin.Y, (subName == ".Origin.Z" and setVal) or rootOrigin.Z)
-							local direction = (subName == ".Direction" and setVal) or Vector3.new((subName == ".Direction.X" and setVal) or rootDirection.X, (subName == ".Direction.Y" and setVal) or rootDirection.Y, (subName == ".Direction.Z" and setVal) or rootDirection.Z)
-							setVal = Ray.new(origin,direction)
-						elseif rootTypeName == "Faces" then
-							local faces = {}
-							local faceList = {"Back","Bottom","Front","Left","Right","Top"}
-							for _,face in pairs(faceList) do
-								local val
-								if subName == "."..face then
-									val = setVal
-								else
-									val = root[face]
-								end
-								if val then faces[#faces+1] = Enum.NormalId[face] end
-							end
-							setVal = Faces.new(unpack(faces))
-						elseif rootTypeName == "Axes" then
-							local axes = {}
-							local axesList = {"X","Y","Z"}
-							for _,axe in pairs(axesList) do
-								local val
-								if subName == "."..axe then
-									val = setVal
-								else
-									val = root[axe]
-								end
-								if val then axes[#axes+1] = Enum.Axis[axe] end
-							end
-							setVal = Axes.new(unpack(axes))
-						elseif rootTypeName == "NumberRange" then
-							setVal = NumberRange.new(subName == ".Min" and setVal or root.Min, subName == ".Max" and setVal or root.Max)
-						end
-					end
-
-					if typeName == "PhysicalProperties" and setVal then
-						setVal = root or PhysicalProperties.new(obj.Material)
-					end
-
-					if prop.IsAttribute then
-						setAttribute(obj,attributeName,setVal)
-						
-						-- ADONIS
-						Dex_RemoteEvent:InvokeServer("SetPropertyAttribute", obj, attributeName, setVal)
-					else
-						obj[propName] = setVal
-						
-						-- ADONIS
-						Dex_RemoteEvent:InvokeServer("SetProperty", obj, propName, setVal)
-					end
-				end)
-			end
-		end
-
-		if not noupdate then
-			Properties.ComputeConflicts(prop)
-		end
-	end
-
-	Properties.InitInputBox = function()
-		inputBox = create({
-			{1,"Frame",{BackgroundColor3=Color3.new(0.14901961386204,0.14901961386204,0.14901961386204),BorderSizePixel=0,Name="InputBox",Size=UDim2.new(0,200,0,22),Visible=false,ZIndex=2,}},
-			{2,"TextBox",{BackgroundColor3=Color3.new(0.17647059261799,0.17647059261799,0.17647059261799),BackgroundTransparency=1,BorderColor3=Color3.new(0.062745101749897,0.51764708757401,1),BorderSizePixel=0,ClearTextOnFocus=false,Font=3,Parent={1},PlaceholderColor3=Color3.new(0.69803923368454,0.69803923368454,0.69803923368454),Position=UDim2.new(0,3,0,0),Size=UDim2.new(1,-6,1,0),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextXAlignment=0,ZIndex=2,}},
-		})
-		inputTextBox = inputBox.TextBox
-		inputBox.BackgroundColor3 = Settings.Theme.TextBox
-		inputBox.Parent = Properties.Window.GuiElems.Content.List
-
-		inputTextBox.FocusLost:Connect(function()
-			if not inputProp then return end
-
-			local prop = inputProp
-			inputProp = nil
-			local val = Properties.StringToValue(prop,inputTextBox.Text)
-			if val then Properties.SetProp(prop,val) else Properties.Refresh() end
-		end)
-
-		inputTextBox.Focused:Connect(function()
-			inputTextBox.SelectionStart = 1
-			inputTextBox.CursorPosition = #inputTextBox.Text + 1
-		end)
-
-		Lib.ViewportTextBox.convert(inputTextBox)
-	end
-
-	Properties.SetInputProp = function(prop,entryIndex,special)
-		local typeData = prop.ValueType
-		local typeName = typeData.Name
-		local fullName = prop.Class.."."..prop.Name..(prop.SubName or "")
-		local propObj = autoUpdateObjs[fullName]
-		local propVal = Properties.GetPropVal(prop,propObj)
-
-		if prop.Tags.ReadOnly then return end
-
-		inputProp = prop
-		if special then
-			if special == "color" then
-				if typeName == "Color3" then
-					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
-					Properties.DisplayColorEditor(prop,propVal)
-				elseif typeName == "BrickColor" then
-					Properties.DisplayBrickColorEditor(prop,entryIndex,propVal)
-				elseif typeName == "ColorSequence" then
-					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
-					Properties.DisplayColorSequenceEditor(prop,propVal)
-				end
-			elseif special == "right" then
-				if typeName == "NumberSequence" then
-					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
-					Properties.DisplayNumberSequenceEditor(prop,propVal)
-				elseif typeName == "ColorSequence" then
-					inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
-					Properties.DisplayColorSequenceEditor(prop,propVal)
-				end
-			end
-		else
-			if Properties.IsTextEditable(prop) then
-				-- TODO: A setting maybe.
-				--inputTextBox.Text = propVal and Properties.ValueToString(prop,propVal) or ""
-				local rawStr = propVal and Properties.ValueToString(prop,propVal) or ""
-				inputTextBox.Text = rawStr:gsub("-?%d+%.%d+",function(num)
-					return tostring(tonumber(("%."..Settings.Properties.NumberRounding.."f"):format(num)))
-				end)
-				inputTextBox:CaptureFocus()
-			elseif typeData.Category == "Enum" then
-				Properties.DisplayEnumDropdown(entryIndex)
-			elseif typeName == "BrickColor" then
-				Properties.DisplayBrickColorEditor(prop,entryIndex,propVal)
-			end
-		end
-		Properties.Refresh()
-	end
-
-	Properties.InitSearch = function()
-		local searchBox = Properties.GuiElems.ToolBar.SearchFrame.SearchBox
-
-		Lib.ViewportTextBox.convert(searchBox)
-
-		searchBox:GetPropertyChangedSignal("Text"):Connect(function()
-			Properties.SearchText = searchBox.Text
-			Properties.Update()
-			Properties.Refresh()
-		end)
-	end
-
-	Properties.InitEntryStuff = function()
-		Properties.EntryTemplate = create({
-			{1,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.17647059261799,0.17647059261799,0.17647059261799),BackgroundTransparency=0.2,BorderColor3=Color3.new(0.1294117718935,0.1294117718935,0.1294117718935),Font=3,Name="Entry",Position=UDim2.new(0,1,0,1),Size=UDim2.new(0,250,0,22),Text="",TextSize=14,}},
-			{2,"Frame",{BackgroundColor3=Color3.new(0.04313725605607,0.35294118523598,0.68627452850342),BackgroundTransparency=1,BorderColor3=Color3.new(0.33725491166115,0.49019610881805,0.73725491762161),BorderSizePixel=0,Name="NameFrame",Parent={1},Position=UDim2.new(0,20,0,0),Size=UDim2.new(1,-40,1,0),}},
-			{3,"TextLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Font=3,Name="PropName",Parent={2},Position=UDim2.new(0,2,0,0),Size=UDim2.new(1,-2,1,0),Text="Anchored",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,TextTruncate=1,TextXAlignment=0,}},
-			{4,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,ClipsDescendants=true,Font=3,Name="Expand",Parent={2},Position=UDim2.new(0,-20,0,1),Size=UDim2.new(0,20,0,20),Text="",TextSize=14,Visible=false,}},
-			{5,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5642383285",ImageRectOffset=Vector2.new(144,16),ImageRectSize=Vector2.new(16,16),Name="Icon",Parent={4},Position=UDim2.new(0,2,0,2),ScaleType=4,Size=UDim2.new(0,16,0,16),}},
-			{6,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=4,Name="ToggleAttributes",Parent={2},Position=UDim2.new(1,-85,0,0),Size=UDim2.new(0,85,0,22),Text="[SETTING: OFF]",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,Visible=false,}},
-			{7,"Frame",{BackgroundColor3=Color3.new(0.04313725605607,0.35294118523598,0.68627452850342),BackgroundTransparency=1,BorderColor3=Color3.new(0.33725491166115,0.49019607901573,0.73725491762161),BorderSizePixel=0,Name="ValueFrame",Parent={1},Position=UDim2.new(1,-100,0,0),Size=UDim2.new(0,80,1,0),}},
-			{8,"Frame",{BackgroundColor3=Color3.new(0.14117647707462,0.14117647707462,0.14117647707462),BorderColor3=Color3.new(0.33725491166115,0.49019610881805,0.73725491762161),BorderSizePixel=0,Name="Line",Parent={7},Position=UDim2.new(0,-1,0,0),Size=UDim2.new(0,1,1,0),}},
-			{9,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="ColorButton",Parent={7},Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
-			{10,"Frame",{BackgroundColor3=Color3.new(1,1,1),BorderColor3=Color3.new(0,0,0),Name="ColorPreview",Parent={9},Position=UDim2.new(0,5,0,6),Size=UDim2.new(0,10,0,10),}},
-			{11,"UIGradient",{Parent={10},}},
-			{12,"Frame",{BackgroundTransparency=1,Name="EnumArrow",Parent={7},Position=UDim2.new(1,-16,0,3),Size=UDim2.new(0,16,0,16),Visible=false,}},
-			{13,"Frame",{BackgroundColor3=Color3.new(0.86274510622025,0.86274510622025,0.86274510622025),BorderSizePixel=0,Parent={12},Position=UDim2.new(0,8,0,9),Size=UDim2.new(0,1,0,1),}},
-			{14,"Frame",{BackgroundColor3=Color3.new(0.86274510622025,0.86274510622025,0.86274510622025),BorderSizePixel=0,Parent={12},Position=UDim2.new(0,7,0,8),Size=UDim2.new(0,3,0,1),}},
-			{15,"Frame",{BackgroundColor3=Color3.new(0.86274510622025,0.86274510622025,0.86274510622025),BorderSizePixel=0,Parent={12},Position=UDim2.new(0,6,0,7),Size=UDim2.new(0,5,0,1),}},
-			{16,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Font=3,Name="ValueBox",Parent={7},Position=UDim2.new(0,4,0,0),Size=UDim2.new(1,-8,1,0),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,TextTruncate=1,TextXAlignment=0,}},
-			{17,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="RightButton",Parent={7},Position=UDim2.new(1,-20,0,0),Size=UDim2.new(0,20,0,22),Text="...",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
-			{18,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="SettingsButton",Parent={7},Position=UDim2.new(1,-20,0,0),Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
-			{19,"Frame",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Name="SoundPreview",Parent={7},Size=UDim2.new(1,0,1,0),Visible=false,}},
-			{20,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="ControlButton",Parent={19},Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,}},
-			{21,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5642383285",ImageRectOffset=Vector2.new(144,16),ImageRectSize=Vector2.new(16,16),Name="Icon",Parent={20},Position=UDim2.new(0,2,0,3),ScaleType=4,Size=UDim2.new(0,16,0,16),}},
-			{22,"Frame",{BackgroundColor3=Color3.new(0.3137255012989,0.3137255012989,0.3137255012989),BorderSizePixel=0,Name="TimeLine",Parent={19},Position=UDim2.new(0,26,0.5,-1),Size=UDim2.new(1,-34,0,2),}},
-			{23,"Frame",{BackgroundColor3=Color3.new(0.2352941185236,0.2352941185236,0.2352941185236),BorderColor3=Color3.new(0.1294117718935,0.1294117718935,0.1294117718935),Name="Slider",Parent={22},Position=UDim2.new(0,-4,0,-8),Size=UDim2.new(0,8,0,18),}},
-			{24,"TextButton",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="EditAttributeButton",Parent={1},Position=UDim2.new(1,-20,0,0),Size=UDim2.new(0,20,0,22),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,}},
-			{25,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5034718180",ImageTransparency=0.20000000298023,Name="Icon",Parent={24},Position=UDim2.new(0,2,0,3),Size=UDim2.new(0,16,0,16),}},
-			{26,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.2352941185236,0.2352941185236,0.2352941185236),BorderSizePixel=0,Font=3,Name="RowButton",Parent={1},Size=UDim2.new(1,0,1,0),Text="Add Attribute",TextColor3=Color3.new(1,1,1),TextSize=14,TextTransparency=0.10000000149012,Visible=false,}},
-		})
-
-		local fullNameFrame = Lib.Frame.new()
-		local label = Lib.Label.new()
-		label.Parent = fullNameFrame.Gui
-		label.Position = UDim2.new(0,2,0,0)
-		label.Size = UDim2.new(1,-4,1,0)
-		fullNameFrame.Visible = false
-		fullNameFrame.Parent = window.Gui
-
-		Properties.FullNameFrame = fullNameFrame
-		Properties.FullNameFrameAttach = Lib.AttachTo(fullNameFrame)
-	end
-
-	Properties.Init = function() -- TODO: MAKE BETTER
-		local guiItems = create({
-			{1,"Folder",{Name="Items",}},
-			{2,"Frame",{BackgroundColor3=Color3.new(0.20392157137394,0.20392157137394,0.20392157137394),BorderSizePixel=0,Name="ToolBar",Parent={1},Size=UDim2.new(1,0,0,22),}},
-			{3,"Frame",{BackgroundColor3=Color3.new(0.14901961386204,0.14901961386204,0.14901961386204),BorderColor3=Color3.new(0.1176470592618,0.1176470592618,0.1176470592618),BorderSizePixel=0,Name="SearchFrame",Parent={2},Position=UDim2.new(0,3,0,1),Size=UDim2.new(1,-6,0,18),}},
-			{4,"TextBox",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,ClearTextOnFocus=false,Font=3,Name="SearchBox",Parent={3},PlaceholderColor3=Color3.new(0.39215689897537,0.39215689897537,0.39215689897537),PlaceholderText="Search properties",Position=UDim2.new(0,4,0,0),Size=UDim2.new(1,-24,0,18),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextXAlignment=0,}},
-			{5,"UICorner",{CornerRadius=UDim.new(0,2),Parent={3},}},
-			{6,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.12549020349979,0.12549020349979,0.12549020349979),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="Reset",Parent={3},Position=UDim2.new(1,-17,0,1),Size=UDim2.new(0,16,0,16),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,}},
-			{7,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5034718129",ImageColor3=Color3.new(0.39215686917305,0.39215686917305,0.39215686917305),Parent={6},Size=UDim2.new(0,16,0,16),}},
-			{8,"TextButton",{AutoButtonColor=false,BackgroundColor3=Color3.new(0.12549020349979,0.12549020349979,0.12549020349979),BackgroundTransparency=1,BorderSizePixel=0,Font=3,Name="Refresh",Parent={2},Position=UDim2.new(1,-20,0,1),Size=UDim2.new(0,18,0,18),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,Visible=false,}},
-			{9,"ImageLabel",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,Image="rbxassetid://5642310344",Parent={8},Position=UDim2.new(0,3,0,3),Size=UDim2.new(0,12,0,12),}},
-			{10,"Frame",{BackgroundColor3=Color3.new(0.15686275064945,0.15686275064945,0.15686275064945),BorderSizePixel=0,Name="ScrollCorner",Parent={1},Position=UDim2.new(1,-16,1,-16),Size=UDim2.new(0,16,0,16),Visible=false,}},
-			{11,"Frame",{BackgroundColor3=Color3.new(1,1,1),BackgroundTransparency=1,ClipsDescendants=true,Name="List",Parent={1},Position=UDim2.new(0,0,0,23),Size=UDim2.new(1,0,1,-23),}},
-		})
-
-		-- Vars
-		categoryOrder =  API.CategoryOrder
-		for category,_ in next,categoryOrder do
-			if not Properties.CollapsedCategories[category] then
-				expanded["CAT_"..category] = true
-			end
-		end
-		expanded["Sound.SoundId"] = true
-
-		-- Init window
-		window = Lib.Window.new()
-		Properties.Window = window
-		window:SetTitle("Properties")
-
-		toolBar = guiItems.ToolBar
-		propsFrame = guiItems.List
-
-		Properties.GuiElems.ToolBar = toolBar
-		Properties.GuiElems.PropsFrame = propsFrame
-
-		Properties.InitEntryStuff()
-
-		-- Window events
-		window.GuiElems.Main:GetPropertyChangedSignal("AbsoluteSize"):Connect(function()
-			if Properties.Window:IsContentVisible() then
-				Properties.UpdateView()
-				Properties.Refresh()
-			end
-		end)
-		window.OnActivate:Connect(function()
-			Properties.UpdateView()
-			Properties.Update()
-			Properties.Refresh()
-		end)
-		window.OnRestore:Connect(function()
-			Properties.UpdateView()
-			Properties.Update()
-			Properties.Refresh()
-		end)
-
-		-- Init scrollbars
-		scrollV = Lib.ScrollBar.new()		
-		scrollV.WheelIncrement = 3
-		scrollV.Gui.Position = UDim2.new(1,-16,0,23)
-		scrollV:SetScrollFrame(propsFrame)
-		scrollV.Scrolled:Connect(function()
-			Properties.Index = scrollV.Index
-			Properties.Refresh()
-		end)
-
-		scrollH = Lib.ScrollBar.new(true)
-		scrollH.Increment = 5
-		scrollH.WheelIncrement = 20
-		scrollH.Gui.Position = UDim2.new(0,0,1,-16)
-		scrollH.Scrolled:Connect(function()
-			Properties.Refresh()
-		end)
-
-		-- Setup Gui
-		window.GuiElems.Line.Position = UDim2.new(0,0,0,22)
-		toolBar.Parent = window.GuiElems.Content
-		propsFrame.Parent = window.GuiElems.Content
-		guiItems.ScrollCorner.Parent = window.GuiElems.Content
-		scrollV.Gui.Parent = window.GuiElems.Content
-		scrollH.Gui.Parent = window.GuiElems.Content
-		Properties.InitInputBox()
-		Properties.InitSearch()
-	end
-
-	return Properties
-end
-
--- TODO: Remove when open source
-if gethsfuncs then
-	_G.moduleData = {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-else
-	return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-end]]></ProtectedString>
-							<int64 name="SourceAssetId">-1</int64>
-							<BinaryString name="Tags"></BinaryString>
-						</Properties>
-					</Item>
-					<Item class="ModuleScript" referent="RBX45C235FD54584E47B79FBBC7BCDE251A">
-						<Properties>
-							<BinaryString name="AttributesSerialize"></BinaryString>
-							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-							<bool name="DefinesCapabilities">false</bool>
-							<Content name="LinkedSource"><null></null></Content>
-							<string name="Name">SettingsEditor</string>
-							<string name="ScriptGuid">{C07EC65A-181C-473C-8839-D90370715008}</string>
-							<ProtectedString name="Source"><![CDATA[--[[
-	Settings Module
-	
-	The Module to configure settings
-]]
-
--- ADONIS
-local ReplicatedStorage = game:GetService("ReplicatedStorage");
-local Dex_RemoteEvent = ReplicatedStorage:WaitForChild("NewDex_Event");
-
-
--- Common Locals
-local Main,Lib,Apps,Settings -- Main Containers
-local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
-local API,RMD,env,service,plr,create,createSimple -- Main Locals
-
-local function initDeps(data)
-	Main = data.Main
-	Lib = data.Lib
-	Apps = data.Apps
-	Settings = data.Settings
-
-	API = data.API
-	RMD = data.RMD
-	env = data.env
-	service = data.service
-	plr = data.plr
-	create = data.create
-	createSimple = data.createSimple
-end
-
-local function initAfterMain()
-	Explorer = Apps.Explorer
-	Properties = Apps.Properties
-	ScriptViewer = Apps.ScriptViewer
-	Notebook = Apps.Notebook
-end
-
-
-local function main()
-	local SettingsEditor = {}
-	
-	local scrollV, scrollH
-	local settingsListFrame
-	local expanded, viewList = {}, {}
-	
-	local topOffset = 0 --23 for that search bar thingy
-	
-	local scrollbarThickness = 6 -- for layout
-	
-	SettingsEditor.SettingsInfo = require(script.settingsInfo)
-	-- Pass Vargs
-	SettingsEditor.SettingsInfo.initDeps({
-		Main = Main,
-		Lib = Lib,
-		Apps = Apps,
-		Settings = Settings
-	})
-	
-	
-	SettingsEditor.EntryTemplate = function()
-		local Entry = Instance.new("TextButton")
-		Entry.Name = "Entry"
-		Entry.Size = UDim2.new(1, 0, 0, 22)
-		Entry.BorderColor3 = Color3.fromRGB(33, 33, 33)
-		Entry.BackgroundTransparency = 0.2
-		Entry.Position = UDim2.new(0, 1, 0, 1)
-		Entry.BackgroundColor3 = Color3.fromRGB(45, 45, 45)
-		Entry.AutoButtonColor = false
-		Entry.FontSize = Enum.FontSize.Size14
-		Entry.TextSize = 14
-		Entry.Text = ""
-		Entry.Font = Enum.Font.SourceSans
-
-		local NameFrame = Instance.new("Frame")
-		NameFrame.Name = "NameFrame"
-		NameFrame.Size = UDim2.new(1, -40, 1, 0)
-		NameFrame.BorderColor3 = Color3.fromRGB(86, 125, 188)
-		NameFrame.BackgroundTransparency = 1
-		NameFrame.Position = UDim2.new(0, 20, 0, 0)
-		NameFrame.BorderSizePixel = 0
-		NameFrame.BackgroundColor3 = Color3.fromRGB(11, 90, 175)
-		NameFrame.Parent = Entry
-
-		local PropName = Instance.new("TextLabel")
-		PropName.Name = "PropName"
-		PropName.Size = UDim2.new(1, -2, 1, 0)
-		PropName.BackgroundTransparency = 1
-		PropName.Position = UDim2.new(0, 2, 0, 0)
-		PropName.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		PropName.FontSize = Enum.FontSize.Size14
-		PropName.TextTruncate = Enum.TextTruncate.AtEnd
-		PropName.TextSize = 14
-		PropName.TextColor3 = Color3.fromRGB(255, 255, 255)
-		PropName.Text = "Anchored"
-		PropName.Font = Enum.Font.SourceSans
-		PropName.TextTransparency = 0.1
-		PropName.TextXAlignment = Enum.TextXAlignment.Left
-		PropName.Parent = NameFrame
-
-		local Expand = Instance.new("TextButton")
-		Expand.Name = "Expand"
-		Expand.Visible = false
-		Expand.Size = UDim2.new(0, 20, 0, 20)
-		Expand.ClipsDescendants = true
-		Expand.BackgroundTransparency = 1
-		Expand.Position = UDim2.new(0, -20, 0, 1)
-		Expand.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		Expand.FontSize = Enum.FontSize.Size14
-		Expand.TextSize = 14
-		Expand.Text = ""
-		Expand.Font = Enum.Font.SourceSans
-		Expand.Parent = NameFrame
-
-		local Icon = Instance.new("ImageLabel")
-		Icon.Name = "Icon"
-		Icon.Size = UDim2.new(0, 16, 0, 16)
-		Icon.BackgroundTransparency = 1
-		Icon.Position = UDim2.new(0, 2, 0, 2)
-		Icon.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		Icon.ScaleType = Enum.ScaleType.Crop
-		Icon.ImageRectOffset = Vector2.new(144, 16)
-		Icon.ImageRectSize = Vector2.new(16, 16)
-		Icon.Image = "rbxassetid://5642383285"
-		Icon.Parent = Expand
-
-		local ToggleAttributes = Instance.new("TextButton")
-		ToggleAttributes.Name = "ToggleAttributes"
-		ToggleAttributes.Visible = false
-		ToggleAttributes.Size = UDim2.new(0, 85, 0, 22)
-		ToggleAttributes.BackgroundTransparency = 1
-		ToggleAttributes.Position = UDim2.new(1, -85, 0, 0)
-		ToggleAttributes.BorderSizePixel = 0
-		ToggleAttributes.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		ToggleAttributes.FontSize = Enum.FontSize.Size14
-		ToggleAttributes.TextSize = 14
-		ToggleAttributes.TextColor3 = Color3.fromRGB(255, 255, 255)
-		ToggleAttributes.Text = "[SETTING: OFF]"
-		ToggleAttributes.Font = Enum.Font.SourceSansBold
-		ToggleAttributes.TextTransparency = 0.1
-		ToggleAttributes.Parent = NameFrame
-
-		local ValueFrame = Instance.new("Frame")
-		ValueFrame.Name = "ValueFrame"
-		ValueFrame.Size = UDim2.new(0, 80, 1, 0)
-		ValueFrame.BorderColor3 = Color3.fromRGB(86, 125, 188)
-		ValueFrame.BackgroundTransparency = 1
-		ValueFrame.Position = UDim2.new(1, -100, 0, 0)
-		ValueFrame.BorderSizePixel = 0
-		ValueFrame.BackgroundColor3 = Color3.fromRGB(11, 90, 175)
-		ValueFrame.Parent = Entry
-
-		local Line = Instance.new("Frame")
-		Line.Name = "Line"
-		Line.Size = UDim2.new(0, 1, 1, 0)
-		Line.BorderColor3 = Color3.fromRGB(86, 125, 188)
-		Line.Position = UDim2.new(0, -1, 0, 0)
-		Line.BorderSizePixel = 0
-		Line.BackgroundColor3 = Color3.fromRGB(36, 36, 36)
-		Line.Parent = ValueFrame
-
-		local EnumArrow = Instance.new("Frame")
-		EnumArrow.Name = "EnumArrow"
-		EnumArrow.Visible = false
-		EnumArrow.Size = UDim2.new(0, 16, 0, 16)
-		EnumArrow.BackgroundTransparency = 1
-		EnumArrow.Position = UDim2.new(1, -16, 0, 3)
-		EnumArrow.Parent = ValueFrame
-
-		local Frame = Instance.new("Frame")
-		Frame.Size = UDim2.new(0, 1, 0, 1)
-		Frame.Position = UDim2.new(0, 8, 0, 9)
-		Frame.BorderSizePixel = 0
-		Frame.BackgroundColor3 = Color3.fromRGB(220, 220, 220)
-		Frame.Parent = EnumArrow
-
-		local Frame1 = Instance.new("Frame")
-		Frame1.Size = UDim2.new(0, 3, 0, 1)
-		Frame1.Position = UDim2.new(0, 7, 0, 8)
-		Frame1.BorderSizePixel = 0
-		Frame1.BackgroundColor3 = Color3.fromRGB(220, 220, 220)
-		Frame1.Parent = EnumArrow
-
-		local Frame2 = Instance.new("Frame")
-		Frame2.Size = UDim2.new(0, 5, 0, 1)
-		Frame2.Position = UDim2.new(0, 6, 0, 7)
-		Frame2.BorderSizePixel = 0
-		Frame2.BackgroundColor3 = Color3.fromRGB(220, 220, 220)
-		Frame2.Parent = EnumArrow
-
-		local ValueBox = Instance.new("TextButton")
-		ValueBox.Name = "ValueBox"
-		ValueBox.Size = UDim2.new(1, -8, 1, 0)
-		ValueBox.BackgroundTransparency = 1
-		ValueBox.Position = UDim2.new(0, 4, 0, 0)
-		ValueBox.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		ValueBox.FontSize = Enum.FontSize.Size14
-		ValueBox.TextTruncate = Enum.TextTruncate.AtEnd
-		ValueBox.TextSize = 14
-		ValueBox.TextColor3 = Color3.fromRGB(255, 255, 255)
-		ValueBox.Text = ""
-		ValueBox.Font = Enum.Font.SourceSans
-		ValueBox.TextTransparency = 0.1
-		ValueBox.TextXAlignment = Enum.TextXAlignment.Left
-		ValueBox.Parent = ValueFrame
-
-		local RightButton = Instance.new("TextButton")
-		RightButton.Name = "RightButton"
-		RightButton.Visible = false
-		RightButton.Size = UDim2.new(0, 20, 0, 22)
-		RightButton.BackgroundTransparency = 1
-		RightButton.Position = UDim2.new(1, -20, 0, 0)
-		RightButton.BorderSizePixel = 0
-		RightButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		RightButton.FontSize = Enum.FontSize.Size14
-		RightButton.TextSize = 14
-		RightButton.TextColor3 = Color3.fromRGB(255, 255, 255)
-		RightButton.Text = "..."
-		RightButton.Font = Enum.Font.SourceSans
-		RightButton.Parent = ValueFrame
-
-		local SettingsButton = Instance.new("TextButton")
-		SettingsButton.Name = "SettingsButton"
-		SettingsButton.Visible = false
-		SettingsButton.Size = UDim2.new(0, 20, 0, 22)
-		SettingsButton.BackgroundTransparency = 1
-		SettingsButton.Position = UDim2.new(1, -20, 0, 0)
-		SettingsButton.BorderSizePixel = 0
-		SettingsButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		SettingsButton.FontSize = Enum.FontSize.Size14
-		SettingsButton.TextSize = 14
-		SettingsButton.TextColor3 = Color3.fromRGB(255, 255, 255)
-		SettingsButton.Text = ""
-		SettingsButton.Font = Enum.Font.SourceSans
-		SettingsButton.Parent = ValueFrame
-
-		local SoundPreview = Instance.new("Frame")
-		SoundPreview.Name = "SoundPreview"
-		SoundPreview.Visible = false
-		SoundPreview.Size = UDim2.new(1, 0, 1, 0)
-		SoundPreview.BackgroundTransparency = 1
-		SoundPreview.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		SoundPreview.Parent = ValueFrame
-
-		local ControlButton = Instance.new("TextButton")
-		ControlButton.Name = "ControlButton"
-		ControlButton.Size = UDim2.new(0, 20, 0, 22)
-		ControlButton.BackgroundTransparency = 1
-		ControlButton.BorderSizePixel = 0
-		ControlButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		ControlButton.FontSize = Enum.FontSize.Size14
-		ControlButton.TextSize = 14
-		ControlButton.TextColor3 = Color3.fromRGB(255, 255, 255)
-		ControlButton.Text = ""
-		ControlButton.Font = Enum.Font.SourceSans
-		ControlButton.Parent = SoundPreview
-
-		local Icon1 = Instance.new("ImageLabel")
-		Icon1.Name = "Icon"
-		Icon1.Size = UDim2.new(0, 16, 0, 16)
-		Icon1.BackgroundTransparency = 1
-		Icon1.Position = UDim2.new(0, 2, 0, 3)
-		Icon1.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		Icon1.ScaleType = Enum.ScaleType.Crop
-		Icon1.ImageRectOffset = Vector2.new(144, 16)
-		Icon1.ImageRectSize = Vector2.new(16, 16)
-		Icon1.Image = "rbxassetid://5642383285"
-		Icon1.Parent = ControlButton
-
-		local TimeLine = Instance.new("Frame")
-		TimeLine.Name = "TimeLine"
-		TimeLine.Size = UDim2.new(1, -34, 0, 2)
-		TimeLine.Position = UDim2.new(0, 26, 0.5, -1)
-		TimeLine.BorderSizePixel = 0
-		TimeLine.BackgroundColor3 = Color3.fromRGB(80, 80, 80)
-		TimeLine.Parent = SoundPreview
-
-		local Slider = Instance.new("Frame")
-		Slider.Name = "Slider"
-		Slider.Size = UDim2.new(0, 8, 0, 18)
-		Slider.BorderColor3 = Color3.fromRGB(33, 33, 33)
-		Slider.Position = UDim2.new(0, -4, 0, -8)
-		Slider.BackgroundColor3 = Color3.fromRGB(60, 60, 60)
-		Slider.Parent = TimeLine
-
-		local InfoButton = Instance.new("TextButton")
-		InfoButton.Name = "InfoButton"
-		InfoButton.Size = UDim2.new(0, 20, 0, 22)
-		InfoButton.BackgroundTransparency = 1
-		InfoButton.Position = UDim2.new(1, -20, 0, 0)
-		InfoButton.BorderSizePixel = 0
-		InfoButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		InfoButton.FontSize = Enum.FontSize.Size14
-		InfoButton.TextSize = 14
-		InfoButton.TextColor3 = Color3.fromRGB(255, 255, 255)
-		InfoButton.Text = ""
-		InfoButton.Font = Enum.Font.SourceSans
-		InfoButton.Parent = Entry
-
-		local Icon2 = Instance.new("ImageLabel")
-		Icon2.Name = "Icon"
-		Icon2.Size = UDim2.new(0, 16, 0, 16)
-		Icon2.BackgroundTransparency = 1
-		Icon2.Position = UDim2.new(0, 2, 0, 3)
-		Icon2.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		Icon2.ImageTransparency = 0.2
-		Icon2.Image = "rbxassetid://6578933307"
-		Icon2.Parent = InfoButton
-		
-		return Entry
-	end
-	
-	
-	SettingsEditor.StringToValue = function(settingInfo, str)
-		local typeName = settingInfo.typeName
-		
-		-- For numbers and stuff
-		if Apps.Properties.TypeNameConvert[typeName] then
-			typeName = Apps.Properties.TypeNameConvert[typeName]
-		end
-		
-
-		if typeName == "string" or typeName == "Content" then
-			return str
-		elseif Apps.Properties.ToNumberTypes[typeName] then
-			return tonumber(str)
-		elseif typeName == "Vector2" then
-			local vals = str:split(",")
-			local x,y = tonumber(vals[1]),tonumber(vals[2])
-			if x and y and #vals >= 2 then return Vector2.new(x,y) end
-		elseif typeName == "Vector3" then
-			local vals = str:split(",")
-			local x,y,z = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3])
-			if x and y and z and #vals >= 3 then return Vector3.new(x,y,z) end
-		elseif typeName == "UDim" then
-			local vals = str:split(",")
-			local scale,offset = tonumber(vals[1]),tonumber(vals[2])
-			if scale and offset and #vals >= 2 then return UDim.new(scale,offset) end
-		elseif typeName == "UDim2" then
-			local vals = str:gsub("[{}]",""):split(",")
-			local xScale,xOffset,yScale,yOffset = tonumber(vals[1]),tonumber(vals[2]),tonumber(vals[3]),tonumber(vals[4])
-			if xScale and xOffset and yScale and yOffset and #vals >= 4 then return UDim2.new(xScale,xOffset,yScale,yOffset) end
-		elseif typeName == "CFrame" then
-			local vals = str:split(",")
-			local s,result = pcall(CFrame.new,unpack(vals))
-			if s and #vals >= 12 then return result end
-		elseif typeName == "Rect" then
-			local vals = str:split(",")
-			local s,result = pcall(Rect.new,unpack(vals))
-			if s and #vals >= 4 then return result end
-		elseif typeName == "Ray" then
-			local vals = str:gsub("[{}]",""):split(",")
-			local s,origin = pcall(Vector3.new,unpack(vals,1,3))
-			local s2,direction = pcall(Vector3.new,unpack(vals,4,6))
-			if s and s2 and #vals >= 6 then return Ray.new(origin,direction) end
-		elseif typeName == "NumberRange" then
-			local vals = str:split(",")
-			local s,result = pcall(NumberRange.new,unpack(vals))
-			if s and #vals >= 1 then return result end
-		elseif typeName == "Color3" then
-			local vals = str:gsub("[{}]",""):split(",")
-			local s,result = pcall(Color3.fromRGB,unpack(vals))
-			if s and #vals >= 3 then return result end
-		end
-
-		return nil
-	end
-	
-	SettingsEditor.ValueToString = function(val)
-		local typeName = typeof(val)
-
-		if typeName == "Color3" then
-			return Lib.ColorToBytes(val)
-		elseif typeName == "NumberRange" then
-			return val.Min..", "..val.Max
-		end
-
-		return tostring(val)
-	end
-	
-	-- InputBox
-	SettingsEditor.CreateInputBox = function(valueBox: TextBox)
-		-- valueBox is the box the inputBox is tied to
-		
-		local inputBox = create({
-			{1,"Frame",{BackgroundColor3=Color3.new(0.14901961386204,0.14901961386204,0.14901961386204),BorderSizePixel=0,Name="InputBox",Size=UDim2.new(0,200,0,22),Visible=false,ZIndex=2,}},
-			{2,"TextBox",{BackgroundColor3=Color3.new(0.17647059261799,0.17647059261799,0.17647059261799),BackgroundTransparency=1,BorderColor3=Color3.new(0.062745101749897,0.51764708757401,1),BorderSizePixel=0,ClearTextOnFocus=false,Font=3,Parent={1},PlaceholderColor3=Color3.new(0.69803923368454,0.69803923368454,0.69803923368454),Position=UDim2.new(0,3,0,0),Size=UDim2.new(1,-6,1,0),Text="",TextColor3=Color3.new(1,1,1),TextSize=14,TextXAlignment=0,ZIndex=2,}},
-		})
-		local inputTextBox = inputBox.TextBox
-		inputBox.BackgroundColor3 = Settings.Theme.TextBox
-
-		inputTextBox.FocusLost:Connect(function()
-			-- make inputBox no longer visible
-			
-			valueBox.Visible = true
-			inputBox.Visible = false
-		end)
-
-		inputTextBox.Focused:Connect(function()
-			inputTextBox.SelectionStart = 1
-			inputTextBox.CursorPosition = #inputTextBox.Text + 1
-		end)
-		
-		
-		-- Sync inputTextBox with bound valueBox
-		valueBox.Changed:Connect(function(property)
-			if (property == "Text") then
-				inputTextBox.Text = valueBox.Text
-			end
-		end)
-		
-		-- When clicking on the valueBox, show the inputBox
-		valueBox.MouseButton1Click:Connect(function()
-			inputBox.Visible = true
-			valueBox.Visible = false
-		end)
-		
-
-		Lib.ViewportTextBox.convert(inputTextBox)
-		
-		return inputBox
-	end
-	
-	
-	SettingsEditor.DisplayColorEditor = function(obj, currentColor)
-		local editor = SettingsEditor.ColorEditor
-		
-		if not editor then
-			editor = Lib.ColorPicker.new()
-			
-			SettingsEditor.ColorEditor = editor
-		end
-		
-		-- Always update the the connection
-		if (editor) then
-			-- Check for current connection
-			if (SettingsEditor.ColorEditor.con_OnSelect) then
-				-- Disconnect
-				SettingsEditor.ColorEditor.con_OnSelect:Disconnect()
-				
-				-- Set to nil
-				SettingsEditor.ColorEditor.con_OnSelect = nil
-			end
-			
-			local connection
-			connection = editor.OnSelect:Connect(function(col)
-				if not editor.CurrentProp then return end
-				if not (editor.CurrentProp == obj) then return end
-
-				local colVal = (col or BrickColor.new(col))
-				
-				
-				-- Set value
-				obj:SetColor3Value(colVal)
-
-				-- Fire Color Changed
-				obj.OnColorChange:Fire()
-			end)
-			
-			-- Put connection there
-			SettingsEditor.ColorEditor.con_OnSelect = connection
-		end
-		
-		editor.CurrentProp = obj
-		if currentColor then
-			editor:SetColor(currentColor)
-		end
-		
-		editor:Show()
-		
-		return editor
-	end
-	
-	
-	SettingsEditor.NewPropEntry = function()
-		local newEntry = SettingsEditor.EntryTemplate():Clone()
-		local nameFrame = newEntry.NameFrame
-		local valueFrame = newEntry.ValueFrame
-
-		local iconFrame = Main.MiscIcons:GetLabel()
-		iconFrame.Position = UDim2.new(0,2,0,3)
-		iconFrame.Parent = newEntry.ValueFrame.RightButton
-		
-		
-		
-		return {
-			Gui = newEntry,
-			GuiElems = {
-				NameFrame = nameFrame,
-				ValueFrame = valueFrame,
-				PropName = nameFrame.PropName,
-				ValueBox = valueFrame.ValueBox,
-				Expand = nameFrame.Expand,
-				EnumArrow = valueFrame.EnumArrow,
-				RightButton = valueFrame.RightButton,
-				RightButtonIcon = iconFrame,
-				SoundPreview = valueFrame.SoundPreview,
-				SoundPreviewSlider = valueFrame.SoundPreview.TimeLine.Slider,
-				InfoButton = newEntry.InfoButton
-			}
-		}
-	end
-	
-	
-	SettingsEditor.ColorButton = (function()
-		local funcs = {}
-		
-		local function createButton()
-			local ColorButton = Instance.new("TextButton")
-			ColorButton.Name = "ColorButton"
-			ColorButton.Visible = false
-			ColorButton.Size = UDim2.new(0, 20, 0, 22)
-			ColorButton.BackgroundTransparency = 1
-			ColorButton.BorderSizePixel = 0
-			ColorButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-			ColorButton.FontSize = Enum.FontSize.Size14
-			ColorButton.TextSize = 14
-			ColorButton.TextColor3 = Color3.fromRGB(255, 255, 255)
-			ColorButton.Text = ""
-			ColorButton.Font = Enum.Font.SourceSans
-
-			local ColorPreview = Instance.new("Frame")
-			ColorPreview.Name = "ColorPreview"
-			ColorPreview.Size = UDim2.new(0, 10, 0, 10)
-			ColorPreview.BorderColor3 = Color3.fromRGB(0, 0, 0)
-			ColorPreview.Position = UDim2.new(0, 5, 0, 6)
-			ColorPreview.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-			ColorPreview.Parent = ColorButton
-
-			local UIGradient = Instance.new("UIGradient")
-			UIGradient.Parent = ColorPreview
-			
-			
-			return ColorButton
-		end
-		
-		
-		-- Sets the preview color
-		function funcs:SetPreviewColor(color)
-			self.GuiElems.Gradient.Color = ColorSequence.new(color)
-		end
-		
-		-- Set Color3Value
-		function funcs:SetColor3Value(color)
-			self.CurrentColor3 = color
-			
-			-- Update preview color as well
-			self:SetPreviewColor(color)
-		end
-		
-		
-		
-		local mt = {__index = funcs}
-		
-		local function new()
-			local colorButton = createButton()
-			
-			local obj = setmetatable({
-				Gui = colorButton;
-				GuiElems = {
-					ColorButton = colorButton;
-					ColorPreview = colorButton.ColorPreview;
-					Gradient = colorButton.ColorPreview.UIGradient;
-				};
-				
-				-- Signal used for Connections
-				OnColorChange = Lib.Signal.new();
-				
-			}, mt)
-			
-			-- Current Value
-			obj.CurrentColor3 = Color3.fromRGB(255, 255, 255)
-			
-			
-			-- Setup Gui Functions
-			colorButton.ZIndex = 2 -- so it's clickable
-			-- because ColorPreview obstructs it
-
-
-			-- Color Picker
-			colorButton.MouseButton1Click:Connect(function()
-				SettingsEditor.DisplayColorEditor(obj, obj.CurrentColor3)
-			end)
-			
-			return obj
-		end
-		
-		return {new = new}
-	end)()
-	
-	
-	SettingsEditor.Update = function()
-
-	end
-	
-	SettingsEditor.UpdateView = function()
-
-	end
-	
-	SettingsEditor.Refresh = function()
-		
-	end
-	
-	
-	
-	SettingsEditor.ScrollBarFrame = function()
-		local ScrollingFrame = Instance.new("ScrollingFrame")
-		ScrollingFrame.Size = UDim2.new(1, 0, 1, 0)
-		ScrollingFrame.BackgroundTransparency = 1
-		ScrollingFrame.BorderSizePixel = 0
-		
-		ScrollingFrame.AutomaticCanvasSize = Enum.AutomaticSize.Y
-		ScrollingFrame.ScrollBarImageColor3 = Color3.fromRGB(0, 0, 0)
-		ScrollingFrame.ScrollBarThickness = 6
-		
-		local UILIstLayout = Instance.new("UIListLayout")
-		UILIstLayout.SortOrder = Enum.SortOrder.LayoutOrder
-		UILIstLayout.Parent = ScrollingFrame
-		
-		return ScrollingFrame
-	end
-	
-	
-	SettingsEditor.CategoryListFrame = function()
-		local List = Instance.new("Frame")
-		List.Name = "List"
-		List.AutomaticSize = Enum.AutomaticSize.Y
-		List.Size = UDim2.new(1, -6, 0.1, 0)
-		List.ClipsDescendants = true
-		List.BackgroundTransparency = 1
-		List.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-		
-		
-		local UILIstLayout = Instance.new("UIListLayout")
-		UILIstLayout.SortOrder = Enum.SortOrder.LayoutOrder
-		UILIstLayout.Parent = List
-
-		return List
-	end
-	
-	
-	
-	-- Creates a dropdown
-	SettingsEditor.CategoryDropdown = (function()
-		local funcs = {}
-		
-		local function createFrame(self)
-			local Expander = Instance.new("TextButton")
-			Expander.Name = "Expander"
-			Expander.Size = UDim2.new(1, -scrollbarThickness, 0, 22)
-			Expander.BorderColor3 = Color3.fromRGB(33, 33, 33)
-			Expander.BackgroundTransparency = 0.2
-			Expander.Position = UDim2.new(0, 1, 0, 1)
-			Expander.BackgroundColor3 = Color3.fromRGB(45, 45, 45)
-			Expander.AutoButtonColor = false
-			Expander.FontSize = Enum.FontSize.Size14
-			Expander.TextSize = 14
-			Expander.Text = ""
-			Expander.Font = Enum.Font.SourceSans
-
-			local NameFrame = Instance.new("Frame")
-			NameFrame.Name = "NameFrame"
-			NameFrame.Size = UDim2.new(1, -40, 1, 0)
-			NameFrame.BorderColor3 = Color3.fromRGB(86, 125, 188)
-			NameFrame.BackgroundTransparency = 1
-			NameFrame.Position = UDim2.new(0, 20, 0, 0)
-			NameFrame.BorderSizePixel = 0
-			NameFrame.BackgroundColor3 = Color3.fromRGB(11, 90, 175)
-			NameFrame.Parent = Expander
-
-			local PropName = Instance.new("TextLabel")
-			PropName.Name = "PropName"
-			PropName.Size = UDim2.new(1, -2, 1, 0)
-			PropName.BackgroundTransparency = 1
-			PropName.Position = UDim2.new(0, 2, 0, 0)
-			PropName.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-			PropName.FontSize = Enum.FontSize.Size14
-			PropName.TextTruncate = Enum.TextTruncate.AtEnd
-			PropName.TextSize = 14
-			PropName.TextColor3 = Color3.fromRGB(255, 255, 255)
-			PropName.Text = "Category"
-			PropName.Font = Enum.Font.SourceSansBold
-			PropName.TextTransparency = 0.1
-			PropName.TextXAlignment = Enum.TextXAlignment.Left
-			PropName.Parent = NameFrame
-
-			local Expand = Instance.new("TextButton")
-			Expand.Name = "Expand"
-			Expand.Size = UDim2.new(0, 20, 0, 20)
-			Expand.ClipsDescendants = true
-			Expand.BackgroundTransparency = 1
-			Expand.Position = UDim2.new(0, -20, 0, 1)
-			Expand.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-			Expand.FontSize = Enum.FontSize.Size14
-			Expand.TextSize = 14
-			Expand.Text = ""
-			Expand.Font = Enum.Font.SourceSans
-			Expand.Parent = NameFrame
-
-			local Icon = Instance.new("ImageLabel")
-			Icon.Name = "Icon"
-			Icon.Size = UDim2.new(0, 16, 0, 16)
-			Icon.BackgroundTransparency = 1
-			Icon.Position = UDim2.new(0, 2, 0, 2)
-			Icon.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-			Icon.ScaleType = Enum.ScaleType.Crop
-			Icon.ImageRectOffset = Vector2.new(144, 16)
-			Icon.ImageRectSize = Vector2.new(16, 16)
-			Icon.Image = "rbxassetid://5642383285"
-			Icon.Parent = Expand
-			
-			return Expander
-		end
-		
-		local function setupGuiFuncs(self)
-			local Expander = self.Gui
-			
-			local Expand = Expander.NameFrame.Expand
-			
-			-- Functions
-			local function updateIcon()
-				Apps.Explorer.MiscIcons:DisplayByKey(self.GuiElems.Icon, self.Expanded and "Collapse" or "Expand")
-			end
-			
-			Expand.MouseButton1Click:Connect(function()
-				if (self.ToggleFrame) then
-					self.ToggleFrame.Visible = not self.ToggleFrame.Visible
-				end
-				
-				if (self.ToggleFrame.Visible) then
-					self.Expanded = true
-				else
-					self.Expanded = false
-				end
-				
-				-- Update Icon
-				updateIcon()
-			end)
-			
-			-- Init
-			updateIcon()
-		end
-		
-		function funcs:SetDisplayName(displayName)
-			if (self.Gui:FindFirstChild("NameFrame")) then
-				self.Gui.NameFrame.PropName.Text = displayName
-			end	
-		end
-		
-		
-		-- Set the frame to toggle
-		function funcs:SetToggleFrame(toggleFrame)
-			self.ToggleFrame = toggleFrame
-			
-			return self.ToggleFrame
-		end
-		
-		
-		local mt = {}
-		mt.__index = funcs
-		
-		local function new(toggleFrame, displayName)
-			local obj = setmetatable({}, mt)
-			
-			obj.Gui = createFrame(obj)
-			
-			obj.GuiElems = {
-				Icon = obj.Gui.NameFrame.Expand.Icon
-			}
-			
-			obj.Expanded = true -- Whether expanded
-			
-			setupGuiFuncs(obj)
-			
-			obj:SetDisplayName(displayName)
-			
-			obj:SetToggleFrame(toggleFrame)
-			
-			
-			return obj
-		end
-		
-		return {new = new}
-	end)()
-	
-	
-	-- Change a setting
-	SettingsEditor.SetSettingValue = function(categoryName, settingName, settingInfo, newValue)
-		if (settingInfo.OnChange) then
-			settingInfo.OnChange(newValue)
-		else
-			Settings[categoryName][settingName] = newValue
-		end
-	end
-	
-	
-	SettingsEditor.SetupInfoDesc = function()
-		local infoDescBox = SettingsEditor.InfoDescBox
-		-- TODO: Maybe change this
-		
-		if not (infoDescBox) then
-			local newFrame = Instance.new("Frame")
-			newFrame.BackgroundColor3 = Color3.fromRGB(0,0,0)
-			newFrame.BackgroundTransparency = 0.2
-			newFrame.BorderSizePixel = 0
-			newFrame.Size = UDim2.new(0,0,0,0)
-			newFrame.AutomaticSize = Enum.AutomaticSize.XY
-			newFrame.Visible = false -- not visible
-			
-			local newTextBox = Instance.new("TextBox")
-			newTextBox.BackgroundTransparency = 1
-			newTextBox.TextColor3 = Color3.fromRGB(255, 255, 255)
-			newTextBox.Size = UDim2.new(0,0,0,0)
-			newTextBox.AutomaticSize = Enum.AutomaticSize.XY
-			newTextBox.Parent = newFrame
-			
-			
-			infoDescBox = newFrame
-			SettingsEditor.InfoDescBox = infoDescBox
-			
-			
-			infoDescBox.Parent = SettingsEditor.Window.Gui
-		end
-		
-		return infoDescBox
-	end
-	
-	
-	-- Creates a setting entry box, to change the setting
-	SettingsEditor.CreateSettingEntry = function(categoryName, settingName, settingInfo)
-		local newEntry = SettingsEditor.NewPropEntry()
-		newEntry.Gui.Parent = settingsListFrame
-		
-		-- Change name
-		newEntry.GuiElems.PropName.Text = settingName
-		
-		-- InfoButton
-		local InfoButton: TextBox = newEntry.GuiElems.InfoButton
-		
-		-- If there's a setting description
-		if (settingInfo.desc) then
-			local infoDescBox:Frame = SettingsEditor.InfoDescBox
-			local isEnter = false
-			
-			InfoButton.MouseEnter:Connect(function(x, y)
-				isEnter = true
-				
-				-- Set setting description
-				infoDescBox.TextBox.Text = settingInfo.desc
-				
-				infoDescBox.Position = UDim2.new(0, x, 0, y)
-				infoDescBox.Visible = true
-			end)
-			
-			InfoButton.MouseMoved:Connect(function(x, y)
-				infoDescBox.Position = UDim2.new(0, x, 0, y)
-				infoDescBox.Visible = true
-			end)
-			
-			InfoButton.MouseLeave:Connect(function(x, y)
-				if (isEnter == true) then
-					isEnter = false
-					infoDescBox.Visible = false
-				end
-			end)
-		else
-			-- Don't show info button, if there's no description.
-			InfoButton.Visible = false
-		end
-		
-		
-		-- ValueBox
-		local ValueBox: TextButton = newEntry.Gui.ValueFrame.ValueBox
-		
-		
-		-- Boolean
-		if (settingInfo.typeName == "boolean") then
-			-- Checkbox
-			local newCheckbox = Lib.Checkbox.new()
-			
-			-- Set current value
-			newCheckbox:SetState(Settings[categoryName][settingName], false)
-			
-			
-			-- Whenever Checkbox value changes
-			newCheckbox.OnInput:Connect(function()
-				local newValue = newCheckbox.Toggled
-				
-				-- Sets the value
-				SettingsEditor.SetSettingValue(categoryName, settingName, settingInfo, newValue)
-			end)
-
-			newCheckbox.Gui.Parent = newEntry.Gui.ValueFrame
-			
-			
-		-- Color3
-		elseif (settingInfo.typeName == "Color3") then
-			local colorButton = SettingsEditor.ColorButton.new()
-			colorButton.Gui.Parent = newEntry.Gui.ValueFrame
-			
-			-- Set current Color3
-			colorButton:SetColor3Value(Settings[categoryName][settingName])
-			
-			colorButton.Gui.Visible = true
-			
-			
-			-- Fired once color input was changed
-			colorButton.OnColorChange:Connect(function()
-				local newColor = colorButton.CurrentColor3
-				
-				SettingsEditor.SetSettingValue(categoryName, settingName, settingInfo, newColor)
-			end)
-			
-			
-		else
-			-- For anything else
-			local inputBox = SettingsEditor.CreateInputBox(ValueBox)
-			local inputTextBox = inputBox.TextBox.Input
-
-			inputBox.Parent = newEntry.Gui.ValueFrame
-
-			inputTextBox.FocusLost:Connect(function()
-				local convertedVal = SettingsEditor.StringToValue(settingInfo, inputTextBox.Text)
-
-				if (convertedVal) then
-					ValueBox.Text = SettingsEditor.ValueToString(convertedVal)
-
-					-- Sets value
-					SettingsEditor.SetSettingValue(categoryName, settingName, settingInfo, convertedVal)
-				end
-			end)
-
-			-- Set current value
-			ValueBox.Text = SettingsEditor.ValueToString(Settings[categoryName][settingName])
-		end
-		
-		return newEntry
-	end
-	
-	
-	-- Set up the settings.
-	SettingsEditor.SetupSettings = function(categoryIndex, parentTo)
-		local infoTable = SettingsEditor.SettingsInfo[categoryIndex]
-		
-		for _, settingName in ipairs(infoTable.Order) do
-			if (infoTable.Info[settingName]) then
-				local settingInfo = infoTable.Info[settingName]
-				
-				local newEntry = SettingsEditor.CreateSettingEntry(categoryIndex, settingName, settingInfo)
-				
-				newEntry.Gui.Parent = parentTo
-			end
-		end
-	end
-	
-	
-	
-	-- Create new Category
-	SettingsEditor.NewCategory = function(indexName, displayName, parentTo)
-		-- indexName, how it should be indexed
-		-- displayName, how the category should show up
-
-		local categoryListFrame = SettingsEditor.CategoryListFrame():Clone()
-		categoryListFrame.Name = indexName
-		--categoryListFrame.Visible = false
-		
-		-- Setup settings
-		SettingsEditor.SetupSettings(indexName, categoryListFrame)
-		
-		
-		local category = SettingsEditor.CategoryDropdown.new(categoryListFrame, displayName)
-		category.Gui.Parent = parentTo
-		
-		-- parent category list
-		categoryListFrame.Parent = parentTo
-		
-		return category
-	end
-	
-	
-	
-	
-	-- Generate Setting buttons and stuff
-	SettingsEditor.RenderSettings = function()
-		for _,categoryName in ipairs(SettingsEditor.SettingsInfo._Categories) do
-			SettingsEditor.NewCategory(categoryName, categoryName, settingsListFrame)
-		end
-	end
-	
-	
-	-- Init
-	SettingsEditor.Init = function()
-		local window = Lib.Window.new()
-		SettingsEditor.Window = window
-
-		window:SetTitle("Settings")
-		window.Resizable = true
-		
-		-- Setup Results ScrollingFrame
-		settingsListFrame = SettingsEditor.ScrollBarFrame()
-		
-		SettingsEditor.Window.GuiElems.Main.Parent.Name = "Dex_SettingsWindow" -- Change ScreenGui name
-		
-		
-		-- Setup Gui
-		SettingsEditor.SetupInfoDesc() -- Hover text description
-		
-		SettingsEditor.RenderSettings() -- Sets up UI to change settings
-		
-		
-		-- Window Add, adds things to the "Content"
-		window:Add(settingsListFrame)
-	end
-	
-	
-	
-	return SettingsEditor
-end
-
-
--- TODO: Remove when open source
-if gethsfuncs then
-	_G.moduleData = {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-else
-	return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-end]]></ProtectedString>
-							<int64 name="SourceAssetId">-1</int64>
-							<BinaryString name="Tags"></BinaryString>
-						</Properties>
-						<Item class="ModuleScript" referent="RBX8876388B635A4215B4B5911742733E68">
-							<Properties>
-								<BinaryString name="AttributesSerialize"></BinaryString>
-								<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-								<bool name="DefinesCapabilities">false</bool>
-								<Content name="LinkedSource"><null></null></Content>
-								<string name="Name">settingsInfo</string>
-								<string name="ScriptGuid">{4EB7F004-779E-4072-B0FF-A1E6E719E63E}</string>
-								<ProtectedString name="Source"><![CDATA[local settingsInfo = {}
-
--- Common Locals
-local Main,Lib,Apps,Settings -- Main Containers
-local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
-local API,RMD,env,service,plr,create,createSimple -- Main Locals
-
-
-function settingsInfo.initDeps(data)
-	Main = data.Main
-	Lib = data.Lib
-	Apps = data.Apps
-	Settings = data.Settings
-
-	--API = data.API
-	--RMD = data.RMD
-	--env = data.env
-	--service = data.service
-	--plr = data.plr
-	--create = data.create
-	--createSimple = data.createSimple
-end
-
-
--- Register Setting
-local function RegisterSetting(categoryTable, settingName, data)
-	categoryTable.Info[settingName] = data
-	
-	table.insert(categoryTable.Order, settingName)
-end
-
---[[
-Example Settings
-
--- this is the basic setup
-settingInfo.CategoryName
-
-
-]]
-
--- The order here, defines the order on how they show up
-settingsInfo._Categories = {
-	--"Main",
-	"Explorer",
-	"Properties",
-	"Theme",
-}
-
--- TODO: Use "DefaultSettings" for default values perhaps
-
-settingsInfo.Main = {}
-settingsInfo.Main.Info = {}
-settingsInfo.Main.Order = {}
-
---[[RegisterSetting(settingsInfo["Main"], "ResetOnSpawn", {
-	desc = "Whether to reset the UI on spawn.";
-	defaultVal = true;
-	typeName = "boolean";
-
-	OnChange = function(newValue)
-		Settings.Main.ResetOnSpawn = newValue
-		
-		if (Main.LocalScript_Gui) then
-			Main.LocalScript_Gui.ResetOnSpawn = newValue
-		end
-		
-		if (Main.MainGui) then
-			Main.MainGui.ResetOnSpawn = newValue
-		end
-		
-		if (Lib.SidesGui) then
-			Lib.SidesGui.ResetOnSpawn = newValue
-		end
-		
-		if (Lib.StoredWindows) then
-			for k,v in pairs(Lib.StoredWindows) do
-				if (v.Gui) then
-					v.Gui.ResetOnSpawn = newValue
-				end
-			end
-		end
-	end;
-})]]
-
-
-
-settingsInfo.Explorer = {}
-settingsInfo.Explorer.Info = {}
-settingsInfo.Explorer.Order = {}
-
-
-
--- Example Setting
-RegisterSetting(settingsInfo.Explorer, "Sorting", {
-	desc = nil;
-	defaultVal = true;
-	typeName = "boolean";
-
-	OnChange = function(newValue)
-		Apps.Explorer.SetSortingEnabled(newValue)
-	end;
-})
-
-
-RegisterSetting(settingsInfo.Explorer, "TeleportToOffset", {
-	desc = "Offset when teleporting to Instances";
-	defaultVal = Vector3.new(0,0,0);
-	typeName = "Vector3";
-})
-
-RegisterSetting(settingsInfo.Explorer, "ClickToSelect", {
-	desc = "Whether clicking will select parts";
-	defaultVal = false;
-	typeName = "boolean";
-	
-	OnChange = function(newValue)
-		Settings.Explorer.ClickToSelect = newValue
-		Apps.Explorer.InitClickToSelect()
-	end,
-})
-
-
---[[RegisterSetting(settingsInfo.Explorer, "ClickToRename", {
-	desc = "ClickToRename";
-	defaultVal = true;
-	typeName = "boolean";
-})]]
-
-
-RegisterSetting(settingsInfo.Explorer, "AutoUpdateSearch", {
-	desc = nil;
-	defaultVal = true;
-	typeName = "boolean";
-})
-
-
---[[RegisterSetting(settingsInfo.Explorer, "AutoUpdateMode", {
-	desc = "0 Default, 1 no tree update, 2 no descendant events, 3 frozen";
-	defaultVal = 0;
-	typeName = "number";
-})]]
-
-
-RegisterSetting(settingsInfo.Explorer, "PartSelectionBox", {
-	desc = "Toggle Selection Box on Objects";
-	defaultVal = true;
-	typeName = "boolean";
-})
-
-RegisterSetting(settingsInfo.Explorer, "GuiSelectionBox", {
-	desc = "Toggle Selection Box on GUIs";
-	defaultVal = true;
-	typeName = "boolean";
-})
-
-RegisterSetting(settingsInfo.Explorer, "CopyPathUseGetChildren", {
-	desc = nil;
-	defaultVal = true;
-	typeName = "boolean";
-})
-
-
-
-
-settingsInfo.Properties = {}
-settingsInfo.Properties.Info = {}
-settingsInfo.Properties.Order = {}
-
-RegisterSetting(settingsInfo.Properties, "MaxConflictCheck", {
-	desc = nil;
-	defaultVal = 50;
-	typeName = "number";
-})
-
-
-RegisterSetting(settingsInfo.Properties, "ShowDeprecated", {
-	desc = nil;
-	defaultVal = false;
-	typeName = "boolean";
-})
-
-RegisterSetting(settingsInfo.Properties, "ShowHidden", {
-	desc = nil;
-	defaultVal = false;
-	typeName = "boolean";
-})
-
-
-RegisterSetting(settingsInfo.Properties, "NumberRounding", {
-	desc = nil;
-	defaultVal = 3;
-	typeName = "number";
-})
-
-
-RegisterSetting(settingsInfo.Properties, "ShowAttributes", {
-	desc = nil;
-	defaultVal = false;
-	typeName = "boolean";
-})
-
-
-RegisterSetting(settingsInfo.Properties, "MaxAttributes", {
-	desc = nil;
-	defaultVal = 50;
-	typeName = "number";
-})
-
-
-RegisterSetting(settingsInfo.Properties, "ScaleType", {
-	desc = "0 Full Name Shown, 1 Equal Halves";
-	defaultVal = 1;
-	typeName = "number";
-})
-
-
-settingsInfo.Theme = {}
-settingsInfo.Theme.Info = {}
-settingsInfo.Theme.Order = {}
-
-local rgb = Color3.fromRGB
-
-RegisterSetting(settingsInfo.Theme, "Main1", {
-	desc = nil;
-	defaultVal = rgb(52,52,52);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "Main2", {
-	desc = nil;
-	defaultVal = rgb(45,45,45);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "Outline1", {
-	desc = "Mainly frames";
-	defaultVal = rgb(33,33,33);
-	typeName = "Color3";
-})
-RegisterSetting(settingsInfo.Theme, "Outline2", {
-	desc = "Mainly button";
-	defaultVal = rgb(55,55,55);
-	typeName = "Color3";
-})
-RegisterSetting(settingsInfo.Theme, "Outline3", {
-	desc = "Mainly textbox";
-	defaultVal = rgb(30,30,30);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "TextBox", {
-	desc = nil;
-	defaultVal = rgb(38,38,38);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "Menu", {
-	desc = nil;
-	defaultVal = rgb(32,32,32);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "ListSelection", {
-	desc = nil;
-	defaultVal = rgb(11,90,175);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "Button", {
-	desc = nil;
-	defaultVal = rgb(60,60,60);
-	typeName = "Color3";
-})
-RegisterSetting(settingsInfo.Theme, "ButtonHover", {
-	desc = nil;
-	defaultVal = rgb(68,68,68);
-	typeName = "Color3";
-})
-RegisterSetting(settingsInfo.Theme, "ButtonPress", {
-	desc = nil;
-	defaultVal = rgb(40,40,40);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "Highlight", {
-	desc = nil;
-	defaultVal = rgb(75,75,75);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "Text", {
-	desc = nil;
-	defaultVal = rgb(255,255,255);
-	typeName = "Color3";
-})
-RegisterSetting(settingsInfo.Theme, "PlaceholderText", {
-	desc = nil;
-	defaultVal = rgb(100,100,100);
-	typeName = "Color3";
-})
-
-RegisterSetting(settingsInfo.Theme, "Important", {
-	desc = nil;
-	defaultVal = rgb(255,0,0);
-	typeName = "Color3";
-})
-
-
-
-return settingsInfo]]></ProtectedString>
-								<int64 name="SourceAssetId">-1</int64>
-								<BinaryString name="Tags"></BinaryString>
-							</Properties>
-						</Item>
-					</Item>
-					<Item class="ModuleScript" referent="RBXCBB7FD6FBF8E45ED863E3C9684146043">
-						<Properties>
-							<BinaryString name="AttributesSerialize"></BinaryString>
-							<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
-							<bool name="DefinesCapabilities">false</bool>
-							<Content name="LinkedSource"><null></null></Content>
-							<string name="Name">AboutMenu</string>
-							<string name="ScriptGuid">{715204E4-4F9D-4816-98B0-B96946C53ED2}</string>
-							<ProtectedString name="Source"><![CDATA[--[[
-	Settings Module
-	
-	The Module to configure settings
-]]
-
--- ADONIS
-local ReplicatedStorage = game:GetService("ReplicatedStorage");
-local Dex_RemoteEvent = ReplicatedStorage:WaitForChild("NewDex_Event");
-
-
--- Common Locals
-local Main,Lib,Apps,Settings -- Main Containers
-local Explorer, Properties, ScriptViewer, Notebook -- Major Apps
-local API,RMD,env,service,plr,create,createSimple -- Main Locals
-
-local function initDeps(data)
-	Main = data.Main
-	Lib = data.Lib
-	Apps = data.Apps
-	Settings = data.Settings
-
-	API = data.API
-	RMD = data.RMD
-	env = data.env
-	service = data.service
-	plr = data.plr
-	create = data.create
-	createSimple = data.createSimple
-end
-
-local function initAfterMain()
-	Explorer = Apps.Explorer
-	Properties = Apps.Properties
-	ScriptViewer = Apps.ScriptViewer
-	Notebook = Apps.Notebook
-end
-
-
-local function main()
-	local AboutMenu = {}
-	
-	local scrollV, scrollH
-	local settingsListFrame
-	local expanded, viewList = {}, {}
-	
-	local aboutFrame
-	
-	
-	AboutMenu.AboutFrame = function()
-		local aboutFrame = create({
-			{1,'Frame',{Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Name='AboutFrame',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
-			{2,'Frame',{Parent={1},Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Name='Container',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
-			{3,'UIListLayout',{Parent={2},VerticalAlignment=Enum.VerticalAlignment.Center,SortOrder=Enum.SortOrder.LayoutOrder,HorizontalAlignment=Enum.HorizontalAlignment.Center,}}
-		})
-		
-		--local Container = aboutFrame.Container
-		
-		return aboutFrame
-	end
-	
-	
-	AboutMenu.CreditsEntry = (function()
-		local funcs = {}
-		
-		local function createGui()
-			local creditsEntry = create({
-				{1,'Frame',{Size=UDim2.new(1, 0, 0, 10),BorderColor3=Color3.fromRGB(0, 0, 0),Name='TextEntry',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
-				{2,'TextBox',{Parent={1},BorderSizePixel=0,RichText=true,BackgroundColor3=Color3.fromRGB(255, 255, 255),TextWrapped=true,TextSize=20,TextColor3=Color3.fromRGB(255, 255, 255),Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Text='text',Font=Enum.Font.SourceSans,BackgroundTransparency=1,ClearTextOnFocus=false,TextEditable=false,}}
-			})
-			
-			return creditsEntry
-		end
-		
-		
-		function funcs:ChangeText(text)
-			self.GuiElems.TextBox.Text = text
-		end
-		
-		
-		local mt = {__index = funcs}
-		local function new(text)
-			local obj = setmetatable({}, mt)
-			
-			obj.Gui = createGui()
-			
-			obj.GuiElems = {
-				TextBox = obj.Gui.TextBox
-			}
-			
-			if (text) then
-				obj:ChangeText(text)
-			end
-			
-			
-			-- Parent
-			obj.Gui.Parent = aboutFrame.Container
-			
-			return obj
-		end
-		
-		
-		return {new = new}
-	end)()
-	
-	
-	AboutMenu.AddCreditsEntry = function(text, properties)
-		local creditsEntry = create({
-			{1,'Frame',{Size=UDim2.new(1, 0, 0, 10),AutomaticSize=Enum.AutomaticSize.XY,BorderColor3=Color3.fromRGB(0, 0, 0),Name='TextEntry',BorderSizePixel=0,BackgroundTransparency=1,BackgroundColor3=Color3.fromRGB(255, 255, 255),}},
-			{2,'TextLabel',{Parent={1},AutomaticSize=Enum.AutomaticSize.XY,BorderSizePixel=0,RichText=true,BackgroundColor3=Color3.fromRGB(255, 255, 255),TextWrapped=true,TextSize=14,TextColor3=Color3.fromRGB(255, 255, 255),Size=UDim2.new(1, 0, 1, 0),BorderColor3=Color3.fromRGB(0, 0, 0),Text='text',Font=Enum.Font.SourceSans,BackgroundTransparency=1,}}
-		})
-		
-		local entryText = creditsEntry.TextLabel
-		entryText.Text = text
-		
-		-- Default text size
-		entryText.TextSize = 16
-		
-		if (properties) then
-			for property, val in pairs(properties) do
-				entryText[property] = val
-			end
-		end
-		
-		
-		creditsEntry.Parent = aboutFrame.Container
-		
-
-		return creditsEntry
-	end
-	
-	-- Init
-	AboutMenu.Init = function()
-		local window = Lib.Window.new()
-		AboutMenu.Window = window
-
-		window:SetTitle("About")
-		window.Resizable = true
-		
-		-- Setup Results ScrollingFrame
-		AboutMenu.Window.GuiElems.Main.Parent.Name = "Dex_AboutWindow" -- Change ScreenGui name
-		
-		
-		-- Create Gui
-		aboutFrame = AboutMenu.AboutFrame()
-		
-		AboutMenu.AddCreditsEntry("<b>About Dex</b>", {
-			TextSize = 30,
-		})
-		
-		AboutMenu.AddCreditsEntry("<b>Version:</b> ".. Main.Version)
-		AboutMenu.AddCreditsEntry("\n", {TextSize = 5})
-		AboutMenu.AddCreditsEntry("Developed by Moon aka. LorekeeperZinnia")
-		AboutMenu.AddCreditsEntry("This version is modified, the official release was never finished.", {
-			TextSize = 12,
-		})
-		AboutMenu.AddCreditsEntry("\n\n", {TextSize = 10})
-		AboutMenu.AddCreditsEntry("<b>Additional Contributors:</b>", {TextSize = 17})
-		AboutMenu.AddCreditsEntry("SnowyShiro", {TextSize = 17})
-		AboutMenu.AddCreditsEntry("<i>Modified GuiToLuaAE</i>")
-		AboutMenu.AddCreditsEntry("")
-		AboutMenu.AddCreditsEntry("karl-police", {TextSize = 17})
-		AboutMenu.AddCreditsEntry("EasternBloxxer", {TextSize = 17})
-		AboutMenu.AddCreditsEntry("<i>Added additional features, Adonis Plugin</i>")
-		
-		
-		
-		-- Window Add, adds things to the "Content"
-		window:Add(aboutFrame)
-	end
-	
-	
-	
-	return AboutMenu
-end
-
-
--- TODO: Remove when open source
-if gethsfuncs then
-	_G.moduleData = {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-else
-	return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}
-end]]></ProtectedString>
+return {InitDeps = initDeps, InitAfterMain = initAfterMain, Main = main}]]></ProtectedString>
 							<int64 name="SourceAssetId">-1</int64>
 							<BinaryString name="Tags"></BinaryString>
 						</Properties>
 					</Item>
 				</Item>
-				<Item class="ModuleScript" referent="RBX2870DE7C0D9A4D1B8733CA35B8F0676B">
+				<Item class="ModuleScript" referent="RBXf447703cd72f4718bc64e5ff91e02450">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>
@@ -13105,7 +13212,7 @@ end]]></ProtectedString>
 						<BinaryString name="Tags"></BinaryString>
 					</Properties>
 				</Item>
-				<Item class="ModuleScript" referent="RBX2B009677E56E445F816AE2DCAD1F6EA8">
+				<Item class="ModuleScript" referent="RBX6ce7f57709854f189a879da815d691f5">
 					<Properties>
 						<BinaryString name="AttributesSerialize"></BinaryString>
 						<SecurityCapabilities name="Capabilities">0</SecurityCapabilities>


### PR DESCRIPTION
this PR updates :dexnew and adds these changes:
- all scripts: add silencers to warnings, for example Explorer.abc = nil at the start of the module init

- in Explorer: 
   - added smooth animation to expanding a node and smooth animation for the arrow
   - fixed Call Function appearing on non-event/function instances
   - added an actual UI to Call Function
   - added View Description button, but the RMD is missing summaries for a lot of instances so not very sure whether it's really that useful
   
- in Properties: 
   - changed the checkbox style to 0 to match the settings editor
   - made sound preview copy the sound's descendants to have sound effects match the original sound
 
OBS gave up but here's a few screenshots
POF:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/d5356e65-4e54-4339-a606-c6f1a5637ce1" />
<img width="851" alt="image" src="https://github.com/user-attachments/assets/d67ba7f2-468b-486b-836f-c7562b723d33" />
<img width="578" alt="image" src="https://github.com/user-attachments/assets/248abc54-d727-41c2-af34-9559761e4bf2" />
