### PR TITLE
Fix command hidden from others message showing when ChatCommands is disabled

### DIFF
--- a/MainModule/Server/Core/Admin.luau
+++ b/MainModule/Server/Core/Admin.luau
@@ -56,7 +56,7 @@ return function(Vargs, GetEnv)
 
 								if not SenderPlayer then
 									return true
-								elseif Admin.DoHideChatCmd(SenderPlayer, chatMessage.Text) then -- // Hide chat commands?
+								elseif Settings.ChatCommands and Admin.DoHideChatCmd(SenderPlayer, chatMessage.Text) then -- // Hide chat commands?
 									if IsOriginalSender then
 										Remote.Send(SenderPlayer, "Function", "DisplaySystemMessageInTextChat", nil, "You ran a command hidden from others!")
 									end


### PR DESCRIPTION
Closes #1965

POF:
https://github.com/user-attachments/assets/8766fc31-d307-4804-a5f0-151c6e4126fc
https://github.com/user-attachments/assets/4ea1e6fe-c016-41e8-a7ab-0a25fb809c6a