### PR TITLE
Re-add ChatCreateRobloxCommands

### DIFF
--- a/Loader/Config/Settings.luau
+++ b/Loader/Config/Settings.luau
@@ -283,17 +283,18 @@ settings.CommandCooldowns = {
 ]]
 }
 
-settings.FunCommands = true				-- Are fun commands enabled?
-settings.PlayerCommands = true			-- Are player-level utility commands enabled?
-settings.AgeRestrictedCommands = true	-- Are age-locked commands enabled?
-settings.WarnDangerousCommand = false	-- Do dangerous commands ask for confirmation?
-settings.CommandFeedback = false		-- Should players be notified when commands with non-obvious effects are run on them?
-settings.CrossServerCommands = true		-- Are commands which affect more than one server enabled?
-settings.ChatCommands = true			-- If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands
-settings.CreatorPowers = true			-- Gives me creator-level admin; This is strictly used for debugging; I can't debug without full access to the script
-settings.CodeExecution = false			-- Enables the use of code execution in Adonis. Scripting related (such as ;s) and a few other commands require this
-settings.SilentCommandDenials = false	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
+settings.FunCommands = true					-- Are fun commands enabled?
+settings.PlayerCommands = true				-- Are player-level utility commands enabled?
+settings.AgeRestrictedCommands = true		-- Are age-locked commands enabled?
+settings.WarnDangerousCommand = false		-- Do dangerous commands ask for confirmation?
+settings.CommandFeedback = false			-- Should players be notified when commands with non-obvious effects are run on them?
+settings.CrossServerCommands = true			-- Are commands which affect more than one server enabled?
+settings.ChatCommands = true				-- If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands
+settings.CreatorPowers = true				-- Gives me creator-level admin; This is strictly used for debugging; I can't debug without full access to the script
+settings.CodeExecution = false				-- Enables the use of code execution in Adonis. Scripting related (such as ;s) and a few other commands require this
+settings.SilentCommandDenials = false		-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
 settings.OverrideChatCallbacks = true		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
+settings.ChatCreateRobloxCommands = false	-- Whether "/" commands for Roblox should get created in new Chat
 
 settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is ;slocked

--- a/MainModule/Client/Core/Process.luau
+++ b/MainModule/Client/Core/Process.luau
@@ -67,7 +67,11 @@ return function(Vargs, GetEnv)
 		Process.RateLimits = Remote.Get("RateLimits") or Process.RateLimits;
 
 		--// Hide TextChatComands
-		Process.HandleTextChatCommands()
+		task.defer(function()
+			if Remote.Get("Variable", "ChatCreateRobloxCommands") then
+				Process.HandleTextChatCommands()
+			end
+		end)
 
 		Process.RunAfterLoaded = nil;
 	end

--- a/MainModule/Server/Core/Admin.luau
+++ b/MainModule/Server/Core/Admin.luau
@@ -1219,7 +1219,7 @@ return function(Vargs, GetEnv)
 			if Variables.ChatCreateRobloxCommands then
 				-- // Support for commands to be ran via TextChat
 				task.spawn(function()
-					local container = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.TextChatService:WaitForChild("TextChatCommands", 9e9)
+					local container = service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService and service.TextChatService:WaitForChild("TextChatCommands", 120)
 
 					if container then
 						for _, v in container:GetChildren() do

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -134,6 +134,7 @@ return function(Vargs, GetEnv)
 		WhitelistedVariable = {
 			MusicList = true,
 			CodeName = true,
+			ChatCreateRobloxCommands = true,
 		};
 
 		Returnables = {

--- a/MainModule/Server/Dependencies/DefaultSettings.luau
+++ b/MainModule/Server/Dependencies/DefaultSettings.luau
@@ -283,17 +283,18 @@ settings.CommandCooldowns = {
 ]]
 }
 
-settings.FunCommands = true				-- Are fun commands enabled?
-settings.PlayerCommands = true			-- Are player-level utility commands enabled?
-settings.AgeRestrictedCommands = true	-- Are age-locked commands enabled?
-settings.WarnDangerousCommand = false	-- Do dangerous commands ask for confirmation?
-settings.CommandFeedback = false		-- Should players be notified when commands with non-obvious effects are run on them?
-settings.CrossServerCommands = true		-- Are commands which affect more than one server enabled?
-settings.ChatCommands = true			-- If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands
-settings.CreatorPowers = true			-- Gives me creator-level admin; This is strictly used for debugging; I can't debug without full access to the script
-settings.CodeExecution = true			-- Enables the use of code execution in Adonis; Scripting related (such as ;s) and a few other commands require this
-settings.SilentCommandDenials = false	-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
-settings.OverrideChatCallbacks = true	-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
+settings.FunCommands = true					-- Are fun commands enabled?
+settings.PlayerCommands = true				-- Are player-level utility commands enabled?
+settings.AgeRestrictedCommands = true		-- Are age-locked commands enabled?
+settings.WarnDangerousCommand = false		-- Do dangerous commands ask for confirmation?
+settings.CommandFeedback = false			-- Should players be notified when commands with non-obvious effects are run on them?
+settings.CrossServerCommands = true			-- Are commands which affect more than one server enabled?
+settings.ChatCommands = true				-- If false you will not be able to run commands via the chat; Instead, you MUST use the console or you will be unable to run commands
+settings.CreatorPowers = true				-- Gives me creator-level admin; This is strictly used for debugging; I can't debug without full access to the script
+settings.CodeExecution = false				-- Enables the use of code execution in Adonis. Scripting related (such as ;s) and a few other commands require this
+settings.SilentCommandDenials = false		-- If true, there will be no differences between the error messages shown when a user enters an invalid command and when they have insufficient permissions for the command
+settings.OverrideChatCallbacks = true		-- If the TextChatService ShouldDeliverCallbacks of all channels are overridden by Adonis on load. Required for slowmode. Mutes use a CanSend method to mute when this is set to false.
+settings.ChatCreateRobloxCommands = false	-- Whether "/" commands for Roblox should get created in new Chat
 
 settings.BanMessage = "Banned"				-- Message shown to banned users upon kick
 settings.LockMessage = "Not Whitelisted"	-- Message shown to people when they are kicked while the game is ;slocked


### PR DESCRIPTION
Re-added `Settings.ChatCreateRobloxCommands`, default is currently false. Also adds some checks to make sure HandleTextChatCommands is loaded when the setting is enabled & change timeout to 120 to prevent infinite yielding.

Would be better for the developer to actually know the option instead of it being obscured behind source code and being on by default.

PoF (Off & On):
<img width="548" height="241" alt="image" src="https://github.com/user-attachments/assets/608f8675-e64c-4bb5-b9f1-704cf8751e92" />
<img width="502" height="224" alt="image" src="https://github.com/user-attachments/assets/85d5fb1a-82ad-49eb-ac12-242b7b145b97" />
