### PR TITLE
Ensure console respects chat

### DIFF
--- a/MainModule/Client/UI/Aero/Console.rbxmx
+++ b/MainModule/Client/UI/Aero/Console.rbxmx
@@ -941,7 +941,7 @@ return function(data, env)
 	end)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
-		local textbox = service.UserInputService:GetFocusedTextBox()
+		local textbox = service.UserInputService:GetFocusedTextBox() or service.TextChatService.ChatInputBarConfiguration.IsFocused
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Default/Console.rbxmx
+++ b/MainModule/Client/UI/Default/Console.rbxmx
@@ -825,7 +825,7 @@ return function(data, env)
 	end)
 
 	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject, gameProcessedEvent)
-		local textbox = service.UserInputService:GetFocusedTextBox()
+		local textbox = service.UserInputService:GetFocusedTextBox() or service.TextChatService.ChatInputBarConfiguration.IsFocused
 		if not textbox and not gameProcessedEvent and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Rounded/Console.rbxmx
+++ b/MainModule/Client/UI/Rounded/Console.rbxmx
@@ -749,7 +749,7 @@ return function(data, env)
 	end)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
-		local textbox = service.UserInputService:GetFocusedTextBox()
+		local textbox = service.UserInputService:GetFocusedTextBox() or service.TextChatService.ChatInputBarConfiguration.IsFocused
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Steampunk/Console.rbxmx
+++ b/MainModule/Client/UI/Steampunk/Console.rbxmx
@@ -336,7 +336,7 @@ return function(data, env)
 	end)
 
 	gTable.BindEvent(service.UserInputService.InputBegan, function(inputObject: InputObject, gameProcessedEvent)
-		local textbox = service.UserInputService:GetFocusedTextBox()
+		local textbox = service.UserInputService:GetFocusedTextBox() or service.TextChatService.ChatInputBarConfiguration.IsFocused
 		if not textbox and not gameProcessedEvent and rawequal(inputObject.UserInputType, Enum.UserInputType.Keyboard) and inputObject.KeyCode.Name == (Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Unity/Console.rbxmx
+++ b/MainModule/Client/UI/Unity/Console.rbxmx
@@ -805,7 +805,7 @@ return function(data, env)
 	end)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
-		local textbox = service.UserInputService:GetFocusedTextBox()
+		local textbox = service.UserInputService:GetFocusedTextBox() or service.TextChatService.ChatInputBarConfiguration.IsFocused
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end

--- a/MainModule/Client/UI/Windows XP/Console.rbxmx
+++ b/MainModule/Client/UI/Windows XP/Console.rbxmx
@@ -721,7 +721,7 @@ return function(data, env)
 	end)
 
 	BindEvent(service.UserInputService.InputBegan, function(InputObject, gameProcessedEvent)
-		local textbox = service.UserInputService:GetFocusedTextBox()
+		local textbox = service.UserInputService:GetFocusedTextBox() or service.TextChatService.ChatInputBarConfiguration.IsFocused
 		if not textbox and not gameProcessedEvent and rawequal(InputObject.UserInputType, Enum.UserInputType.Keyboard) and InputObject.KeyCode.Name == (client.Variables.CustomConsoleKey or consoleKey) then
 			service.Events.ToggleConsole:Fire()
 		end


### PR DESCRIPTION
Roblox has recently introduced a change that results in `ContextActionService` ignoring chat inputs. CoreGui is made nil, so CAS won't properly detect that the events are game processed events.

See this DevForum thread: https://devforum.roblox.com/t/userinputservicegetfocusedtextbox-returns-nil-with-the-chat-box-focused/3940424