### PR TITLE
Fix for :Restart not teleporting all players to a public server

### DIFF
--- a/MainModule/Server/Plugins/Server-SoftShutdown.luau
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.luau
@@ -1,6 +1,7 @@
 --// Originally written by Merely
 --// Edited by GitHub@LolloDev5123 and Irreflexive
 --// GitHub@Expertcoderz was here to make things look better
+--// GitHub@annoynumus was here to patch the return teleport
 
 return function(Vargs, GetEnv)
 	local server = Vargs.Server
@@ -61,7 +62,7 @@ return function(Vargs, GetEnv)
 
 					task.wait(waitTime + 5)
 					waitTime /= 2
-					
+
 					Logs:AddLog("Script", `Teleporting {player.Name} back to the main game`)
 					teleportedPlayers[player] = 1
 					table.insert(playersToTeleport, player)
@@ -77,7 +78,7 @@ return function(Vargs, GetEnv)
 				local data = type(joindata) == "table" and joindata.TeleportData
 
 				if type(data) == "table" and data[PARAMETER_NAME] then
-					if TeleportTask.Running then
+					if TeleportTask.Running or TeleportTask.R_Status == "Idle" then
 						TeleportTask.Finished:wait()
 					end
 


### PR DESCRIPTION
This PR addresses a bug where players who joined after the initial teleport were being teleported *before* the teleport thread had started running. Since the thread hadn't yet executed, no `jobId` had been generated by `ReserveServer`, resulting in an error when trying to teleport these players.

This caused only one player (typically the first to join) to be teleported successfully, while others remained stuck in a reserved server with no destination.

To fix this, I added a check to see if `R_Status` is `"Idle"`—meaning the teleport thread hasn't run yet—and if so, the script now waits until the thread completes and the `jobId` is available before teleporting late-joining players.

This ensures all players are correctly teleported once the job is ready.

Video: https://youtu.be/NKHdaDSVu6U