### PR TITLE
Disable :rainbowify until fixed

### DIFF
--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -648,6 +648,7 @@ return function(Vargs, env)
 		};
 
 		Rainbowify = {
+			Disabled = true; -- Disabled until command gets fixed, due to cloth-removal (#2090)
 			Prefix = Settings.Prefix;
 			Commands = {"rainbowify", "rainbow"};
 			Args = {"player"};


### PR DESCRIPTION
Disabled the :rainbowify command due to ToS concerns.

Just to avoid potential problems, I think :rainbowify should be disabled, as the script never runs (#2090), but it does remove a player's clothes, essentially stripping them naked, which I'm sure would go against some Roblox ToS.

PoF and recording of the issue are included below:

<img width="439" height="305" alt="image" src="https://github.com/user-attachments/assets/029b18cd-ae49-43bd-bc9e-a40c7c8efd89" />

https://github.com/user-attachments/assets/0057c3f6-0765-4013-b0ce-eb4bad8565b9

