### PR TITLE
Respect gameProcessedEvent for Console

### DIFF
--- a/MainModule/Client/UI/Aero/Console.rbxmx
+++ b/MainModule/Client/UI/Aero/Console.rbxmx
@@ -931,15 +931,19 @@ return function(data, env)
 		end
 	end)
 
-	BindEvent(service.UserInputService.InputBegan, function(InputObject)
+	BindEvent(service.Events.ToggleConsole, function()
+		if opened then
+			close()
+		else
+			open()
+		end
+		client.Variables.ConsoleOpen = opened
+	end)
+
+	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
-		if not (textbox) and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
-			if opened then
-				close()
-			else
-				open()
-			end
-			client.Variables.ConsoleOpen = opened
+		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
+			service.Events.ToggleConsole:Fire()
 		end
 	end)
 

--- a/MainModule/Client/UI/Default/Console.rbxmx
+++ b/MainModule/Client/UI/Default/Console.rbxmx
@@ -727,18 +727,18 @@ return function(data, env)
 	end)
 
 	text:GetPropertyChangedSignal("Text"):Connect(function()
-		if text.Text ~= "" and openConsole then
+		if text.Text ~= "" and opened then
 			local tabWhiteSpace = "	"
 			if string.sub(text.Text, string.len(text.Text)) == tabWhiteSpace then
 				if autoList:FindFirstChild("Entry 0") then
 					local args = string.split(text.Text, splitKey) -- Get command args
 					local textWithoutLastArg = string.sub(text.Text, 1, string.len(text.Text) - string.len(args[#args])) -- Remove the last arg
-					
+
 					text.Text = `{textWithoutLastArg}{autoList["Entry 0"].Text} ` -- Combine the text witout the last arg and the player name
 				elseif scroll:FindFirstChild("Entry 0") then
 					text.Text = string.split(scroll["Entry 0"].Text, "<")[1]
 				end
-				
+
 				text.CursorPosition = string.len(text.Text) + 1
 				text.Text = string.gsub(text.Text, tabWhiteSpace, "")
 			end
@@ -756,7 +756,7 @@ return function(data, env)
 			for _, v in commands do
 				local cmdName = string.match(string.lower(nText), `^(.-){splitKey}`) or string.lower(nText)
 				if string.sub(string.lower(v), 1, #nText) == string.lower(nText) or string.find(string.lower(v), cmdName, 1, true) then
-					selectedCmd = v 
+					selectedCmd = v
 					if not scrollOpen then
 						scrollOpenTween:Play()
 						--frame.Size = UDim2.new(1,0,0,140)
@@ -777,13 +777,13 @@ return function(data, env)
 					num += 1
 				end
 			end
-			
+
 			local aNum = 0
 			local fullSplit = string.split(nText, splitKey)
 			if num > 0 and #fullSplit > 1 then
 				local provided = string.match(nText, `.+{splitKey}(.*)$`)
 				local selectedSplit = string.split(selectedCmd, splitKey)
-				
+
 				local arg = selectedSplit[#fullSplit]
 				for _, v in UI.Autocomplete(provided, arg) do
 					local new = entry:Clone()
@@ -797,11 +797,11 @@ return function(data, env)
 						text.Text = text.Text..tostring(v)
 						text:CaptureFocus()
 					end)
-					
+
 					aNum += 1
 				end
 			end
-			
+
 			frame.Size = UDim2.new(1, 0, 0, math.clamp((math.max(num, aNum) * 20) + 40, 40, 140))
 			scroll.CanvasSize = UDim2.fromOffset(0, num * 20)
 		elseif text.Text == "" and opened then
@@ -815,7 +815,7 @@ return function(data, env)
 		end
 	end)
 
-	service.HookEvent("ToggleConsole", function()
+	gTable.BindEvent(service.Events.ToggleConsole, function()
 		if opened then
 			closeConsole()
 		else
@@ -824,9 +824,9 @@ return function(data, env)
 		Variables.ConsoleOpen = opened
 	end)
 
-	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject)
+	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
-		if not textbox and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
+		if not textbox and not gameProcessedEvent and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end
 	end)

--- a/MainModule/Client/UI/Default/Settings.luau
+++ b/MainModule/Client/UI/Default/Settings.luau
@@ -113,9 +113,9 @@ return function(data, env)
 			Function = function(toggle)
 				local gotKey, visualName
 				toggle.Text = "Waiting..."
-				local event = service.UserInputService.InputBegan:Connect(function(InputObject)
+				local event = service.UserInputService.InputBegan:Connect(function(InputObject, gameProcessedEvent)
 					local textbox = service.UserInputService:GetFocusedTextBox()
-					if not (textbox) and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
+					if not (textbox) and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
 						gotKey, visualName = InputObject.KeyCode.Name, Functions.KeyCodeToName(InputObject.KeyCode.Value)
 					end
 				end)

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -1052,9 +1052,9 @@ return function(data, env)
 					doneKey = false
 					button.Text = "Waiting..."
 					Variables.WaitingForBind = true
-					keyInputHandler = window:BindEvent(service.UserInputService.InputBegan, function(InputObject)
+					keyInputHandler = window:BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 						local textbox = service.UserInputService:GetFocusedTextBox()
-						if not (textbox) and not doneKey and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
+						if not (textbox) and not gameProcessedEvent and not doneKey and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
 							currentKey = InputObject.KeyCode
 							if currentKey then
 								button.Text = string.upper(keyCodeToName(currentKey.Value))
@@ -1511,9 +1511,9 @@ return function(data, env)
 						service.Debounce("CliSettingKeybinder", function()
 							local gotKey, visualName
 							toggle.Text = "Waiting..."
-							local event = service.UserInputService.InputBegan:Connect(function(InputObject)
+							local event = service.UserInputService.InputBegan:Connect(function(InputObject, gameProcessedEvent)
 								local textbox = service.UserInputService:GetFocusedTextBox()
-								if not (textbox) and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
+								if not (textbox) and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
 									gotKey, visualName = InputObject.KeyCode.Name, Functions.KeyCodeToName(InputObject.KeyCode.Value)
 								end
 							end)
@@ -1661,7 +1661,7 @@ return function(data, env)
 										return
 									end
 								end
-								
+
 								UI.Make("Hint",{
 									Message = "Operation cancelled, all of your data is safe!"
 								})

--- a/MainModule/Client/UI/Rounded/Console.rbxmx
+++ b/MainModule/Client/UI/Rounded/Console.rbxmx
@@ -540,7 +540,7 @@ return function(data, env)
 	if env then
 		setfenv(1, env)
 	end
-	
+
 	local player = service.Players.LocalPlayer
 	local playergui = player.PlayerGui
 	local gui = script.Parent.Parent
@@ -739,15 +739,19 @@ return function(data, env)
 		end
 	end)
 
-	BindEvent(service.UserInputService.InputBegan, function(InputObject)
+	BindEvent(service.Events.ToggleConsole, function()
+		if opened then
+			close()
+		else
+			open()
+		end
+		client.Variables.ConsoleOpen = opened
+	end)
+
+	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
-		if not (textbox) and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
-			if opened then
-				close()
-			else
-				open()
-			end
-			client.Variables.ConsoleOpen = opened
+		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
+			service.Events.ToggleConsole:Fire()
 		end
 	end)
 

--- a/MainModule/Client/UI/Steampunk/Console.rbxmx
+++ b/MainModule/Client/UI/Steampunk/Console.rbxmx
@@ -326,7 +326,7 @@ return function(data, env)
 		end
 	end)
 
-	service.HookEvent("ToggleConsole", function()
+	gTable.BindEvent(service.Events.ToggleConsole, function()
 		if opened then
 			closeConsole()
 		else
@@ -335,9 +335,9 @@ return function(data, env)
 		Variables.ConsoleOpen = opened
 	end)
 
-	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject)
+	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
-		if not textbox and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
+		if not textbox and not gameProcessedEvent and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end
 	end)

--- a/MainModule/Client/UI/Unity/Console.rbxmx
+++ b/MainModule/Client/UI/Unity/Console.rbxmx
@@ -795,15 +795,19 @@ return function(data, env)
 		end
 	end)
 
-	BindEvent(service.UserInputService.InputBegan, function(InputObject)
+	BindEvent(service.Events.ToggleConsole, function()
+		if opened then
+			close()
+		else
+			open()
+		end
+		client.Variables.ConsoleOpen = opened
+	end)
+
+	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
-		if not (textbox) and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
-			if opened then
-				close()
-			else
-				open()
-			end
-			client.Variables.ConsoleOpen = opened
+		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
+			service.Events.ToggleConsole:Fire()
 		end
 	end)
 

--- a/MainModule/Client/UI/Windows XP/Console.rbxmx
+++ b/MainModule/Client/UI/Windows XP/Console.rbxmx
@@ -711,15 +711,19 @@ return function(data, env)
 		end
 	end)
 
-	BindEvent(service.UserInputService.InputBegan, function(InputObject)
+	BindEvent(service.Events.ToggleConsole, function()
+		if opened then
+			close()
+		else
+			open()
+		end
+		client.Variables.ConsoleOpen = opened
+	end)
+
+	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
-		if not (textbox) and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
-			if opened then
-				close()
-			else
-				open()
-			end
-			client.Variables.ConsoleOpen = opened
+		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
+			service.Events.ToggleConsole:Fire()
 		end
 	end)
 


### PR DESCRIPTION
Use GPE alongside GetFocusedTextbox to prevent keybinds from triggering whilst using Chat or focused on any other textbox due to the recent CoreGui changes, using GetFocusedTextbox to see if the chat is open has stopped working causing Adonis's Console to open whilst chatting.

Also adds ToggleConsole to other UIs that don't have functionality which work as expected.

PoF:
https://github.com/user-attachments/assets/2b9c1ec1-dc8d-41bf-a3df-9becdda98554
