### PR TITLE
Add "Font" to service so that it can be used in UI elements.

### DIFF
--- a/MainModule/Shared/Service.luau
+++ b/MainModule/Shared/Service.luau
@@ -1440,6 +1440,7 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 		Pcall = Pcall;
 		Threads = Threads;
 		DataModel = game;
+		Font = Font;
 		WrapService = WrapService;
 		EventService = EventService;
 		ThreadService = ThreadService;


### PR DESCRIPTION
Add service.Font for use in UIs themes. Currently, attempting to use Font.new() or related functions as an alternative to the now-depricated Enum.Font results in an error, as "Font" is not included in the environment used by UI elements.