### PR TITLE
Hotfix for chat input focus detection with Roblox breaking change

### DIFF
--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -1283,6 +1283,15 @@ return function(Vargs, GetEnv)
 				local key = tostring(input.KeyCode.Value)
 				local textbox = service.UserInputService:GetFocusedTextBox()
 
+				--[[
+				## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+				<SAKARI INSERT PULL REQUEST LINK HERE>
+				]]
+
+				if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+					textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+				end
+				
 				if Variables.KeybindsEnabled and not (textbox) and key and Variables.KeyBinds[key] and not Variables.WaitingForBind then
 					local isAdmin = Remote.Get("CheckAdmin")
 					if time() - timer > 5 or isAdmin then

--- a/MainModule/Client/Core/Process.luau
+++ b/MainModule/Client/Core/Process.luau
@@ -173,6 +173,16 @@ return function(Vargs, GetEnv)
 			end
 
 			local textbox = service.UserInputService:GetFocusedTextBox()
+
+			--[[
+			## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+			<SAKARI INSERT PULL REQUEST LINK HERE>
+			]]
+
+			if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+				textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+			end
+
 			if textbox and service.CheckProperty(textbox, "ReleaseFocus") then
 				textbox:ReleaseFocus()
 			end

--- a/MainModule/Client/UI/Aero/Console.rbxmx
+++ b/MainModule/Client/UI/Aero/Console.rbxmx
@@ -942,6 +942,16 @@ return function(data, env)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Aero/PlayerList.rbxmx
+++ b/MainModule/Client/UI/Aero/PlayerList.rbxmx
@@ -359,6 +359,16 @@ return function(data, env)
 
 	service.UserInputService.InputBegan:Connect(function(InputObject)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+		
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+		
 		if not (textbox) and InputObject.UserInputType==Enum.UserInputType.Keyboard and InputObject.KeyCode == Enum.KeyCode.Tab then
 			if drag.Visible then
 				drag.Visible = false

--- a/MainModule/Client/UI/Default/Console.rbxmx
+++ b/MainModule/Client/UI/Default/Console.rbxmx
@@ -826,6 +826,16 @@ return function(data, env)
 
 	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+
 		if not textbox and not gameProcessedEvent and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Default/PlayerList.rbxmx
+++ b/MainModule/Client/UI/Default/PlayerList.rbxmx
@@ -344,6 +344,16 @@ return function(data, env)
 	
 	service.UserInputService.InputBegan:Connect(function(InputObject)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+		
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+		
 		if not (textbox) and InputObject.UserInputType==Enum.UserInputType.Keyboard and InputObject.KeyCode == Enum.KeyCode.Tab then
 			if drag.Visible then
 				drag.Visible = false

--- a/MainModule/Client/UI/Default/Settings.luau
+++ b/MainModule/Client/UI/Default/Settings.luau
@@ -115,6 +115,16 @@ return function(data, env)
 				toggle.Text = "Waiting..."
 				local event = service.UserInputService.InputBegan:Connect(function(InputObject, gameProcessedEvent)
 					local textbox = service.UserInputService:GetFocusedTextBox()
+
+					--[[
+					## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+					<SAKARI INSERT PULL REQUEST LINK HERE>
+					]]
+
+					if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+						textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+					end
+
 					if not (textbox) and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
 						gotKey, visualName = InputObject.KeyCode.Name, Functions.KeyCodeToName(InputObject.KeyCode.Value)
 					end

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -1054,6 +1054,16 @@ return function(data, env)
 					Variables.WaitingForBind = true
 					keyInputHandler = window:BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 						local textbox = service.UserInputService:GetFocusedTextBox()
+
+						--[[
+						## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+						<SAKARI INSERT PULL REQUEST LINK HERE>
+						]]
+
+						if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+							textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+						end
+
 						if not (textbox) and not gameProcessedEvent and not doneKey and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
 							currentKey = InputObject.KeyCode
 							if currentKey then
@@ -1513,6 +1523,16 @@ return function(data, env)
 							toggle.Text = "Waiting..."
 							local event = service.UserInputService.InputBegan:Connect(function(InputObject, gameProcessedEvent)
 								local textbox = service.UserInputService:GetFocusedTextBox()
+
+								--[[
+								## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+								<SAKARI INSERT PULL REQUEST LINK HERE>
+								]]
+
+								if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+									textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+								end
+
 								if not (textbox) and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) then
 									gotKey, visualName = InputObject.KeyCode.Name, Functions.KeyCodeToName(InputObject.KeyCode.Value)
 								end

--- a/MainModule/Client/UI/Rounded/Console.rbxmx
+++ b/MainModule/Client/UI/Rounded/Console.rbxmx
@@ -750,6 +750,16 @@ return function(data, env)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Steampunk/Console.rbxmx
+++ b/MainModule/Client/UI/Steampunk/Console.rbxmx
@@ -337,6 +337,16 @@ return function(data, env)
 
 	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+
 		if not textbox and not gameProcessedEvent and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Unity/Console.rbxmx
+++ b/MainModule/Client/UI/Unity/Console.rbxmx
@@ -806,6 +806,16 @@ return function(data, env)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Windows XP/Console.rbxmx
+++ b/MainModule/Client/UI/Windows XP/Console.rbxmx
@@ -722,6 +722,16 @@ return function(data, env)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
 		local textbox = service.UserInputService:GetFocusedTextBox()
+
+		--[[
+		## BreakingChange from roblox, this corrects not detecting the chat box being focused 
+		<SAKARI INSERT PULL REQUEST LINK HERE>
+		]]
+
+		if not textbox and service.TextChatService.ChatInputBarConfiguration.IsFocused  then
+			textbox = service.TextChatService.ChatInputBarConfiguration.TextBox
+		end
+
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end


### PR DESCRIPTION
Update all relevant UI and core scripts to correctly detect when the new TextChatService chat input bar is focused, addressing a breaking change from Roblox. This ensures keybinds and input handling work as expected when the chat bar is active.

❤ AI generated commit message my beloved

Anyway, Roblox pushed a update that [does not return the chat box with the old methods](https://devforum.roblox.com/t/userinputservicegetfocusedtextbox-returns-nil-with-the-chat-box-focused/3940424/3), this breaks many input filters, such as this project.

I have applied a low effort hotfix for this, and I have not tested this.

**Remember to delete this section when you submit your PR!**
