### PR TITLE
Fix cross-server shutdown countdown system

### DIFF
--- a/MainModule/Server/Plugins/Cross_Server.luau
+++ b/MainModule/Server/Plugins/Cross_Server.luau
@@ -89,26 +89,23 @@ return function(Vargs, GetEnv)
 
 		GlobalRestartRequest = function(jobId, reason, countdown, abortable)
 			local taskobj
+			
 			if reason == "[CRS_SRV]:abort" then
 				for i,t in service.Threads.Tasks do
 					if t.Name == "GLOBALRESTART_COUNTDOWN" then
-						pcall(task.cancel,t.Thread) -- forcefully close not caring about adonis's task system
-						coroutine.close(t.Thread)
-						t.Kill() -- mark it as killed so adonis sees it
-						Functions.Hint(`Server restart aborted. Server will no longer restart.`, service.GetPlayers())
+						pcall(task.cancel, t.Thread)
+						t.Remove()
+						Functions.Hint("Server restart aborted. This server will no longer restart.", service.GetPlayers())
+						Logs.AddLog(Logs.Script, `Global restart aborted`)
 						return
 					end
 				end
 				return
 			end
 			if countdown then
-				Logs.AddLog("Script", {
-					`Global restart issued {countdown} seconds for "{reason}"`
-				});
+				Logs.AddLog(Logs.Script, `Global restart issued {countdown} seconds for "{reason}"`)
 			else
-				Logs.AddLog("Script", {
-					`Global restart issued for "{reason}"`
-				});
+				Logs.AddLog(Logs.Script, `Global restart issued for "{reason}"`);
 			end
 			if countdown then
 				do
@@ -116,64 +113,53 @@ return function(Vargs, GetEnv)
 					if countdown < 60 then time = `{countdown} seconds`
 					else time = `{math.floor(countdown/60)} minutes`
 					end
-					Functions.Hint(`Server restart in {time}.`, service:GetPlayers())
+					Functions.Hint(`Server restart in {time}.`, service.GetPlayers())
 				end
-				local forceful_exit = false
 				for i,t in service.Threads.Tasks do
 					if t.Name == "GLOBALRESTART_COUNTDOWN" then
-						pcall(task.cancel,t.Thread) -- forcefully close not caring about adonis's task system
-						coroutine.close(t.Thread)
-						t.Kill() -- mark it as killed so adonis sees it
+						pcall(task.cancel, t.Thread)
+						t.Remove()
+						Logs.AddLog(Logs.Script, `Global restart aborted`)
+						return
 					end
 				end
-				taskobj = service.Threads.NewTask("THREAD: GLOBALRESTART_COUNTDOWN", function()
+				taskobj = select(2, service.Threads.NewTask("GLOBALRESTART_COUNTDOWN", function()
 					local brackets = {
-						[1800]="30 minutes",
-						[1200]="20 minutes",
-						[600]="10 minutes",
-						[300]="5 minutes",
-						[120]="2 minutes",
-						[60]="1 minute",
-						[30]="30 seconds",
-						[10]="10 seconds"
+						{1800, "30 minutes"},
+						{1200, "20 minutes"},
+						{600, "10 minutes"},
+						{300, "5 minutes"},
+						{120, "2 minutes"},
+						{60, "1 minute"},
+						{30, "30 seconds"},
+						{10, "10 seconds"},
 					}
 					local currentbracket,lastbracket
 					local function updatebracket()
-						local i = 1
-						local lastt
-						for time,bracket in pairs(brackets) do
-							if time <= countdown then
-								currentbracket = brackets[lastt]
+						for _, v in brackets do
+							if countdown <= v[1] then
+								currentbracket = v[2]
 							end
-							i+=1
 						end
 					end
 					updatebracket()
 					lastbracket = currentbracket
 					while countdown > 0 do
 						countdown -= task.wait(1)
-						if taskobj.R_Status == "Stopping" and abortable then
-							Functions.Hint(`Server restart aborted. Server will no longer restart.`, service.GetPlayers())
-							return
-						end
 						updatebracket()
 						if lastbracket ~= currentbracket then
 							Functions.Hint(`Server restart in {currentbracket}.`, service.GetPlayers())
 						end
 						lastbracket = currentbracket
 					end
-					Logs.AddLog("Script", {
-						`Server is restarting NOW. (issued global restart)`
-					});
+					Logs.AddLog(Logs.Script, "Server is restarting NOW. (issued global restart)")
 					Admin.RunCommand(`{Settings.Prefix}restart`, reason)
-				end)
+				end))
 				taskobj.abortable = abortable
