### PR TITLE
Add speed and looping control to :animation (#1924)

### DIFF
--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -1014,7 +1014,9 @@ return function(Vargs, GetEnv)
 			})
 			local track = animator:LoadAnimation(anim)
 
-			track.Looped = isLooped or false
+			if isLooped ~= nil then
+				track.Looped = isLooped
+			end
 
 			track:Play(nil, nil, animSpeed or 1)
 		end;

--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -998,12 +998,13 @@ return function(Vargs, GetEnv)
 			table.clear(objects)
 		end;
 
-		PlayAnimation = function(animId)
+		PlayAnimation = function(animId: number, animSpeed: number?, isLooped: boolean?)
 			if animId == 0 then return end
 
 			local char = service.Player.Character
 			local human = char and char:FindFirstChildOfClass("Humanoid")
 			local animator = human and human:FindFirstChildOfClass("Animator") or human and human:WaitForChild("Animator", 9e9)
+
 			if not animator then return end
 
 			for _, v in animator:GetPlayingAnimationTracks() do v:Stop() end
@@ -1012,7 +1013,10 @@ return function(Vargs, GetEnv)
 				Name = "ADONIS_Animation"
 			})
 			local track = animator:LoadAnimation(anim)
-			track:Play()
+
+			track.Looped = isLooped or false
+
+			track:Play(nil, nil, animSpeed or 1)
 		end;
 
 		StopAnimation = function()

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -4360,7 +4360,7 @@ return function(Vargs, env)
 		Animation = {
 			Prefix = Settings.Prefix;
 			Commands = {"animation", "loadanim", "animate"};
-			Args = {"player", "animationID", "speed (default: 1)", "isLooped? (default: false)"};
+			Args = {"player", "animationID", "speed (default: 1)", "isLooped? (default: decided by the animation)"};
 			Description = "Plays the specified animation on a target";
 			Fun = true;
 			AdminLevel = "Moderators";
@@ -4374,7 +4374,8 @@ return function(Vargs, env)
 				local id = assert(tonumber(args[2]), `{tostring(args[2])} is not a valid ID!`)
 				local speed = args[3] and assert(tonumber(args[3]), `{tostring(args[3])} is not a valid speed!`) or nil
 
-				local isLooped = args[4] == "true" or args[4] == "1"or false -- TODO Possibly add a helper function for parsing string into bool?
+				-- TODO Possibly add a helper function for parsing string into bool?
+				local isLooped = args[4] and (args[4] == "true" or args[4] == "1")
 
 				for _, v in service.GetPlayers(plr, args[1]) do
 					Functions.PlayAnimation(v , id, speed, isLooped)

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -4371,21 +4371,13 @@ return function(Vargs, env)
 					args[1] = nil 
 				end
 
-				assert(tonumber(args[2]), `{tostring(args[2])} is not a valid ID!`)
-				if args[3] then
-					assert(tonumber(args[3]), `{tostring(args[3])} is not a valid speed!`)
-				end
+				local id = assert(tonumber(args[2]), `{tostring(args[2])} is not a valid ID!`)
+				local speed = args[3] and assert(tonumber(args[3]), `{tostring(args[3])} is not a valid speed!`) or nil
 
-				local isLooped = false
-
-				-- TODO Possibly add a helper function for parsing string into bool?
-				if args[4] == "true" or args[4] == "1" then
-					isLooped = true
-				end
-
+				local isLooped = args[4] == "true" or args[4] == "1"or false -- TODO Possibly add a helper function for parsing string into bool?
 
 				for _, v in service.GetPlayers(plr, args[1]) do
-					Functions.PlayAnimation(v , args[2], tonumber(args[3]), isLooped)
+					Functions.PlayAnimation(v , id, speed, isLooped)
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -4360,17 +4360,32 @@ return function(Vargs, env)
 		Animation = {
 			Prefix = Settings.Prefix;
 			Commands = {"animation", "loadanim", "animate"};
-			Args = {"player", "animationID"};
-			Description = "Load the animation onto the target";
+			Args = {"player", "animationID", "speed (default: 1)", "isLooped? (default: false)"};
+			Description = "Plays the specified animation on a target";
 			Fun = true;
 			AdminLevel = "Moderators";
 			Function = function(plr, args)
-				if args[1] and not args[2] then args[2] = args[1] args[1] = nil end
+				-- Command got ran without a target
+				if args[1] and not args[2] then 
+					args[2] = args[1] 
+					args[1] = nil 
+				end
 
-				assert(tonumber(args[2]), `{tostring(args[2])} is not a valid ID`)
+				assert(tonumber(args[2]), `{tostring(args[2])} is not a valid ID!`)
+				if args[3] then
+					assert(tonumber(args[3]), `{tostring(args[3])} is not a valid speed!`)
+				end
+
+				local isLooped = false
+
+				-- TODO Possibly add a helper function for parsing string into bool?
+				if args[4] == "true" or args[4] == "1" then
+					isLooped = true
+				end
+
 
 				for _, v in service.GetPlayers(plr, args[1]) do
-					Functions.PlayAnimation(v , args[2])
+					Functions.PlayAnimation(v , args[2], args[3], isLooped)
 				end
 			end
 		};

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -4385,7 +4385,7 @@ return function(Vargs, env)
 
 
 				for _, v in service.GetPlayers(plr, args[1]) do
-					Functions.PlayAnimation(v , args[2], args[3], isLooped)
+					Functions.PlayAnimation(v , args[2], tonumber(args[3]), isLooped)
 				end
 			end
 		};

--- a/MainModule/Server/Core/Functions.luau
+++ b/MainModule/Server/Core/Functions.luau
@@ -1118,13 +1118,13 @@ return function(Vargs, GetEnv)
 			end
 		end;
 
-		PlayAnimation = function(player, animId)
+		PlayAnimation = function(player: Player, animId: number, animSpeed: number?, isLooped: boolean?)
 			if player.Character and tonumber(animId) then
 				local human = player.Character:FindFirstChildOfClass("Humanoid")
 				if human and not human:FindFirstChildOfClass("Animator") then
 					service.New("Animator", human)
 				end
-				Remote.Send(player,"Function","PlayAnimation",animId)
+				Remote.Send(player, "Function", "PlayAnimation", animId, animSpeed or 1, isLooped or false)
 			end
 		end;
 


### PR DESCRIPTION
Adds two new optional arguments to the `:animate` command. 

`[speed] (default: 1)`: Controls the animation speed
`[isLooped?] (default: false)`: Controls whether the animation track should be loaded as a looped one, or not


PoF:

https://github.com/user-attachments/assets/6dafa992-6fdd-4c2a-89d7-8a0f75949663

Argument validation:
speed should be a `number`, otherwise the assertion will throw
the looped argument only cares about `"true"` and `"1"`
in all other cases, it will default to `false`


https://github.com/user-attachments/assets/0e6ccdab-441d-4ef7-9680-a0ccf96a3877

