### PR TITLE
Push missing globals to environment

### DIFF
--- a/MainModule/Client/Client.luau
+++ b/MainModule/Client/Client.luau
@@ -26,72 +26,26 @@ local CORE_LOADING_ORDER = table.freeze({
 })
 
 --// Loccalllsssss
-local _G, game, script, getfenv, setfenv, workspace, getmetatable, setmetatable, loadstring, coroutine, rawequal, typeof, print, math, warn, error, pcall, xpcall, select, rawset, rawget, ipairs, pairs, next, Rect, Axes, os, time, Faces, unpack, string, Color3, newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor, NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint, NumberSequenceKeypoint, PhysicalProperties, Region3int16, Vector3int16, require, table, type, wait, Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, delay, spawn, task, tick, assert =
-	_G,
-game,
-script,
-getfenv,
-setfenv,
-workspace,
-getmetatable,
-setmetatable,
-loadstring,
-coroutine,
-rawequal,
-typeof,
-print,
-math,
-warn,
-error,
-pcall,
-xpcall,
-select,
-rawset,
-rawget,
-ipairs,
-pairs,
-next,
-Rect,
-Axes,
-os,
-time,
-Faces,
-table.unpack,
-string,
-Color3,
-newproxy,
-tostring,
-tonumber,
-Instance,
-TweenInfo,
-BrickColor,
-NumberRange,
-ColorSequence,
-NumberSequence,
-ColorSequenceKeypoint,
-NumberSequenceKeypoint,
-PhysicalProperties,
-Region3int16,
-Vector3int16,
-require,
-table,
-type,
-task.wait,
-Enum,
-UDim,
-UDim2,
-Vector2,
-Vector3,
-Region3,
-CFrame,
-Ray,
-task.delay,
-task.defer,
-task,
-tick,
-function(cond, errMsg)
-	return cond or error(errMsg or "assertion failed!", 2)
-end
+local _G, game, script, getfenv, setfenv, workspace,
+getmetatable, setmetatable, loadstring, coroutine,
+rawequal, typeof, print, math, warn, error,  pcall,
+xpcall, select, rawset, rawget, ipairs, pairs,
+next, Rect, Axes, os, time, Faces, unpack, string, Color3,
+newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+Vector3int16, require, table, type, wait,
+Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, spawn, delay, task, assert, debug, tick =
+	_G, game, script, getfenv, setfenv, workspace,
+getmetatable, setmetatable, loadstring, coroutine,
+rawequal, typeof, print, math, warn, error,  pcall,
+xpcall, select, rawset, rawget, ipairs, pairs,
+next, Rect, Axes, os, time, Faces, table.unpack, string, Color3,
+newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
+NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
+NumberSequenceKeypoint, PhysicalProperties, Region3int16,
+Vector3int16, require, table, type, task.wait,
+Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, task.defer, task.delay, task, function(cond, errMsg) return cond or error(errMsg or "assertion failed!", 2) end, debug, tick;
 
 local SERVICES_WE_USE = table.freeze({
 	"Workspace",
@@ -153,6 +107,7 @@ local origEnv = getfenv()
 setfenv(1, setmetatable({}, { __metatable = unique }))
 local startTime = time()
 local oldInstNew = Instance.new
+local oldFromExisting = Instance.fromExisting
 local oldReq = require
 local locals = {}
 local client = {}
@@ -421,6 +376,7 @@ BrickColor = Localize(BrickColor)
 TweenInfo = Localize(TweenInfo)
 Axes = Localize(Axes)
 task = Localize(task)
+debug = Localize(debug)
 
 --// Wrap
 log("Wrap")
@@ -447,6 +403,9 @@ Instance = {
 	new = function(obj, parent)
 		return service_Wrap(oldInstNew(obj, service_UnWrap(parent)), true)
 	end,
+	fromExisting = function(existingInstance: Instance)
+		return service_Wrap(oldFromExisting(service_UnWrap(existingInstance)))
+	end
 }
 require = function(obj, noWrap: boolean?)
 	return if noWrap == true then oldReq(service_UnWrap(obj)) else service_Wrap(oldReq(service_UnWrap(obj)), true)
@@ -522,6 +481,7 @@ for ind, loc in
 		Ray = Ray,
 		task = task,
 		tick = tick,
+		debug = debug,
 		service = service,
 	}
 do

--- a/MainModule/Client/Plugins/Misc_Features.luau
+++ b/MainModule/Client/Plugins/Misc_Features.luau
@@ -4,7 +4,6 @@ return function(Vargs, GetEnv)
 	local client = Vargs.Client;
 	local service = Vargs.Service;
 
-	local Settings = client.Settings
 	local Functions, Anti, Core, Logs, Remote, Process, Variables = client.Functions, client.Anti, client.Core, client.Logs, client.Remote, client.Process, client.Variables
 
 	-- // Backwards compatibility
@@ -35,7 +34,6 @@ return function(Vargs, GetEnv)
 		__newindex = function(_, ind, val)
 			warn("Unencrypted remote commands are deprecated; moving", ind, "to Remote.Commands. Replace `Remote.Unencrypted` with `Remote.Commands`!")
 			Remote.Commands[ind] = val
-			Logs:AddLog("Script", `Attempted to add {ind} to legacy Remote.Unencrypted. Moving to Remote.Commands`)
 		end
 	})
 	client.Folder:SetSpecial("Shared", client.Shared)