-				taskobj.Start()
+				taskobj.Resume()
 				return
 			end
-			Logs.AddLog("Script", {
-				`Server is restarting NOW. (issued global restart)`
-			});
+			Logs.AddLog(Logs.Script, "Server is restarting NOW. (issued global restart)")
 			Admin.RunCommand(`{Settings.Prefix}restart`, reason)
 		end;
 

--- a/MainModule/Server/Plugins/Server-SoftShutdown.luau
+++ b/MainModule/Server/Plugins/Server-SoftShutdown.luau
@@ -203,22 +203,22 @@ return function(Vargs, GetEnv)
 		CrossServerDenied = true;
 		IsCrossServer = true;
 		Function = function(plr: Player, args: {string})
-			local time
+			local seconds = tonumber(args[2])
 			if args[2] then
-				time = string.lower(args[2])
+				local time = string.lower(args[2])
 				if string.sub(time, -1, -1) == "s" then
-					time = tonumber(string.sub(time, 1, -2))
+					seconds = tonumber(string.sub(time, 1, -2))
 				elseif string.sub(time, -1, -1) == "m" then
-					time = tonumber(string.sub(time, 1, -2)) * 60
+					seconds = tonumber(string.sub(time, 1, -2)) * 60
 				else
-					error("Invalid time specified.");
+					error(`Invalid time specified ({args[2]})`)
 				end
-				assert(time, "Invalid time specified.")
 			end
+			
 			if not Core.CrossServer("GlobalRestartRequest",
 				args[1] or "No reason specified.",
-				if args[2] then tonumber(args[2]) else args[2],
-				not (string.lower(args[3]) == "no" or string.lower(args[3]) == "false")
+				seconds,
+				not (args[3] and (string.lower(args[3]) == "no" or string.lower(args[3]) == "false"))
 				)
 			then
 				error("CrossServer handler not ready (try again later)")
@@ -235,12 +235,7 @@ return function(Vargs, GetEnv)
 		CrossServerDenied = true;
 		IsCrossServer = true;
 		Function = function(plr: Player, args: {string})
-			if not Core.CrossServer("GlobalRestartRequest",
-				"[CRS_SRV]:abort",
-				0,
-				false
-				)
-			then
+			if not Core.CrossServer("GlobalRestartRequest", "[CRS_SRV]:abort") then
 				error("CrossServer handler not ready (try again later)")
 			end
 		end
@@ -258,7 +253,10 @@ return function(Vargs, GetEnv)
 			for i,t in service.Threads.Tasks do
 				if t.Name == "GLOBALRESTART_COUNTDOWN" then
 					assert(t.abortable, "Failed to abort shutdown (access denied)")
-					t.Stop()
+					pcall(task.cancel, t.Thread)
+					t.Remove()
+					Functions.Hint("Server restart aborted. This server will no longer restart.", service.GetPlayers())
+					Logs.AddLog(Logs.Script, "Global restart aborted for this private server")
 				end
 			end
 		end


### PR DESCRIPTION
For some reason the ;globalsoftshutdown command function parsed & validated the time parameter, but it didn't do anything further with it. The logic for it was already implemented but it was filled with issues. A lot of small fixes were required. Seems like it was like this since it was added. I'm guessing was never properly tested...? Either way, this PR fixes it and makes this feature fully functional.


https://github.com/user-attachments/assets/80920ed1-f653-49ef-bc14-f89d589102e6

