### PR TITLE
Add :undex command to remove Dex from players, and hook the removal function to Server.Core.Admin.luau

### DIFF
--- a/MainModule/Server/Core/Admin.luau
+++ b/MainModule/Server/Core/Admin.luau
@@ -667,6 +667,11 @@ return function(Vargs, GetEnv)
 				end
 			end
 
+			-- Automatically remove the Dex GUI and the authorization if unranked, or demoted below 300 (HeadAdmin)
+			if Commands.DexExplorerNew and Functions.RemoveDexFromPlayer and level < 300 then
+				Functions.RemoveDexFromPlayer(p, true)
+			end
+
 			return level, rank
 		end;
 

--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -188,11 +188,17 @@
 		end
 	end
 
-		-- Function used to remove Dex GUIs from a player.
+	-- Function used to remove Dex GUIs from a player.
 	function ServerNewDex.RemoveDexFromPlayer(ply, removeAuth)
 		if ply then
-			if removeAuth and ServerNewDex.Authorized[ply] then
-				ServerNewDex.Authorized[ply] = nil
+			if ServerNewDex.Authorized[ply] then
+				if ServerNewDex.Authorized[ply].Client then
+					ServerNewDex.Authorized[ply].Client:Destroy()
+				end
+
+				if removeAuth and ServerNewDex.Authorized[ply] then
+					ServerNewDex.Authorized[ply] = nil
+				end
 			end
 
 			for _, dexName in Variables.DexNames do
@@ -205,7 +211,6 @@
 	function ServerNewDex.GiveDexToPlayer(ply)
 		if ply then
 			if ServerNewDex.Authorized[ply] and ServerNewDex.Authorized[ply].Client then
-				ServerNewDex.Authorized[ply].Client:Destroy()
 				ServerNewDex.RemoveDexFromPlayer(ply)
 			end
 
@@ -229,7 +234,6 @@
 		AdminLevel = 300;
 		Function = function(plr, args)
 			if ServerNewDex.Authorized[plr] and ServerNewDex.Authorized[plr].Client then
-				ServerNewDex.Authorized[plr].Client:Destroy()
 				ServerNewDex.RemoveDexFromPlayer(plr)
 				task.wait(0.5) -- Wait a bit for the client-side removal to prevent locked parent issue
 			end
@@ -254,17 +258,10 @@
 		AdminLevel = 300;
 		Function = function(plr, args)
 			for _, player in Service.GetPlayers(plr, args[1]) do
-				if ServerNewDex.Authorized[player] and ServerNewDex.Authorized[player].Client then
-					ServerNewDex.Authorized[player].Client:Destroy()
-					ServerNewDex.RemoveDexFromPlayer(player)
-				end
-
-				task.wait(0.5) -- Wait a bit for the client to completely disappear to prevent false remote detections
-
-				ServerNewDex.Authorized[player] = nil
+				ServerNewDex.RemoveDexFromPlayer(player, true)
 			end
 		end
-	}
+	};
 
 	-- Add the removal function to the functions list
 	Server.Functions.RemoveDexFromPlayer = ServerNewDex.RemoveDexFromPlayer

--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -188,15 +188,36 @@
 		end
 	end
 
+		-- Function used to remove Dex GUIs from a player.
+	function ServerNewDex.RemoveDexFromPlayer(ply, removeAuth)
+		if ply then
+			if removeAuth and ServerNewDex.Authorized[ply] then
+				ServerNewDex.Authorized[ply] = nil
+			end
+
+			for _, dexName in Variables.DexNames do
+				Remote.RemoveLocal(ply, dexName, "PlayerGui")
+			end
+		end
+	end
+
 	-- Function used to give Dex to a player.
 	function ServerNewDex.GiveDexToPlayer(ply)
 		if ply then
+			if ServerNewDex.Authorized[ply] and ServerNewDex.Authorized[ply].Client then
+				ServerNewDex.Authorized[ply].Client:Destroy()
+				ServerNewDex.RemoveDexFromPlayer(ply)
+			end
+
+			local newClient = ServerNewDex.newDex_main:Clone()
+
 			ServerNewDex.Authorized[ply] = {
+				Client = newClient;
 				Clipboard = {};
 			}; --// double as per-player explorer-related data
 
-			if not ServerNewDex.Event then  ServerNewDex.MakeEvent(); end
-			ServerNewDex.MakeLocalDexForPlayer(ply, ServerNewDex.newDex_main:Clone(), ply:FindFirstChild("PlayerGui"))
+			if not ServerNewDex.Event then ServerNewDex.MakeEvent(); end
+			ServerNewDex.MakeLocalDexForPlayer(ply, newClient, ply:FindFirstChild("PlayerGui"))
 		end
 	end
 
