### PR TITLE
Fix a lot of moderator commands that require the player to be in the server throwing errors, doing nothing, or acting weirdly

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -5098,7 +5098,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local statName = assert(args[2], "Missing stat name (argument #2)")
 				local valueToAdd = assert(tonumber(args[3]), "Missing/invalid numerical value to add (argument #3)")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local leaderstats = v:FindFirstChild("leaderstats")
 					if leaderstats then
 						leaderstats.Name = "leaderstats"
@@ -5128,7 +5128,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local statName = assert(args[2], "Missing stat name (argument #2)")
 				local valueToSubtract = assert(tonumber(args[3]), "Missing/invalid numerical value to subtract (argument #3)")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local leaderstats = v:FindFirstChild("leaderstats")
 					if leaderstats then
 						local absoluteMatch = leaderstats:FindFirstChild(statName)
@@ -5162,7 +5162,7 @@ return function(Vargs, env)
 
 				local clothingTemplate = `rbxassetid://{ClothingId}`
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						local bCreateNewDefaultClothing = false
@@ -5231,7 +5231,7 @@ return function(Vargs, env)
 
 				local clothingTemplate = `rbxassetid://{ClothingId}`
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						local bCreateNewDefaultClothing = false
@@ -5303,7 +5303,7 @@ return function(Vargs, env)
 
 				local clothingTemplate = `rbxassetid://{ClothingId}`
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						local humanoid = v.Character:FindFirstChildOfClass("Humanoid")
 						local bCreateNewDefaultClothing = false
@@ -5390,7 +5390,7 @@ return function(Vargs, env)
 					error("Invalid face(Image/robloxFace)", 0)
 				end
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local Head = v.Character and v.Character:FindFirstChild("Head")
 					local face = Head and Head:FindFirstChild("face")
 
@@ -5504,7 +5504,7 @@ return function(Vargs, env)
 					end
 				end
 
-				for _, v: Player in service.GetPlayers(plr, args[1]) do
+				for _, v: Player in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -5565,7 +5565,7 @@ return function(Vargs, env)
 			Description = "Remove any t-shirt(s) worn by the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 						if humanoid then
@@ -5585,7 +5585,7 @@ return function(Vargs, env)
 			Description = "Remove any shirt(s) worn by the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
-				for _, v: Player in service.GetPlayers(plr, args[1]) do
+				for _, v: Player in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -5603,7 +5603,7 @@ return function(Vargs, env)
 			Description = "Remove any pants(s) worn by the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})
-				for _, v: Player in service.GetPlayers(plr, args[1]) do
+				for _, v: Player in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -5660,7 +5660,7 @@ return function(Vargs, env)
 				pitch = tonumber(args[4]) or pitch
 
 
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.Send(v, "Function", "PlayAudio", id, volume, pitch, loop)
 
 				end
@@ -5675,7 +5675,7 @@ return function(Vargs, env)
 			Description = "Stops audio playing on the specified player's client";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string}, data: {})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.Send(v, "Function", "StopAudio", "all")
 
 				end
@@ -5714,7 +5714,7 @@ return function(Vargs, env)
 					SoundId = `rbxassetid://{args[2]}`;
 				})
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local char = v.Character
 					local rootPart = char and char:FindFirstChild("HumanoidRootPart")
 					if rootPart then
@@ -5740,7 +5740,7 @@ return function(Vargs, env)
 			Description = `Removes audio placed into character via {Settings.Prefix}charaudio command`;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local char = v.Character
 					local rootPart = char and char:FindFirstChild("HumanoidRootPart")
 					if rootPart then

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -6053,7 +6053,7 @@ return function(Vargs, env)
 
 				scr.Name = "ADONIS_FLIGHT"
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local part = v.Character and v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local oldp = part:FindFirstChild("ADONIS_FLIGHT_POSITION")
@@ -6099,7 +6099,10 @@ return function(Vargs, env)
 				end
                 scr:Destroy()
 
-				Functions.Hint("You are now flying - press E to toggle flight", service.GetPlayers(plr, args[1]), 10)
+				Functions.Hint("You are now flying - press E to toggle flight", service.GetPlayers(plr, args[1], {
+					DontError = true,
+					NoFakePlayer = true
+				}), 10)
 			end
 		};
 
@@ -6112,7 +6115,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local speed = tonumber(args[2])
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local part = v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local scr = part:FindFirstChild("ADONIS_FLIGHT")
@@ -6137,7 +6140,7 @@ return function(Vargs, env)
 			Description = "Removes the target player(s)'s ability to fly";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local part = v.Character and v.Character:FindFirstChild("HumanoidRootPart")
 					if part then
 						local oldp = part:FindFirstChild("ADONIS_FLIGHT_POSITION")
@@ -6162,7 +6165,7 @@ return function(Vargs, env)
 			Description = "Fling the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Routine(function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") and v.Character:FindFirstChild("Humanoid") then
 							local xran local zran
