### PR TITLE
Add permission checks for :nil command to prevent higher ranks from being kicked

### DIFF
--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -1446,10 +1446,15 @@ return function(Vargs, env)
 			Description = `Deletes the player forcefully, causing them to be kicked for "Player has been removed from the DataModel"`;
 			AdminLevel = "Admins";
 			Function = function(plr: Player, args: {string})
+				local sourcePlayerLevel = Admin.GetLevel(plr)
 				for _, v in service.GetPlayers(plr, args[1]) do
-					v.Character = nil
-					v.Parent = nil
-					Functions.Hint(`Sent {service.FormatPlayer(v)} to nil`, {plr})
+					if Admin.GetLevel(v) <= sourcePlayerLevel then
+						v.Character = nil
+						v.Parent = nil
+						Functions.Hint(`Sent {service.FormatPlayer(v)} to nil`, {plr})
+					else
+						Functions.Hint(`You don't have permission to send {service.FormatPlayer(v)} to nil`, {plr})
+					end
 				end
 			end
 		};


### PR DESCRIPTION
This PR makes it so the `:nil` command can only be used towards players with the same or lower rank than the user of the command, by including a permission check between the source player and target player(s).

## Proof of functionality

https://github.com/user-attachments/assets/cd97b531-b1bb-4308-bf6c-eeb7c2528b45