@@ -207,14 +228,46 @@
 		Description = "Lets you explore the game using new Dex [Credits to LorekeeperZinnia]";
 		AdminLevel = 300;
 		Function = function(plr, args)
+			if ServerNewDex.Authorized[plr] and ServerNewDex.Authorized[plr].Client then
+				ServerNewDex.Authorized[plr].Client:Destroy()
+				ServerNewDex.RemoveDexFromPlayer(plr)
+				task.wait(0.5) -- Wait a bit for the client-side removal to prevent locked parent issue
+			end
+
+			local newClient = ServerNewDex.newDex_main:Clone()
+
 			ServerNewDex.Authorized[plr] = {
 				Clipboard = {};
+				Client = newClient;
 			}; --// double as per-player explorer-related data
 
-			if not ServerNewDex.Event then  ServerNewDex.MakeEvent(); end
-			Remote.MakeLocal(plr, newDex_main:Clone(), "PlayerGui")
+			if not ServerNewDex.Event then ServerNewDex.MakeEvent(); end
+			Remote.MakeLocal(plr, newClient, "PlayerGui")
 		end
 	};
+
+	Commands.RemoveDexExplorer = {
+		Prefix = Settings.Prefix;
+		Commands = {"removedexnew"; "removedex"; "removedexexplorer"; "undex"; "undexnew"};
+		Args = {"player"};
+		Description = "Removes the Dex GUIs and authorization from a specified player";
+		AdminLevel = 300;
+		Function = function(plr, args)
+			for _, player in Service.GetPlayers(plr, args[1]) do
+				if ServerNewDex.Authorized[player] and ServerNewDex.Authorized[player].Client then
+					ServerNewDex.Authorized[player].Client:Destroy()
+					ServerNewDex.RemoveDexFromPlayer(player)
+				end
+
+				task.wait(0.5) -- Wait a bit for the client to completely disappear to prevent false remote detections
+
+				ServerNewDex.Authorized[player] = nil
+			end
+		end
+	}
+
+	-- Add the removal function to the functions list
+	Server.Functions.RemoveDexFromPlayer = ServerNewDex.RemoveDexFromPlayer
 	Logs:AddLog("Script", "NewDex Module Loaded")
 end]]></ProtectedString>
 			<int64 name="SourceAssetId">-1</int64>

--- a/MainModule/Server/Plugins/ServerNewDex.rbxmx
+++ b/MainModule/Server/Plugins/ServerNewDex.rbxmx
@@ -257,8 +257,13 @@
 		Description = "Removes the Dex GUIs and authorization from a specified player";
 		AdminLevel = 300;
 		Function = function(plr, args)
+			local sourcePlayerLevel = Server.Admin.GetLevel(plr)
 			for _, player in Service.GetPlayers(plr, args[1]) do
-				ServerNewDex.RemoveDexFromPlayer(player, true)
+				if Server.Admin.GetLevel(player) <= sourcePlayerLevel then
+					ServerNewDex.RemoveDexFromPlayer(player, true)
+				else
+					Functions.Hint(`You don't have permission to remove Dex from {Service.FormatPlayer(player, true)}`, {plr})
+				end
 			end
 		end
 	};


### PR DESCRIPTION
(Continuation of https://github.com/Epix-Incorporated/Adonis/pull/1877)

This PR makes it so the Dex Explorer can be removed from the source player or a specified target player with `:undex`, `:removedex`, or any other similar commands.

This PR also includes a check for existing Dex_Client in PlayerGui when loading (and removes the old Dex_Client and related GUIs if found) to give the ability for players to refresh Dex in case something else happened.

## Expected intended behavior

After executing `:undex` (or other similar commands) to a player, or commands leading to `Admin.SetLevel(player)` such as `:unrank` is called, every Dex-related GUIs (listed in Variables.DexNames) and the existing Dex_Client in the player's PlayerGui on the server are removed, alongside removing the player from the ServerNewDex.Authorized list for security reasons.

Note that the target player must have the same rank / AdminLevel or lower than the user of the command to prevent misusage (e.g. someone with HeadAdmin uses this command against an experience owner).

## Proof of functionality

Core PoF (Resetting the Dex GUI, executing the `:undex` command itself, and also making sure the remote function still works):

https://github.com/user-attachments/assets/63622fbb-51cd-45e5-8aba-f34310fdaf7c

Two-player PoF (Executing :undex alongside other players):

https://github.com/user-attachments/assets/47378841-d889-4a65-bbb4-a2ca1e1ac372