@@ -6194,7 +6197,7 @@ return function(Vargs, env)
 				local scr = Deps.Assets.Sfling:Clone()
 				scr.Strength.Value = strength
 				scr.Name = "SUPER_FLING"
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local new = scr:Clone()
 					new.Parent = v.Character.HumanoidRootPart
 					new.Disabled = false
@@ -6210,7 +6213,7 @@ return function(Vargs, env)
 			Description = "Name the target player(s) <name> or say hide to hide their character name";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local char = v.Character;
 					local human = char and char:FindFirstChildOfClass("Humanoid");
 					if human then
@@ -6233,7 +6236,7 @@ return function(Vargs, env)
 			Description = "Put the target player(s)'s back to normal";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local char = v.Character;
 					local human = char and char:FindFirstChildOfClass("Humanoid");
 					if human then
@@ -6254,7 +6257,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local name = args[2] == "hide" and " " or args[2]
 
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 
 					if humanoid then
@@ -6271,7 +6274,7 @@ return function(Vargs, env)
 			Description = "Put the target player(s)'s back to normal";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 
 					if humanoid then
@@ -6316,7 +6319,7 @@ return function(Vargs, env)
 				local success, desc = pcall(service.Players.GetHumanoidDescriptionFromOutfitId, service.Players, assert(tonumber(args[2]), "Missing OutfitId"))
 
 				if success then
-					for _, v in service.GetPlayers(plr, args[1]) do
+					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 						if v.Character and v.Character:FindFirstChildOfClass("Humanoid") then
 							v.Character.Humanoid:ApplyDescription(desc, Enum.AssetTypeVerification.Always)
 						end
@@ -6343,7 +6346,7 @@ return function(Vargs, env)
 					local success, desc = pcall(service.Players.GetHumanoidDescriptionFromUserId, service.Players, target.UserId)
 
 					if success then
-						for _, v in service.GetPlayers(plr, args[1]) do
+						for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 							v.CharacterAppearanceId = target.UserId
 
 							if v.Character and v.Character:FindFirstChildOfClass("Humanoid") then