@@ -53,6 +51,4 @@ return function(Vargs, GetEnv)
 	-- TODO: Remove \\/
 	service.OwnsAsset = service.CheckAssetOwnership
 	Functions.CatchError = client.Pcall
-
-	Logs:AddLog("Script", "Misc Features Module Loaded")
 end

--- a/MainModule/Server/Server.luau
+++ b/MainModule/Server/Server.luau
@@ -49,7 +49,7 @@ newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
 NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
 NumberSequenceKeypoint, PhysicalProperties, Region3int16,
 Vector3int16, require, table, type, wait,
-Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, spawn, delay, task, assert =
+Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, spawn, delay, task, assert, debug =
 	_G, game, script, getfenv, setfenv, workspace,
 getmetatable, setmetatable, loadstring, coroutine,
 rawequal, typeof, print, math, warn, error,  pcall,
@@ -59,7 +59,7 @@ newproxy, tostring, tonumber, Instance, TweenInfo, BrickColor,
 NumberRange, ColorSequence, NumberSequence, ColorSequenceKeypoint,
 NumberSequenceKeypoint, PhysicalProperties, Region3int16,
 Vector3int16, require, table, type, task.wait,
-Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, task.defer, task.delay, task, function(cond, errMsg) return cond or error(errMsg or "assertion failed!", 2) end;
+Enum, UDim, UDim2, Vector2, Vector3, Region3, CFrame, Ray, task.defer, task.delay, task, function(cond, errMsg) return cond or error(errMsg or "assertion failed!", 2) end, debug;
 
 local SERVICES_WE_USE = table.freeze {
 	"Workspace";
@@ -87,7 +87,8 @@ local SERVICES_WE_USE = table.freeze {
 }
 
 local unique = {}
-local origEnv = getfenv(); setfenv(1,setmetatable({}, {__metatable = unique}))
+local origEnv = getfenv()
+setfenv(1, setmetatable({}, { __metatable = unique }))
 local locals = {}
 local server = {}
 local service = {}
@@ -95,9 +96,10 @@ local RbxEvents = {}
 local ErrorLogs = {}
 local HookedEvents = {}
 local ServiceSpecific = {}
-local oldReq = require
 local Folder = script.Parent
 local oldInstNew = Instance.new
+local oldFromExisting = Instance.fromExisting
+local oldReq = require
 local isModule = function(module)
 	for ind, modu in pairs(server.Modules) do
 		if module == modu then
@@ -358,11 +360,15 @@ BrickColor = service.Localize(BrickColor)
 TweenInfo = service.Localize(TweenInfo)
 Axes = service.Localize(Axes)
 task = service.Localize(task)
+debug = service.Localize(debug)
 
 --// Wrap
 Instance = {
 	new = function(obj, parent)
 		return oldInstNew(obj, service.UnWrap(parent))
+	end,
+	fromExisting = function(existingInstance: Instance)
+		return oldFromExisting(service.UnWrap(existingInstance))
 	end
 }
 

--- a/MainModule/Server/Server.luau
+++ b/MainModule/Server/Server.luau
@@ -449,6 +449,7 @@ for ind, loc in pairs({
 	CFrame = CFrame;
 	Ray = Ray;
 	task = task;
+	debug = debug;
 	service = service
 	})
 do


### PR DESCRIPTION
Fixes a bug where the exception handler would not work due to 'debug' not being defined as a local inside Client and 'tick' being nil.

Also fixes a hidden error from Client trying to use 'Logs' when it doesn't exist on client that shows due to the fix above.

PoF (both fixes):
<img width="842" height="282" alt="image" src="https://github.com/user-attachments/assets/47b56336-f548-46fe-8c3d-2873ea96a256" />
<img width="689" height="192" alt="image" src="https://github.com/user-attachments/assets/f2264678-4ace-4e4c-97ce-bad9f17beb3c" />
