### PR TITLE
Fix Resize command Breaking

### DIFF
--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3757,9 +3757,7 @@ return function(Vargs, env)
 
 					local resizeAttributeValue = char:GetAttribute("Adonis_Resize")
 					local function setSizeAttribute(Val)
-						if not resizeAttributeValue then
-							char:SetAttribute("Adonis_Resize", Val)
-						elseif Val < Variables.SizeLimit then
+						if not resizeAttributeValue or Val < Variables.SizeLimit then
 							char:SetAttribute("Adonis_Resize", Val)
 						else
 							error(string.format("Cannot resize %s's character by %g%%: size limit exceeded.", service.FormatPlayer(v), num*100))

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3756,18 +3756,22 @@ return function(Vargs, env)
 					end
 
 					local resizeAttributeValue = char:GetAttribute("Adonis_Resize")
-					if not resizeAttributeValue then
-						char:SetAttribute("Adonis_Resize", num)
-					elseif resizeAttributeValue * num < Variables.SizeLimit then
-						char:SetAttribute("Adonis_Resize", resizeAttributeValue * num)
-					else
-						Functions.Hint(string.format("Cannot resize %s's character by %g%%: size limit exceeded.", service.FormatPlayer(v), num*100), {plr})
-						continue
+					local function setSizeAttribute(Val)
+						if not resizeAttributeValue then
+							char:SetAttribute("Adonis_Resize", Val)
+						elseif Val < Variables.SizeLimit then
+							char:SetAttribute("Adonis_Resize", Val)
+						else
+							error(string.format("Cannot resize %s's character by %g%%: size limit exceeded.", service.FormatPlayer(v), num*100))
+						end
 					end
 
 					if human and char:IsA("Model") then
+						setSizeAttribute(num)
 						char:ScaleTo(num)
 					elseif human and human.RigType == Enum.HumanoidRigType.R15 then
+						setSizeAttribute(resizeAttributeValue * num)
+						
 						for _, val in human:GetChildren() do
 							if val:IsA("NumberValue") and val.Name:match(".*Scale") then
 								val.Value *= num
@@ -3775,6 +3779,8 @@ return function(Vargs, env)
 						end
 						fixDensity(char)
 					elseif human and human.RigType == Enum.HumanoidRigType.R6 then
+						setSizeAttribute(resizeAttributeValue * num)
+						
 						local motors = {}
 						table.insert(motors, char.HumanoidRootPart:FindFirstChild("RootJoint"))
 						for _, motor in char.Torso:GetChildren() do

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -3768,7 +3768,7 @@ return function(Vargs, env)
 						setSizeAttribute(num)
 						char:ScaleTo(num)
 					elseif human and human.RigType == Enum.HumanoidRigType.R15 then
-						setSizeAttribute(resizeAttributeValue * num)
+						setSizeAttribute((resizeAttributeValue or 1) * num)
 						
 						for _, val in human:GetChildren() do
 							if val:IsA("NumberValue") and val.Name:match(".*Scale") then
@@ -3777,7 +3777,7 @@ return function(Vargs, env)
 						end
 						fixDensity(char)
 					elseif human and human.RigType == Enum.HumanoidRigType.R6 then
-						setSizeAttribute(resizeAttributeValue * num)
+						setSizeAttribute((resizeAttributeValue or 1) * num)
 						
 						local motors = {}
 						table.insert(motors, char.HumanoidRootPart:FindFirstChild("RootJoint"))


### PR DESCRIPTION
This PR aims to fix an underlying problem with the Resize Command, because most character Models are the Class "Model" it will set the Size to whatever you put I.E: `:size me 15` you character will scale to 15, but whenever you try to set the scale back to `1` and then you set the scale to `10` it will say you exceeded the limit, this is because it was checking the multiplicative form of the Resize which only works i the Character Model is the Class "Model" which in turn prevents you from resizing, I just modified the code so it will only check based on the type of Character Model.

tl;dr
The command would break if you do `:size me 15` - `:size me 1` - `:size me 10` because it was multiply the old size with the new size regardless of the Character Model Class.

PoF:

https://github.com/user-attachments/assets/14f4581c-2aca-46d1-b349-33dce7c4d94f