@@ -6364,7 +6367,7 @@ return function(Vargs, env)
 			Description = "Put the target player(s)'s character appearence back to normal";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Routine(function()
 						v.CharacterAppearanceId = v.UserId
 
@@ -6389,7 +6392,7 @@ return function(Vargs, env)
 			Description = "Continuously heals the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					task.defer(function()
 						service.StartLoop(`{v.UserId}LOOPHEAL`, 0.1, function()
 							if not v or v.Parent ~= service.Players then
@@ -6416,7 +6419,7 @@ return function(Vargs, env)
 			Description = `Undoes {Settings.Prefix}loopheal`;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					service.StopLoop(`{v.UserId}LOOPHEAL`)
 				end
 			end
@@ -6474,7 +6477,7 @@ return function(Vargs, env)
 				return if target and target.Parent then Remote.Get(target, "ClientLog") else {"Player is currently unreachable"}
 			end;
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.MakeGui(plr, "List", {
 						Title = `{service.FormatPlayer(v)}'s Local Log`;
 						Table = Logs.ListUpdaters.LocalLog(plr, v);
@@ -6736,7 +6739,7 @@ return function(Vargs, env)
 					autoUpdate = true
 				end
 				local str = `{Settings.Prefix}logs {tostring(autoUpdate) or ""}`
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Admin.RunCommandAsPlayer(str, v)
 				end
 			end
@@ -6854,7 +6857,7 @@ return function(Vargs, env)
 			Description = "Makes it so the target player(s)'s cam can move around freely (Press Shift+P, F, or DPadLeft to toggle freecam)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local plrgui = v:FindFirstChildOfClass("PlayerGui")
 
 					if not plrgui or plrgui:FindFirstChild("Freecam") then
@@ -6878,7 +6881,7 @@ return function(Vargs, env)
 			Description = "UnFreecam";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local plrgui = v:FindFirstChildOfClass("PlayerGui")
 					local freecam = plrgui and plrgui:FindFirstChild("Freecam")
 					if freecam then
@@ -6901,7 +6904,7 @@ return function(Vargs, env)
 			Description = "Toggles Freecam";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local plrgui = v:FindFirstChildOfClass("PlayerGui")
 					local freecam = plrgui and plrgui:FindFirstChild("Freecam")
 					local remote = freecam and freecam:FindFirstChildOfClass("RemoteFunction")
@@ -6934,7 +6937,7 @@ return function(Vargs, env)
 					walk = true
 				end
 
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Functions.makeRobot(v, num, health, speed, damage, walk, attack, friendly)
 				end
 			end
@@ -6948,7 +6951,7 @@ return function(Vargs, env)
 			Description = "[Experimental] Says aloud the supplied text";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.Send(v, "Function", "TextToSpeech", args[2])
 				end
 			end
@@ -6980,7 +6983,7 @@ return function(Vargs, env)
 				end
 
 				if args[2] then
-					for _, v in service.GetPlayers(plr, args[2]) do
+					for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 						Remote.LoadCode(v, `game:GetService(\"SoundService\").AmbientReverb = Enum.ReverbType[{rev}]`)
 					end
 

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -7005,7 +7005,7 @@ return function(Vargs, env)
 				assert(args[1], "Missing target player")
 				args[2] = string.lower(assert(args[2], "Missing argument #2 (boolean expected)"))
 				assert(args[2] == "true" or args[2] == "false", "Invalid argument #2 (boolean expected)")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.Send(v, "Function", "SetCore", "ResetButtonCallback", if args[2] == "true" then true else false)
 				end
 			end

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -4018,7 +4018,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[2] then
-					for _, v in service.GetPlayers(plr, args[2]) do
+					for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 						Remote.SetLighting(v, "Brightness", args[1])
 					end
 				else
@@ -4035,7 +4035,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[2] then
-					for _, v in service.GetPlayers(plr, args[2]) do
+					for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 						Remote.SetLighting(v, "TimeOfDay", args[1])
 					end
 				else
@@ -4059,7 +4059,7 @@ return function(Vargs, env)
 					Functions.SetAtmosphere("Color", color)
 				end
 				if args[2] then
-					for _, v in service.GetPlayers(plr, args[2]) do
+					for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 						Remote.SetLighting(v, "FogColor", color)
 					end
 				else
@@ -4076,7 +4076,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[3] then
-					for _, v in service.GetPlayers(plr, args[3]) do
+					for _, v in service.GetPlayers(plr, args[3], { NoFakePlayer = true }) do
 						Remote.SetLighting(v, "FogEnd", args[2])
 						Remote.SetLighting(v, "FogStart", args[1])
 					end
@@ -4110,7 +4110,7 @@ return function(Vargs, env)
 					end
 				end
 				if #found > 0 then
-					for _, v in service.GetPlayers(plr, args[1]) do
+					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 						for k, t in found do
 							t:Clone().Parent = v.StarterGear
 						end
@@ -4131,7 +4131,7 @@ return function(Vargs, env)
 			Description = "Removes the desired tool from the target player(s)'s StarterPack";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, string.lower(args[1])) do
+				for _, v in service.GetPlayers(plr, string.lower(args[1]), { NoFakePlayer = true }) do
 					local StarterGear = v:FindFirstChildOfClass("StarterGear")
 					if StarterGear then
 						for _, tool in StarterGear:GetChildren() do
@@ -4169,7 +4169,7 @@ return function(Vargs, env)
 					end
 				end
 				if #found > 0 then
-					for _, v in service.GetPlayers(plr, args[1]) do
+					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 						for k, t in found do
 							t:Clone().Parent = v.Backpack
 						end
@@ -4243,7 +4243,7 @@ return function(Vargs, env)
 			Description = "Removes all of the target player(s)'s on-screen GUIs except Adonis GUIs";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.LoadCode(v, [[for i, v in ipairs(service.PlayerGui:GetChildren()) do if not client.Core.GetGui(v) then pcall(v.Destroy, v) end end]])
 				end
 			end
@@ -4256,7 +4256,7 @@ return function(Vargs, env)
 			Description = "Remove the target player(s)'s tools";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						local hum = v.Character:FindFirstChildOfClass("Humanoid")
 						if hum then hum:UnequipTools() end
@@ -4281,7 +4281,7 @@ return function(Vargs, env)
 			Description = "Remove a specified tool from the target player(s)'s backpack";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						for _, tool in v.Character:GetChildren() do
 							if tool:IsA("BackpackItem") and string.sub(tool.Name:lower(), 1, #args[2])== args[2]:lower() then
@@ -4329,7 +4329,7 @@ return function(Vargs, env)
 			Description = "Removes <number> HP from the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum:TakeDamage(args[2])
@@ -4345,7 +4345,7 @@ return function(Vargs, env)
 			Description = "Set the target player(s)'s health and max health to <number>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = args[2]
@@ -4362,7 +4362,7 @@ return function(Vargs, env)
 			Description = "Set the target player(s)'s jump power to <number>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.JumpPower = args[2] or 50
@@ -4379,7 +4379,7 @@ return function(Vargs, env)
 			Description = "Set the target player(s)'s jump height to <number>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.JumpHeight = args[2] or 7.2
@@ -4399,7 +4399,7 @@ return function(Vargs, env)
 				assert(not args[2] or args[2]:lower() ~= "inf", "Speed cannot be infinite")
 				local speed = tonumber(args[2]) or 16
 				assert(speed >= 0, "Speed cannot be negative")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.WalkSpeed = speed
@@ -4531,7 +4531,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2] and tonumber(args[2]), "Missing or invalid FOV number")
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.LoadCode(v,[[workspace.CurrentCamera.FieldOfView=]].. math.clamp(tonumber(args[2]), 1, 120))
 				end
 			end
@@ -4550,7 +4550,7 @@ return function(Vargs, env)
 				local teleportOptions = if reservedServerInfo then service.New("TeleportOptions", {
 					ReservedServerAccessCode = reservedServerInfo.Code
 				}) else nil
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Routine(function()
 						if
 							Remote.MakeGuiGet(v, "Notification", {
@@ -4631,7 +4631,7 @@ return function(Vargs, env)
 			Hidden = true;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				Functions.Notification("Teleport", "Click to teleport to Plaza Connect", service.GetPlayers(plr, args[1]), 30, "MatIcon://QR code scanner", Core.Bytecode("service.TeleportService:Teleport(5118029260)"))
+				Functions.Notification("Teleport", "Click to teleport to Plaza Connect", service.GetPlayers(plr, args[1], { NoFakePlayer = true }), 30, "MatIcon://QR code scanner", Core.Bytecode("service.TeleportService:Teleport(5118029260)"))
 			end
 		};
 
@@ -4891,7 +4891,7 @@ return function(Vargs, env)
 			Description = "Returns the player to their original position";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, player in service.GetPlayers(plr, args[1]) do
+				for i, player in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if Variables.ReturnPoints[player] then
 						player.Character.HumanoidRootPart.CFrame = Variables.ReturnPoints[player]
 						Variables.ReturnPoints[player] = nil;

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -3123,7 +3123,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local plrBackpack = assert(plr:FindFirstChildOfClass("Backpack"), "You have no backpack")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local scr = Deps.Assets.ClickTeleport:Clone()
 					scr.Mode.Value = "Teleport"
 					scr.Target.Value = v.Name
@@ -3148,7 +3148,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local plrBackpack = assert(plr:FindFirstChildOfClass("Backpack"), "You have no backpack")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local scr = Deps.Assets.ClickTeleport:Clone()
 					scr.Mode.Value = "Walk"
 					scr.Target.Value = v.Name
@@ -3172,7 +3172,7 @@ return function(Vargs, env)
 			Description = "Lets you take control of the target player";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						local Humanoid = v.Character.Humanoid
 
@@ -3215,7 +3215,7 @@ return function(Vargs, env)
 			Description = "Refreshes the target player(s)'s character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, p in service.GetPlayers(plr, args[1]) do
+				for i, p in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					task.defer(function()
 						local oChar = p.Character;
 						local oTools, pBackpack, oHumanoid, oPrimary, oPos;
@@ -3295,7 +3295,7 @@ return function(Vargs, env)
 			Description = "Kills the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						local hum = v.Character:FindFirstChildOfClass("Humanoid")
 						if hum then
@@ -3314,7 +3314,7 @@ return function(Vargs, env)
 			Description = "Respawns the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					task.defer(function()
 						pcall(v.LoadCharacter, v)
 						Remote.Send(v, "Function", "SetView", "reset")
@@ -3330,7 +3330,7 @@ return function(Vargs, env)
 			Description = "Converts players' character to R6";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					task.defer(Functions.ConvertPlayerCharacterToRig, v, "R6")
 				end
 			end
@@ -3343,7 +3343,7 @@ return function(Vargs, env)
 			Description = "Converts players' character to R15";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Functions.ConvertPlayerCharacterToRig(v, "R15")
 				end
 			end
@@ -3356,7 +3356,7 @@ return function(Vargs, env)
 			Description = "Stuns the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 
 					if Humanoid then
@@ -3373,7 +3373,7 @@ return function(Vargs, env)
 			Description = "UnStuns the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 
 					if Humanoid then
@@ -3390,7 +3390,7 @@ return function(Vargs, env)
 			Description = "Forces the target player(s) to jump";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if Humanoid then
 						Humanoid.Jump = true
@@ -3406,7 +3406,7 @@ return function(Vargs, env)
 			Description = "Forces the target player(s) to sit";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local Humanoid = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if Humanoid then
 						Humanoid.Sit = true
@@ -3422,7 +3422,7 @@ return function(Vargs, env)
 			Description = "Set the transparency of the target's character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						for k, p in v.Character:GetChildren() do
 							if p:IsA("BasePart") and p.Name ~= "HumanoidRootPart" then
@@ -3454,7 +3454,7 @@ return function(Vargs, env)
 			Description = "Set the transparency of the target's character's parts, including accessories; supports a comma-separated list of part names";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, player in service.GetPlayers(plr, args[1]) do
+				for i, player in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if player.Character then
 						local humanoid = player.Character:FindFirstChildOfClass("Humanoid")
 						if humanoid then
@@ -3734,7 +3734,7 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) invisible";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") then
@@ -3777,7 +3777,7 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) visible";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") and obj.Name~="HumanoidRootPart" then
@@ -3832,7 +3832,7 @@ return function(Vargs, env)
 					color = assert(Functions.ParseColor3(args[2]), "Invalid color provided")
 				end
 
-				for _, v: Player in service.GetPlayers(plr, args[1]) do
+				for _, v: Player in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid: Humanoid? = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -3854,7 +3854,7 @@ return function(Vargs, env)
 			Description = "Locks the target player(s), preventing the use of btools on the character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") then
