### PR TITLE
Remove ;nil

### DIFF
--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -1437,23 +1437,7 @@ return function(Vargs, env)
 				end
 			end
 		};
-
-		Nil = {
-			Prefix = Settings.Prefix;
-			Commands = {"nil"};
-			Args = {"player"};
-			Hidden = true;
-			Description = `Deletes the player forcefully, causing them to be kicked for "Player has been removed from the DataModel"`;
-			AdminLevel = "Admins";
-			Function = function(plr: Player, args: {string})
-				for _, v in service.GetPlayers(plr, args[1]) do
-					v.Character = nil
-					v.Parent = nil
-					Functions.Hint(`Sent {service.FormatPlayer(v)} to nil`, {plr})
-				end
-			end
-		};
-
+		
 		PromptPremiumPurchase = {
 			Prefix = Settings.Prefix;
 			Commands = {"promptpremiumpurchase", "premiumpurchaseprompt"};


### PR DESCRIPTION
This command bypasses all permission hierarchy checks that ;kick has and provides no advantage over it, so it'd likely be best to just remove it.

If maintainers don't agree, I guess it could just be edited to have the checks added instead.

POF: likely not needed as it is just removal of a few lines of code, and adonis builds/runs successfully.