### PR TITLE
Removal of final remnant of legacy chat

### DIFF
--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -152,27 +152,6 @@ return function(Vargs, GetEnv)
 			end
 		end
 
-		service.TrackTask("Thread: ChatCharacterLimit", function()
-			local ChatModules = service.Chat:WaitForChild("ClientChatModules", 5)
-			if ChatModules then
-				local ChatSettings = ChatModules:WaitForChild("ChatSettings", 5)
-				if ChatSettings then
-					local success, ChatSettingsModule = pcall(function()
-						return require(ChatSettings)
-					end)
-					if success then
-						local NewChatLimit = ChatSettingsModule.MaximumMessageLength
-						if NewChatLimit and type(NewChatLimit) == "number" then
-							Process.MaxChatCharacterLimit = NewChatLimit
-							AddLog("Script", `Chat Character Limit automatically set to {NewChatLimit}`)
-						end
-					else
-						AddLog("Script", "Failed to automatically get ChatSettings Character Limit, ignore if you use a custom chat system")
-					end
-				end
-			end
-		end)
-
 		Process.RunAfterPlugins = nil
 		AddLog("Script", "Process Module RunAfterPlugins Finished")
 	end


### PR DESCRIPTION
Removes ChatSettings MaximumMessageLength fetch that would dynamically fetch the maximum character count since it isn't used in the new TextChatService anymore.