@@ -3875,7 +3875,7 @@ return function(Vargs, env)
 			Description = "UnLocks the the target player(s), makes it so you can use btools on them";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						for a, obj in v.Character:GetChildren() do
 							if obj:IsA("BasePart") then
@@ -3898,7 +3898,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				local color = Functions.ParseColor3(args[2]) or BrickColor.new("Bright blue").Color
 
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						Functions.NewParticle(v.Character.HumanoidRootPart, "PointLight", {
 							Name = "ADONIS_LIGHT";
@@ -3918,7 +3918,7 @@ return function(Vargs, env)
 			Description = "UnLights the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 						Functions.RemoveParticle(v.Character.HumanoidRootPart, "ADONIS_LIGHT")
 					end
@@ -3937,7 +3937,7 @@ return function(Vargs, env)
 				local color = assert(Functions.ParseColor3(args[1]), "Invalid color provided")
 
 				if args[2] then
-					for _, v in service.GetPlayers(plr, args[2]) do
+					for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 						Remote.SetLighting(v, "Ambient", color)
 					end
 				else
@@ -3957,7 +3957,7 @@ return function(Vargs, env)
 				local color = assert(Functions.ParseColor3(args[1]), "Invalid color provided")
 
 				if args[2] then
-					for _, v in service.GetPlayers(plr, args[2]) do
+					for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 						Remote.SetLighting(v, "OutdoorAmbient", color)
 					end
 				else
@@ -3974,7 +3974,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				if args[1] then
-					for _, v in service.GetPlayers(plr, args[1]) do
+					for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 						Remote.SetLighting(v, "FogEnd", 1000000000000)
 					end
 				else
@@ -3992,7 +3992,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				if string.lower(args[1])=="on" or string.lower(args[1])=="true" then
 					if args[2] then
-						for _, v in service.GetPlayers(plr, args[2]) do
+						for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 							Remote.SetLighting(v, "GlobalShadows", true)
 						end
 					else
@@ -4000,7 +4000,7 @@ return function(Vargs, env)
 					end
 				elseif string.lower(args[1])=="off" or string.lower(args[1])=="false" then
 					if args[2] then
-						for _, v in service.GetPlayers(plr, args[2]) do
+						for _, v in service.GetPlayers(plr, args[2], { NoFakePlayer = true }) do
 							Remote.SetLighting(v, "GlobalShadows", false)
 						end
 					else

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -2191,7 +2191,7 @@ return function(Vargs, env)
 			Description = "Gives you a playable keyboard piano. Credit to NickPatella.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local Dropper = v:FindFirstChildOfClass("PlayerGui") or v:FindFirstChildOfClass("Backpack")
 					if Dropper then
 						local piano = Deps.Assets.Piano:Clone()
@@ -2333,7 +2333,7 @@ return function(Vargs, env)
 				end
 			end;
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.MakeGui(plr, "List", {
 						Title = `{service.FormatPlayer(v)}'s Client Instances`;
 						Table = Logs.ListUpdaters.ShowClientInstances(plr, v);
@@ -2353,7 +2353,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local deleteAll = args[2] and (args[2]:lower() == "true" or args[2]:lower() == "yes")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if deleteAll then
 						Routine(Remote.RemoveGui, v, true)
 					else
@@ -2378,7 +2378,7 @@ return function(Vargs, env)
 			Description = "Removes all screen UI effects such as Spooky, Clown, ScreenImage, ScreenVideo, etc.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1] or "all") do
+				for _, v in service.GetPlayers(plr, args[1] or "all", { NoFakePlayer = true }) do
 					Remote.RemoveGui(v, "Effect")
 				end
 			end
@@ -2431,7 +2431,7 @@ return function(Vargs, env)
 			Description = "Sets the player's lighting to match the server's";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					for prop, val in Variables.LightingSettings do
 						Remote.SetLighting(v, prop, val)
 					end
@@ -2446,7 +2446,7 @@ return function(Vargs, env)
 			Description = "Sets target player(s)'s leader stats to 0 (N/A if it's a string)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, string.lower(args[1])) do
+				for _, v in service.GetPlayers(plr, string.lower(args[1]), { NoFakePlayer = true }) do
 					task.spawn(pcall, function()
 						if v and v:FindFirstChild("leaderstats") then
 							for a, q in v.leaderstats:GetChildren() do
@@ -2465,7 +2465,7 @@ return function(Vargs, env)
 			Description = "Prompts the player(s) to buy the product belonging to the ID you supply";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					service.MarketPlace:PromptPurchase(v, tonumber(args[2]), false)
 				end
 			end
@@ -2508,7 +2508,7 @@ return function(Vargs, env)
 						end
 					end
 				end
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Functions.Cape(v, false, mat, color, id, ref)
 				end
 			end
@@ -2521,7 +2521,7 @@ return function(Vargs, env)
 			Description = "Removes the target player(s)'s cape";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Functions.UnCape(v)
 				end
 			end
@@ -2537,7 +2537,7 @@ return function(Vargs, env)
 				local clipper = Deps.Assets.Clipper:Clone()
 				clipper.Name = "ADONIS_NoClip"
 
-				for i, p in service.GetPlayers(plr, args[1]) do
+				for i, p in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Admin.RunCommand(`{Settings.Prefix}clip`, p.Name)
 					local new = clipper:Clone()
 					new.Parent = p.Character.Humanoid
@@ -2557,7 +2557,7 @@ return function(Vargs, env)
 			Description = "Un-NoClips the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, p in service.GetPlayers(plr, args[1]) do
+				for i, p in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local old = p.Character.Humanoid:FindFirstChild("ADONIS_NoClip")
 					if old then
 						if old.Clip.Value then
@@ -2598,7 +2598,7 @@ return function(Vargs, env)
 
 				local Color = args[3] and (string.lower(args[3]) == "rainbow" and "rainbow" or string.match(args[3], "%d") and Functions.ParseColor3(args[3]) or Functions.ParseBrickColor(args[3], true)) or BrickColor.new("White")
 
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local cHumanoidRootPart	= v.Character and v.Character.PrimaryPart or v.Character and v.Character:FindFirstChild("HumanoidRootPart")
 					if cHumanoidRootPart then
 						local CF = CFrame.new(cHumanoidRootPart.CFrame.p + Vector3.new(0, 1, 0))
@@ -2824,7 +2824,7 @@ return function(Vargs, env)
 					off = "off"
 				}
 				local chatColor = args[2] and CHAT_COLORS[args[2]:lower()] or CHAT_COLORS.red
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.MakeGui(v, "BubbleChat", {Color = chatColor;})
 				end
 			end
@@ -2845,7 +2845,7 @@ return function(Vargs, env)
 					Variables.TrackingTable[plr.Name] = {}
 				end
 
-				for _, v: Player in service.GetPlayers(plr, args[1]) do
+				for _, v: Player in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if persistent and Variables.TrackingTable[plr.Name] then
 						Variables.TrackingTable[plr.Name][v] = true
 					end
@@ -2953,7 +2953,7 @@ return function(Vargs, env)
 			Description = "Makes the player(s) character completely local";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.MakeLocal(v, v.Character)
 				end
 			end
@@ -2966,7 +2966,7 @@ return function(Vargs, env)
 			Description = "UnPhases the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						Remote.MoveLocal(v, v.Character.Name, false, workspace)
 						v.Character.Parent = workspace
@@ -2982,7 +2982,7 @@ return function(Vargs, env)
 			Description = "Gives the target player(s) tools that are in the game's StarterPack";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local Backpack = v:FindFirstChildOfClass("Backpack")
 					if Backpack then
 						for a, q in service.StarterPack:GetChildren() do

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -51,7 +51,7 @@ return function(Vargs, env)
 				Remote.Send(plr, "Function", "CharacterESP", false)
 
 				if args[1] then
-					for _2, v2 in service.GetPlayers(plr, args[1]) do
+					for _2, v2 in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 						if not v2.Character then
 							continue
 						end
@@ -138,7 +138,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[2], "Missing message")
 
-				for _, v in service.GetPlayers(plr, assert(args[1], "Missing player name")) do
+				for _, v in service.GetPlayers(plr, assert(args[1], "Missing player name"), { NoFakePlayer = true }) do
 					Functions.Notification("Notification", service.Filter(args[2], plr, v), {v})
 				end
 			end
@@ -193,7 +193,7 @@ return function(Vargs, env)
 				local num = assert(tonumber(args[2]), "Missing or invalid time value (must be a number)")
 				assert(num <= 1000, "Countdown cannot be longer than 1000 seconds.")
 				assert(num >= 0, "Countdown cannot be negative.")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.MakeGui(v, "Countdown", {
 						Time = math.round(num);
 					})

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -1056,7 +1056,7 @@ return function(Vargs, env)
 					CanManageUsers = true;
 				})
 
-				for i, v in service.GetPlayers(plr, args[1]) do
+				for i, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v ~= plr then
 						newSession:AddUser(v)
 						Remote.MakeGui(v, "PrivateChat", {
@@ -1081,7 +1081,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2], "Missing message")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local replyTicket = service.HttpService:GenerateGUID(false)
 					Variables.PMtickets[replyTicket] = plr
 
@@ -1102,7 +1102,7 @@ return function(Vargs, env)
 			Description = "UnColorCorrection the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, p in service.GetPlayers(plr, args[1]) do
+				for _, p in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.RemoveLocal(p, "WINDOW_COLORCORRECTION", "Camera")
 				end
 			end
@@ -1115,7 +1115,7 @@ return function(Vargs, env)
 			Description = "UnSunrays the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.RemoveLocal(v, "WINDOW_SUNRAYS", "Camera")
 				end
 			end
@@ -1128,7 +1128,7 @@ return function(Vargs, env)
 			Description = "UnBloom the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.RemoveLocal(v, "WINDOW_BLOOM", "Camera")
 				end
 			end
@@ -1141,7 +1141,7 @@ return function(Vargs, env)
 			Description = "UnBlur the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.RemoveLocal(v, "WINDOW_BLUR", "Camera")
 				end
 			end
@@ -1154,7 +1154,7 @@ return function(Vargs, env)
 			Description = "Remove admin made lighting effects from the target player's screen";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					for _, e in {"BLUR", "BLOOM", "THERMAL", "SUNRAYS", "COLORCORRECTION"} do
 						Remote.RemoveLocal(v, `WINDOW_{e}`, "Camera")
 					end
@@ -1232,7 +1232,7 @@ return function(Vargs, env)
 				return tab
 			end;
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Routine(function()
 						Remote.MakeGui(plr, "List", {
 							Title = `{service.FormatPlayer(v)}'s tools`;
@@ -1465,8 +1465,8 @@ return function(Vargs, env)
 			Description = "Forces one player to view another";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				local targets = service.GetPlayers(plr, args[2])
-				for _, viewer in service.GetPlayers(plr, args[1]) do
+				local targets = service.GetPlayers(plr, args[2], { NoFakePlayer = true })
+				for _, viewer in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					for _, target in targets do
 						local targetHum = target.Character and target.Character:FindFirstChildOfClass("Humanoid")
 						if not targetHum then continue end
@@ -1488,7 +1488,7 @@ return function(Vargs, env)
 			Description = "Makes you view the target player";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local function viewPlayer(plr: Player, rootPart: BasePart, humanoid: Humanoid)
 						Functions.ResetReplicationFocus(plr)
 						plr.ReplicationFocus = rootPart
@@ -1555,7 +1555,7 @@ return function(Vargs, env)
 			Description = "Makes a viewport of the target player<s>";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v and v.Character:FindFirstChildOfClass("Humanoid") then
 						Remote.MakeGui(plr, "Viewport", {Subject = v.Character.HumanoidRootPart});
 					end
@@ -1570,7 +1570,7 @@ return function(Vargs, env)
 			Description = "Resets your view";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character and v.Character.PrimaryPart then
 						Functions.ResetReplicationFocus(v)
 					else
@@ -1594,7 +1594,7 @@ return function(Vargs, env)
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				local p
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					p = v
 				end
 				if p then
@@ -1730,7 +1730,7 @@ return function(Vargs, env)
 			Description = "Shows the target player's ping";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Functions.Hint(`{service.FormatPlayer(v)}'s Ping is {v:GetNetworkPing() * 1000}ms`, {plr})
 				end
 			end

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -228,7 +228,7 @@ return function(Vargs, env)
 			Description = "Stops all currently running countdowns";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.RemoveGui(v, "Countdown")
 				end
 				service.StopLoop("HintCountdown")
@@ -271,7 +271,7 @@ return function(Vargs, env)
 				assert(args[2], "Missing message")
 
 				local Sender = string.format("Message from %s", service.FormatPlayer(plr))
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Functions.Message(Sender, service.Filter(args[2], plr, v), {v}, true)
 				end
 			end
@@ -311,7 +311,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				assert(args[1], "Missing player name")
 				assert(args[2], "Missing message")
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Remote.RemoveGui(v, "Notify")
 					Functions.Notify(`Message from {service.FormatPlayer(plr)}`, service.Filter(args[2], plr, v), {v})
 				end
@@ -555,7 +555,7 @@ return function(Vargs, env)
 			Description = "Makes a message in the target player(s)'s chat window";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string}, data: {any})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if service.TextChatService and service.TextChatService.ChatVersion == Enum.ChatVersion.TextChatService then
 						local TextToUse = args[2]
 						if data.Options.Chat ~= true then
@@ -577,7 +577,7 @@ return function(Vargs, env)
 			Description = "Gives a force field to the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						service.New("ForceField", v.Character).Visible = if args[2] and args[2]:lower() == "false" then false else true
 					end
@@ -592,7 +592,7 @@ return function(Vargs, env)
 			Description = "Removes force fields on the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if v.Character then
 						Routine(function()
 							for _, c in v.Character:GetChildren() do
@@ -613,7 +613,7 @@ return function(Vargs, env)
 			Description = "Removes the target player(s)'s character";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local char = v.Character
 					if char then
 						Remote.LoadCode(v, [[service.StarterGui:SetCoreGuiEnabled(Enum.CoreGuiType.Backpack, false)]])
@@ -630,7 +630,7 @@ return function(Vargs, env)
 			Description = "UnPunishes the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1])  do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true })  do
 					local char = v.Character
 					if char then
 						char.Parent = workspace
@@ -648,7 +648,7 @@ return function(Vargs, env)
 			Description = "Freezes the target player(s)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Routine(function()
 						if v.Character then
 							for a, obj in v.Character:GetChildren() do
@@ -667,7 +667,7 @@ return function(Vargs, env)
 			Description = "UnFreezes the target players, thaws them out";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Routine(function()
 						if v.Character and v.Character:FindFirstChild("HumanoidRootPart") then
 							local ice = v.Character:FindFirstChild("Adonis_Ice")
@@ -715,7 +715,7 @@ return function(Vargs, env)
 			Description = "FFs, Gods, Names, Freezes, and removes the target player's tools until they jump.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					Routine(function()
 						local ff = service.New("ForceField", v.Character)
 						local hum = v.Character.Humanoid
@@ -756,7 +756,7 @@ return function(Vargs, env)
 			Description = "Heals the target player(s) (Regens their health)";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.Health = hum.MaxHealth
@@ -772,7 +772,7 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) immortal, makes their health so high that normal non-explosive weapons can't kill them";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = math.huge
@@ -792,7 +792,7 @@ return function(Vargs, env)
 			Description = "Makes the target player(s) mortal again";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = 100
@@ -816,7 +816,7 @@ return function(Vargs, env)
 			Description = `Same as {Functions.GetMainPrefix()}god, but also provides blast protection`;
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
+				for _, v in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local hum = v.Character and v.Character:FindFirstChildOfClass("Humanoid")
 					if hum then
 						hum.MaxHealth = math.huge
@@ -841,7 +841,7 @@ return function(Vargs, env)
 			Description = "Removes any hats the target is currently wearing and from their HumanoidDescription.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, p in service.GetPlayers(plr, args[1]) do
+				for _, p in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid: Humanoid? = p.Character and p.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()
@@ -864,7 +864,7 @@ return function(Vargs, env)
 			Function = function(plr: Player, args: {string})
 				-- TODO: HumanoidDescription
 				assert(args[2], "Argument(s) missing or nil")
-				for _, p in service.GetPlayers(plr, args[1]) do
+				for _, p in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					if not p.Character then continue end
 					for _, v in p.Character:GetChildren() do
 						if v:IsA("Accessory") and v.Name:lower() == args[2]:lower() then
@@ -882,7 +882,7 @@ return function(Vargs, env)
 			Description = "Remvoes layered clothings from their HumanoidDescription.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for _, p in service.GetPlayers(plr, args[1]) do
+				for _, p in service.GetPlayers(plr, args[1], { NoFakePlayer = true }) do
 					local humanoid: Humanoid? = p.Character and p.Character:FindFirstChildOfClass("Humanoid")
 					if humanoid then
 						local humanoidDesc: HumanoidDescription = humanoid:GetAppliedDescription()


### PR DESCRIPTION
The issue: A lot of commands require the player to be online and if the `NoFakePlayer = true` parameter on `service.GetPlayers` is not there then some commands will also error out or do nothing not notifying the player isn't in the server/has not been found.

This fix displays this message which is:
<img width="514" height="172" alt="image" src="https://github.com/user-attachments/assets/39c6e81b-5863-422e-bb88-530a4051f1f3" />
instead of the command erroring, doing nothing or acting weirdly as said above

Moderator commands that have been fixed:
- ESP
- Notification
- CountdownPM
- StopCountdown
- MessagePM
- NotifyPM
- ChatNotify
- ForceField
- UnForcefield
- Punish
- UnPunish
- Freeze
- Thaw
- AFK
- Heal
- God
- UnGod
- FullGod
- RemoveHats
- RemoveHat
- RemoveLayeredClothings
- PrivateChat
- PrivateMessage
- UnColorCorrection
- UnSunRays
- UnBloom
- UnBlur
- UnLightingEffect
- ShowBackpack
- ForceView
- View
- Viewport
- ResetView
- GuiView
- GetPing
- Piano
- ShowClientInstances
- ClearGUIs
- ClearEffects
- ClearLighting
- ResetStats
- Sell
- Cape
- UnCape
- NoClip
- Clip
- Jail
- BubbleChat
- Track
- Phase
- UnPhase
- GiveStarterPack
- ClickTeleport
- ClickWalk
- Control
- Refresh
- Kill
- Respawn
- R6
- R15
- Stun
- UnStun
- Jump
- Sit
- Transparency
- TransparentPart
- Invisible
- Visible
- PlayerColor
- Lock
- UnLock
- Light
- UnLight
- Ambient
- OutdoorAmbient
- RemoveFog
- Shadows
- Brightness
- Time
- FogColor
- FogStartEnd
- StarterGive
- StarterRemove
- Give
- RemoveGuis
- RemoveTools
- RemoveTool
- Damage
- SetHealth
- JumpPower
- JumpHeight
- Speed
- SetFOV
- Place
- GRPlaza
- Return
- AddToStat
- SubtractFromStat
- CustomTShirt
- CustomShirt
- CustomPants
- CustomFace
- AvatarItem
- RemoveTShirt
- RemoveShirt
- RemovePants
- UnTargetAudio
- CharacterAudio
- UnCharacterAudio
- Fly
- FlySpeed
- UnFly
- Fling
- SuperFling
- DisplayName
- UnDisplayName
- Name
- UnName
- Outfit
- Char
- UnChar
- LoopHeal
- UnLoopHeal
- LocalLog
- ShowLogs
- Freecam
- UnFreecam
- ToggleFreecam
- Bots
- TextToSpeech
- Reverb
- ResetButtonEnabled