### PR TITLE
Fix CMDx detection

### DIFF
--- a/MainModule/Client/Plugins/Anti_Cheat.luau
+++ b/MainModule/Client/Plugins/Anti_Cheat.luau
@@ -15,25 +15,25 @@ return function(Vargs)
 	setfenv(1, env)
 
 	local _G, game, script, getfenv, setfenv, workspace,
-		getmetatable, setmetatable, loadstring, coroutine,
-		rawequal, typeof, print, math, warn, error,  pcall,
-		xpcall, select, rawset, rawget, ipairs, pairs,
-		next, Rect, Axes, os, time, Faces, unpack, string, Color3,
-		newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
-		NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
-		NumberSequenceKeypoint, PhysicalProperties, Region3int16,
-		Vector3int16, require, table, type, wait,
-		Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay =
-			_G, game, script, getfenv, setfenv, workspace,
-			getmetatable, setmetatable, loadstring, coroutine,
-			rawequal, typeof, print, math, warn, error,  pcall,
-			xpcall, select, rawset, rawget, ipairs, pairs,
-			next, Rect, Axes, os, time, Faces, unpack, string, Color3,
-			newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
-			NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
-			NumberSequenceKeypoint, PhysicalProperties, Region3int16,
-			Vector3int16, require, table, type, wait,
-			Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
+	getmetatable, setmetatable, loadstring, coroutine,
+	rawequal, typeof, print, math, warn, error,  pcall,
+	xpcall, select, rawset, rawget, ipairs, pairs,
+	next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+	newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+	NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+	NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+	Vector3int16, require, table, type, wait,
+	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay =
+		_G, game, script, getfenv, setfenv, workspace,
+	getmetatable, setmetatable, loadstring, coroutine,
+	rawequal, typeof, print, math, warn, error,  pcall,
+	xpcall, select, rawset, rawget, ipairs, pairs,
+	next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+	newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+	NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+	NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+	Vector3int16, require, table, type, wait,
+	Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay
 
 	local Anti, Process, UI, Variables
 	local script = script
@@ -378,11 +378,11 @@ return function(Vargs)
 					if
 						textbox and Anti.RLocked(textbox) and not ((success and value) or service.GuiService.MenuIsOpen or (
 							service.Chat.LoadDefaultChat and
-							textChatService and
-							textChatService.ChatVersion == Enum.ChatVersion.TextChatService and
-							chatBarConfig and
-							chatBarConfig.Enabled
-						))
+								textChatService and
+								textChatService.ChatVersion == Enum.ChatVersion.TextChatService and
+								chatBarConfig and
+								chatBarConfig.Enabled
+							))
 					then
 						Detected("Kick", "Invalid CoreGui Textbox has been selected")
 					end
@@ -514,6 +514,7 @@ return function(Vargs)
 				"Found target with input:";
 				"Couldn't find the target's root part%. :[";
 				"HookMT"; --watameln was here :3
+				"UNC Environment Check"; -- exploiters love UNC check lol
 			}
 
 			local soundIds = {
@@ -521,13 +522,14 @@ return function(Vargs)
 			}
 
 			local function check(Message)
+				if 
+					string.find(string.lower(Message), "failed to load", 1, true) or
+					string.find(string.lower(Message), "meshcontentprovider failed to process", 1, true) or
+					string.find(string.lower(Message), "unknown 'active' animation:", 1, true)
+				then return false end
+
 				for _, v in lookFor do
-					if
-						not string.find(string.lower(Message), "failed to load", 1, true) and
-						not string.find(string.lower(Message), "meshcontentprovider failed to process", 1, true) and
-						not string.find(string.lower(Message), "unknown 'active' animation:", 1, true) and
-						(string.match(string.lower(Message), string.lower(v)) or string.match(Message, v))
-					then
+					if (string.match(string.lower(Message), string.lower(v)) or string.match(Message, v)) then
 						return true
 					end
 				end
@@ -541,10 +543,10 @@ return function(Vargs)
 					not service.UserInputService.TouchEnabled
 				then
 					if not pcall(function()
-						if not isStudio and (findService(game, "VirtualUser") or findService(game, "VirtualInputManager") or findService(game, "UGCValidationService")) then
-							Detected("crash", "Disallowed Services Detected")
-						end
-					end) then
+							if not isStudio and (findService(game, "VirtualUser") or findService(game, "VirtualInputManager") or findService(game, "UGCValidationService")) then
+								Detected("crash", "Disallowed Services Detected")
+							end
+						end) then
 						Detected("kick", "Disallowed Services Finding Error")
 					end
 				end
@@ -562,8 +564,8 @@ return function(Vargs)
 			local function checkTool(t)
 				task.wait()
 
-				if t and (t:IsA("Tool") or t.ClassName == "HopperBin") and not t:FindFirstChild(Variables.CodeName) and service.Player:FindFirstChild("Backpack") and t:IsDescendantOf(service.Player.Backpack) then
-					if t.ClassName == "HopperBin" and (rawequal(t.BinType, Enum.BinType.Grab) or rawequal(t.BinType, Enum.BinType.Clone) or rawequal(t.BinType, Enum.BinType.Hammer) or rawequal(t.BinType, Enum.BinType.GameTool)) then
+				if t and t.ClassName == "HopperBin" and not t:FindFirstChild(Variables.CodeName) and service.Player:FindFirstChild("Backpack") and t:IsDescendantOf(service.Player.Backpack) then
+					if (rawequal(t.BinType, Enum.BinType.Grab) or rawequal(t.BinType, Enum.BinType.Clone) or rawequal(t.BinType, Enum.BinType.Hammer) or rawequal(t.BinType, Enum.BinType.GameTool)) then
 						Detected("kick", "Building Tools detected; "..tostring(t.BinType))
 					end
 				end
@@ -573,8 +575,8 @@ return function(Vargs)
 
 			service.DataModel.ChildAdded:Connect(checkServ)
 
-			service.PolicyService.ChildAdded:Connect(function(child)
-				if child:IsA("Sound") then
+			service.PolicyService.DescendantAdded:Connect(function(child) -- use .DescendantAdded to prevent CMDx's default .ChildAdded connection disabling from being effective
+				if child:IsA("Sound") and child.Parent == service.PolicyService then
 					for i = 1, 5 do
 						if soundIdCheck(child) then
 							Detected("crash", "CMDx Detected; "..tostring(child))


### PR DESCRIPTION
Works around CMDx's `ChildAdded` connection disabling by using `DescendantAdded`, also adds a log detection for UNC check and some minor changes on some checks to avoid redundant code.