### PR TITLE
Fixed server memory leaks

### DIFF
--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -477,37 +477,59 @@ return function(Vargs, GetEnv)
 				folder.Name = depsName--"Adonis_Client"
 				folder.Parent = container
 
-				--// Event only fires AFTER the client is alive and well
-				local event; event = service.Events.ClientLoaded:Connect(function(plr)
-					if p == plr and container.Parent == parentObj then
-						--container:Destroy(); -- Destroy update causes an issue with this pretty sure
-						container.Parent = nil
+				local event
+
+				local Cleanup = function(player, loaded)
+					if player ~= p then
+						return
+					end
+
+					if event then
 						event:Disconnect()
 						event = nil
 					end
-				end)
 
-				--// i personaly think the old method of cleaning it up was stupid and also not working
-				Connections["HookClient_"..p.UserId] = game.Players.PlayerRemoving:Connect(function(Player)
-					if Player == p then
-						if event then
-							event:Disconnect()
-							event = nil
+					if Connections["HookClient_" .. p.UserId] then
+						Connections["HookClient_" .. p.UserId]:Disconnect()
+						Connections["HookClient_" .. p.UserId] = nil
+					end
+
+					if keys then
+						keys.Module = nil
+						keys.EventName = nil
+					end
+
+					if loaded then
+						if container then
+							container.Parent = nil
 						end
-
-						Connections["HookClient_"..p.UserId]:Disconnect()
-						Connections["HookClient_"..p.UserId] = nil
+					else
 						if container then
 							pcall(function()
 								container:Destroy()
-								container = nil
-								if folder then
-									folder:Destroy()
-									folder = nil
-								end
+							end)
+						end
+
+						if folder then
+							pcall(function()
+								folder:Destroy()
 							end)
 						end
 					end
+
+					container = nil
+					folder = nil
+				end
+
+				--// Event only fires AFTER the client is alive and well
+				event = service.Events.ClientLoaded:Connect(function(plr)
+					if p == plr and container and container.Parent == parentObj then
+						Cleanup(plr, true)
+					end
+				end)
+
+				Connections["HookClient_" .. p.UserId] = game.Players.PlayerRemoving:Connect(function(Player)
+					Cleanup(Player, false)
 				end)
 
 				local ok, err = pcall(function()

--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -67,6 +67,8 @@ return function(Vargs, GetEnv)
 		AddLog("Script", "Core Module Initialized")
 	end;
 
+	local Connections = {}
+
 	local function RunAfterPlugins(data)
 		--// RemoteEvent Handling
 		Core.MakeEvent()
@@ -478,23 +480,33 @@ return function(Vargs, GetEnv)
 				--// Event only fires AFTER the client is alive and well
 				local event; event = service.Events.ClientLoaded:Connect(function(plr)
 					if p == plr and container.Parent == parentObj then
-
 						--container:Destroy(); -- Destroy update causes an issue with this pretty sure
 						container.Parent = nil
-						local leaveEvent; leaveEvent = p.AncestryChanged:Connect(function() -- after/on remove, not on removing...
-							task.wait()
-							if p.Parent == nil then
-								-- Prevent potential memory leak and ensure this gets properly murdered when they leave and it's no longer needed
-								pcall(function()
-									container:Destroy()
-								end)
-							end
-						end)
-
-						leaveEvent:Disconnect()
-						leaveEvent = nil
 						event:Disconnect()
 						event = nil
+					end
+				end)
+
+				--// i personaly think the old method of cleaning it up was stupid and also not working
+				Connections["HookClient_"..p.UserId] = game.Players.PlayerRemoving:Connect(function(Player)
+					if Player == p then
+						if event then
+							event:Disconnect()
+							event = nil
+						end
+
+						Connections["HookClient_"..p.UserId]:Disconnect()
+						Connections["HookClient_"..p.UserId] = nil
+						if container then
+							pcall(function()
+								container:Destroy()
+								container = nil
+								if folder then
+									folder:Destroy()
+									folder = nil
+								end
+							end)
+						end
 					end
 				end)
 

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -852,6 +852,9 @@ return function(Vargs, GetEnv)
 			task.delay(1, function()
 				if not service.Players:GetPlayerByUserId(p.UserId) then
 					Core.PlayerData[key] = nil
+					if Remote.Clients[key] then
+						Remote.Clients[key] = nil
+			        end
 				end
 			end)
 
@@ -901,10 +904,6 @@ return function(Vargs, GetEnv)
 			end
 
 			Core.SavePlayerData(p, data)
-
-			if Remote.Clients[key] then
-				Remote.Clients[key] = nil
-			end
 
 			if Settings.ReJail then
 				for i,v in pairs(Variables.Jails) do

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -89,6 +89,9 @@ return function(Vargs, GetEnv)
 		AddLog("Script", "Processing Module Initialized")
 	end;
 
+	local Connections = {}
+	local Tasks = {}
+
 	local function RunAfterPlugins(data)
 		local existingPlayers = service.Players:GetPlayers()
 
@@ -718,6 +721,10 @@ return function(Vargs, GetEnv)
 			Core.PlayerData[key] = nil
 			Remote.Clients[key] = keyData
 
+			Connections[p.UserId] = {}
+			Tasks[p.UserId] = {}
+				
+
 			local ran, err = Pcall(function()
 				task.spawn(function()
 					if Anti.UserSpoofCheck(p) then
@@ -804,7 +811,7 @@ return function(Vargs, GetEnv)
 				})
 
 				--// Get chats
-				p.Chatted:Connect(function(msg)
+				Connections[p.UserId].Chatted = p.Chatted:Connect(function(msg)
 					local ran, err = TrackTask(`{p.Name}Chatted`, Process.Chat, false, p, msg)
 					if not ran then
 						logError(err);
@@ -812,14 +819,16 @@ return function(Vargs, GetEnv)
 				end)
 
 				--// Character added
-				p.CharacterAdded:Connect(function(...)
+				--// well bro you never disconencted these
+				Connections[p.UserId].CharacterAdded = p.CharacterAdded:Connect(function(...)
 					local ran, err = TrackTask(`{p.Name}CharacterAdded`, Process.CharacterAdded, false, p, ...)
 					if not ran then
 						logError(err);
 					end
 				end)
 
-				task.delay(600, function()
+				--// cleans it up incase player leaves during loading
+				Tasks[p.UserId].LoadTimeout = task.delay(600, function()
 					if p.Parent and Core.PlayerData[key] and Remote.Clients[key] and Remote.Clients[key] == keyData and keyData.LoadingStatus ~= "READY" then
 						AddLog("Script", {
 							Text = `{p.Name} Failed to Load`,
@@ -845,6 +854,24 @@ return function(Vargs, GetEnv)
 					Core.PlayerData[key] = nil
 				end
 			end)
+
+			if Connections[p.UserId] then
+				for Index, Connection in pairs(Connections[p.UserId]) do
+					if Connection and Connection.Disconnect then
+						Connection:Disconnect()
+					end
+				end
+				Connections[p.UserId] = nil
+			end
+
+			if Tasks[p.UserId] then
+				for Index, Task in pairs(Tasks[p.UserId]) do
+					if Task then
+						task.cancel(Task)
+					end
+				end
+				Tasks[p.UserId] = nil
+			end
 
 			AddLog("Script", {
 				Text = string.format("Triggered PlayerRemoving for %s", p.Name);
@@ -874,6 +901,10 @@ return function(Vargs, GetEnv)
 			end
 
 			Core.SavePlayerData(p, data)
+
+			if Remote.Clients[key] then
+				Remote.Clients[key] = nil
+			end
 
 			if Settings.ReJail then
 				for i,v in pairs(Variables.Jails) do

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -869,7 +869,7 @@ return function(Vargs, GetEnv)
 
 			if Tasks[p.UserId] then
 				for Index, Task in pairs(Tasks[p.UserId]) do
-					if Task then
+					if Task and coroutine.status(Task) ~= "dead" then
 						task.cancel(Task)
 					end
 				end

--- a/MainModule/Server/Plugins/Anti_Cheat.luau
+++ b/MainModule/Server/Plugins/Anti_Cheat.luau
@@ -113,7 +113,7 @@ return function(Vargs, GetEnv)
 
 			local humanoid = character:FindFirstChildOfClass("Humanoid") or character:WaitForChild("Humanoid")
 
-			humanoid.StateChanged:Connect(function(last, state)
+			Connections[player.UserId].HumanoidStateChanged = humanoid.StateChanged:Connect(function(last, state)
 				if last == Enum.HumanoidStateType.Dead and state ~= Enum.HumanoidStateType.Dead and humanoid then
 					humanoid.Health = 0
 					humanoid:ChangeState(Enum.HumanoidStateType.Dead)

--- a/MainModule/Server/Plugins/Anti_Cheat.luau
+++ b/MainModule/Server/Plugins/Anti_Cheat.luau
@@ -20,6 +20,8 @@ return function(Vargs, GetEnv)
 		Logs:AddLog("Script", "AntiExploit Plugin Module Initialized")
 	end
 
+	local Connections = {}
+
 	local function RunAfterPlugins(data)
 		local function onPlayerAdded(player)
 			if not player.Character then
@@ -55,6 +57,8 @@ return function(Vargs, GetEnv)
 	server.Anti.CharacterCheck = function(player) -- // From my plugin FE++ (Creator Github@ccuser44/Roblox@ALE111_boiPNG)
 		local charGood = false --// Prevent accidental triggers while removing the character ~ Scel
 
+		Connections[player.UserId] = {}
+
 		local function Detected(player, action, reason)
 			if charGood then
 				if Settings.CharacterCheckLogs ~= true and (string.lower(action) == "log" or string.lower(action) == "kill") then
@@ -85,7 +89,7 @@ return function(Vargs, GetEnv)
 		local function onCharacterAdded(character)
 			charGood = true
 
-			character.ChildAdded:Connect(function(child)
+			Connections[player.UserId].ChildAdded = character.ChildAdded:Connect(function(child)
 				if child:IsA("BackpackItem") and Settings.AntiMultiTool == true then
 					local count = 0
 
@@ -186,9 +190,21 @@ return function(Vargs, GetEnv)
 			task.spawn(onCharacterAdded, player.Character)
 		end
 
-		player.CharacterRemoving:Connect(onCharacterRemoving)
-		player.CharacterAdded:Connect(onCharacterAdded)
+		--// Roblox never disconnects these connections when player leaves the game
+		Connections[player.UserId].CharacterRemoving = player.CharacterRemoving:Connect(onCharacterRemoving)
+		Connections[player.UserId].CharacterAdded = player.CharacterAdded:Connect(onCharacterAdded)
 	end;
+
+	service.Players.PlayerRemoving:Connect(function(Player)
+		if Connections[Player.UserId] then
+			for Index, Connection in pairs(Connections[Player.UserId]) do
+				if Connection and Connection.Disconnect then
+					Connection:Disconnect()
+				end
+			end
+			Connections[Player.UserId] = nil
+		end
+	end)
 
 	Init();
 	task.wait()


### PR DESCRIPTION
## Changes
- Fix player connection cleanup in `Process.luau`
- Cancel player load timeout tasks on leave
- Clear `Remote.Clients[key]` on player removal
- Fixed client folder staying referenced in server memory

## Why
These changes prevent memory leaks on server which could impact the server on long uptime

## Note
i made a pull before this one but i fucked something up and didn't see it

## Testing
Tested in Roblox Studio with multiple players joining and leaving. Confirmed that:
- player specific connections are disconnected on leave
- delayed load timeout tasks are canceled on leave
- `Remote.Clients[key]` is removed on leave
- client folder doesn't stay referenced after player leaves

## Proof 
before
<img width="813" height="245" alt="image" src="https://github.com/user-attachments/assets/b7f4c5b3-c5ed-479a-bfca-3db52298f2ff" />
after
<img width="801" height="303" alt="Screenshot 2026-04-03 181144" src="https://github.com/user-attachments/assets/21babdeb-abbe-48c8-8777-e8161ce61a5b" />


