### PR TITLE
Fix Visual Studio Code invalidly indenting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 	"editor.tabSize": 4,
 	"editor.insertSpaces": false,
 	"editor.detectIndentation": false,
+	"files.eol": "\n",
 	"[yaml]": {
 		"editor.detectIndentation": true
 	}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+	"editor.tabSize": 4,
+	"editor.insertSpaces": false,
+	"editor.detectIndentation": false,
+	"[yaml]": {
+		"editor.detectIndentation": true
+	}
+}


### PR DESCRIPTION
VSC (Visual studio code) doesn't use `.editorconfig` which causes it to falsely insert spaces instead of tabs, this fixes it.