### PR TITLE
Prevent ;dexnew from deleting players.

### DIFF
--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -72,6 +72,9 @@
 
 	local Actions = {
 		destroy = function(p: Player, args)
+			if args[1] and args[1]:IsA("Player") then
+				return false;
+			end
 			args[1]:Destroy();
 			return true;
 		end,
@@ -5803,16 +5806,18 @@ local function main()
 			end
 		end
 
-		context:AddRegistered("CUT")
-		context:AddRegistered("COPY")
-		context:AddRegistered("PASTE",emptyClipboard)
-		context:AddRegistered("DUPLICATE")
-		context:AddRegistered("DELETE")
-		context:AddRegistered("RENAME",#sList ~= 1)
+		if not presentClasses["Player"] then
+			context:AddRegistered("DELETE")
+			context:AddRegistered("CUT")
+			context:AddRegistered("COPY")
+			context:AddRegistered("PASTE",emptyClipboard)
+			context:AddRegistered("DUPLICATE")
+			context:AddRegistered("RENAME",#sList ~= 1)
+			context:AddRegistered("GROUP")
+			context:AddRegistered("UNGROUP")
+			context:AddDivider()
+		end
 
-		context:AddDivider()
-		context:AddRegistered("GROUP")
-		context:AddRegistered("UNGROUP")
 		context:AddRegistered("SELECT_CHILDREN")
 		context:AddRegistered("JUMP_TO_PARENT")
 		context:AddRegistered("EXPAND_ALL")

--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -5810,13 +5810,14 @@ local function main()
 			context:AddRegistered("DELETE")
 			context:AddRegistered("CUT")
 			context:AddRegistered("COPY")
-			context:AddRegistered("PASTE",emptyClipboard)
 			context:AddRegistered("DUPLICATE")
 			context:AddRegistered("RENAME",#sList ~= 1)
 			context:AddRegistered("GROUP")
 			context:AddRegistered("UNGROUP")
-			context:AddDivider()
 		end
+
+		context:AddRegistered("PASTE",emptyClipboard)
+		context:AddDivider()
 
 		context:AddRegistered("SELECT_CHILDREN")
 		context:AddRegistered("JUMP_TO_PARENT")


### PR DESCRIPTION
I did post an issue about that 10 gazillion years ago, but today I decided that it's time to just do it then

this PR removes deleting, cutting, copying, pasting, duplicating, renaming, grouping, ungrouping on players as it bypasses permission hierarchy

the group, ungroup and duplicating, copying, cutting were removed because adonis doesn't have WritePlayer capability nor can it unlock the parent property of Player instance
POF:
1: a Player 
<img width="281" height="222" alt="image" src="https://github.com/user-attachments/assets/6802d1c5-14e0-443c-8847-6750324e0e3a" />
2: a MeshPart 
<img width="249" height="221" alt="image" src="https://github.com/user-attachments/assets/fc0fa8a6-16b7-4bc4-a21c-efe76c7b94aa" />
let me know if I should change something

(#1119)