### PR TITLE
Stop :fly command from Memory Leaking a Script

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -6067,7 +6067,6 @@ return function(Vargs, env)
 						if oldga then oldga:Destroy() end
 						if olds then Remote.Send(v, "Function", "Unfly") olds:Destroy() end
 
-						local new = scr:Clone()
 						local flightPositionAttachment: Attachment = service.New("Attachment", {
 							Name = "ADONIS_FLIGHT_POSITION_ATTACHMENT",
 							Parent = part
@@ -6093,8 +6092,8 @@ return function(Vargs, env)
 							Parent = part
 						})
 
-						new.Parent = part
-						new.Disabled = false
+						scr.Parent = part
+						scr.Disabled = false
 					end
 				end
 


### PR DESCRIPTION
This PR aims to prevent the `:fly` command from doing any more Memory Leaks on the Server and Client, before it was cloning the Fly script, then the portion of the code which adds the Gyro attachments, was cloning the Clone and using that 2nd clone as the script, this then made the original Clone useless, and was acting as a Memory Leak.

tl;dr
`:fly` command was leaking memory by cloning a script twice in a row, and not destroying/deleting/using the first clone.

PoF:

https://github.com/user-attachments/assets/024f064a-dad7-47bb-af2b-95c0fb234a71

