### PR TITLE
Revamp command list

### DIFF
--- a/MainModule/Client/UI/Default/CommandList.luau
+++ b/MainModule/Client/UI/Default/CommandList.luau
@@ -9,6 +9,14 @@ return function(data, env)
 	local Remote = client.Remote
 	local UI = client.UI
 
+	local CanBulkPurchaseTypes = {
+		2, 8, 11, 12, 17, 18, 27, 28, 29, 30, 31, 32, -- Classic
+		41, 42, 43, 44, 45, 46, 47, 57, 58, -- Accessories
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 61, -- Animations
+		64, 65, 66, 67, 68, 69, 70, 71, 72, 76, 77, -- Layered Clothing
+		78, 79, 88, 89, 90 -- Other
+	}
+
 	local window = UI.Make("Window", {
 		Name = "Commands",
 		Title = "Commands",
@@ -20,26 +28,30 @@ return function(data, env)
 		return
 	end
 
-	local commands = Remote.Get("SearchCommands", "all") or {}
-	local purchasables = Remote.Get("RankPurchasables") or {}
-	local rankLevels = Remote.Get("RankLevels") or {}
+	local cmdData = Remote.Get("CommandListData")
+	if not cmdData then
+		error("Failed to get command list data")
+	end
 
 	local searchTerm = ""
 	local groupBy = "Rank"
 	
 	local scroll = window:Add("ScrollingFrame", {
 		Name = "CommandList",
-		Position = UDim2.fromOffset(10, 50),
-		Size = UDim2.new(1, -20, 1, -60),
+		Position = UDim2.fromOffset(5, 35),
+		Size = UDim2.new(1, -10, 1, -40),
 		BackgroundTransparency = 1,
 		AutomaticCanvasSize = Enum.AutomaticSize.Y,
 		VerticalScrollBarInset = Enum.ScrollBarInset.ScrollBar,
 	})
+	if window.Dragger then
+		window.Dragger.Modal = true
+	end
 	scroll:Add("UIListLayout", {
 		SortOrder = Enum.SortOrder.LayoutOrder
 	})
 
-	for _, command in commands do
+	for _, command in cmdData.Commands do
 		command.Aliases = {}
 		for _, prefix in (typeof(command.Prefix) == "table" and command.Prefix or {command.Prefix}) do
 			for _, cmd in command.Commands do
@@ -99,6 +111,14 @@ return function(data, env)
 			SortOrder = Enum.SortOrder.Name,
 			Padding = UDim.new(0, 3)
 		})
+		local cmdRank
+		for _, rank in cmdData.Ranks do
+			if rank.Level == command.AdminLevel then
+				cmdRank = rank
+				break
+			end
+		end
+		renderCommandDetailsRow(container, "Rank", if cmdRank then `{cmdRank.Rank} ({cmdRank.Level})` else command.AdminLevel)
 		if #command.Aliases > 1 then
 			local str = ``
 			for _, alias in command.Aliases do
@@ -114,13 +134,37 @@ return function(data, env)
 		return container
 	end
 
+	local function renderRankPurchase(parent, label, buttonText, layoutOrder)
+		local buyFrame = parent:Add("Frame", {
+			Size = UDim2.new(1, 0, 0, 30),
+			LayoutOrder = layoutOrder or 0,
+		})
+		buyFrame:Add("TextLabel", {
+			Text = label,
+			BackgroundTransparency = 1,
+			TextXAlignment = Enum.TextXAlignment.Left,
+			Position = UDim2.fromOffset(5, 0),
+			TextTruncate = Enum.TextTruncate.SplitWord,
+			Size = UDim2.new(1, -110, 1, -5)
+		})
+		local buyButton = buyFrame:Add("TextButton", {
+			Text = buttonText,
+			BackgroundColor3 = Color3.new(0,1,0):lerp(Color3.new(1,0,0), 0.1);
+			BackgroundTransparency = 0.7;
+			TextXAlignment = Enum.TextXAlignment.Center,
+			Position = UDim2.new(1, -95, 0, 0),
+			Size = UDim2.fromOffset(90, 25)
+		})
+		return buyFrame, buyButton
+	end
+
 	local currentDetails, currentRow
 
 	local function renderCommands()
 		local groups = {}
 		local groupsInfo = {}
 
-		for _, command in commands do
+		for _, command in cmdData.Commands do
 			if command.Hidden then continue end
 
 			if searchTerm and #searchTerm > 0 then
@@ -152,7 +196,7 @@ return function(data, env)
 					if groupKey == 0 then
 						name = "Players"
 					else
-						for _, rank in rankLevels do
+						for _, rank in cmdData.Ranks do
 							if rank.Level == command.AdminLevel then
 								name = rank.Rank
 								break
@@ -172,13 +216,9 @@ return function(data, env)
 
 		if groupBy == "Rank" then
 			table.sort(groupsInfo, function(a, b) 
-				if a.Key == "Donors" then
-					return true
-				elseif b.Key == "Donors" then
-					return false
-				else
-					return tostring(a.Key) < tostring(b.Key)
-				end
+				local av = if a.Key == "Donors" then 0.5 else a.Key
+				local bv = if b.Key == "Donors" then 0.5 else b.Key
+				return av < bv
 			end)
 		else
 			table.sort(groupsInfo, function(a, b) return tostring(a.Key) < tostring(b.Key) end)
@@ -203,38 +243,129 @@ return function(data, env)
 			frame:Add("UIListLayout", {
 				SortOrder = Enum.SortOrder.LayoutOrder
 			})
-
-			local groupLabel = frame:Add("TextButton", {
-				Text = `<b>{groupInfo.Name}</b> ({#group})`,
-				RichText = true,
-				TextSize = 18,
-				BackgroundTransparency = 1,
-				Size = UDim2.new(1, 0, 0, 30),
-				TextXAlignment = Enum.TextXAlignment.Left,
-				LayoutOrder = -1
+			frame:Add("UIPadding", {
+				PaddingBottom = UDim.new(0, 5)
 			})
 
-			groupLabel:Add("UIPadding", {
-				PaddingLeft = UDim.new(0, 5),
-				PaddingRight = UDim.new(0, 5)
-			})
+			if #groupsInfo > 1 then
+				local groupLabel = frame:Add("TextButton", {
+					Text = `<b>{groupInfo.Name}</b> ({#group})`,
+					RichText = true,
+					TextSize = 18,
+					AutoButtonColor = false,
+					Size = UDim2.new(1, 0, 0, 30),
+					TextXAlignment = Enum.TextXAlignment.Left,
+					LayoutOrder = -2
+				})
 
-			local expanded = true
-			local arrow = groupLabel:Add("TextLabel", {
-				Text = ">",
-				Size = UDim2.fromOffset(20, 20),
-				Position = UDim2.new(1, -20, 0.5, -10),
-				BackgroundTransparency = 1,
-				Rotation = 90
-			})
-			groupLabel.Activated:Connect(function()
-				expanded = not expanded
-				arrow.Rotation = (if expanded then 90 else 0)
-				for _, cmd in frame:GetChildren() do
-					if cmd == groupLabel or not cmd:IsA("GuiObject") then continue end
-					cmd.Visible = expanded
+				groupLabel:Add("UIPadding", {
+					PaddingLeft = UDim.new(0, 5),
+					PaddingRight = UDim.new(0, 5)
+				})
+
+				local expanded = true
+				local arrow = groupLabel:Add("TextLabel", {
+					Text = ">",
+					Size = UDim2.fromOffset(20, 20),
+					Position = UDim2.new(1, -20, 0.5, -10),
+					BackgroundTransparency = 1,
+					Rotation = 90
+				})
+				groupLabel.Activated:Connect(function()
+					expanded = not expanded
+					arrow.Rotation = (if expanded then 90 else 0)
+					for _, cmd in frame:GetChildren() do
+						if cmd == groupLabel or not cmd:IsA("GuiObject") then continue end
+						cmd.Visible = expanded
+					end
+				end)
+			end
+
+			if groupBy == "Rank" then
+				local rank
+				for _, r in cmdData.Ranks do
+					if r.Level == groupInfo.Key then
+						rank = r
+						break
+					end
 				end
-			end)
+				if rank and ((rank.Rank == "Donors" and not cmdData.PlayerData.isDonor) or (typeof(rank.Level) == "number" and cmdData.PlayerData.Level < rank.Level)) then
+					local hasOneTime, hasSubscription = false, false
+					local cheapestOneTime, cheapestSubscription = nil, nil
+					local oneTimeRow, subscriptionRow = nil, nil
+					local oneTimeButton, subscriptionButton = nil, nil
+					local oneTimeChecking, subscriptionChecking = 0, 0
+					for _, v in rank.Purchasables do
+						if v.Type == Enum.InfoType.Subscription then
+							hasSubscription = true
+							subscriptionChecking += 1
+							task.spawn(function()
+								local info = service.GetSubscriptionInfo(v.Id)
+								info.Id = v.Id
+								info.Type = v.Type
+								if not info or not info.Created or not info.IsForSale then
+									subscriptionChecking -= 1
+									if subscriptionChecking <= 0 and not cheapestSubscription then
+										subscriptionRow:Destroy()
+									end
+									return
+								end
+								local priceTier = if info.PriceInRobux == 0 then info.PriceTier else info.PriceInRobux
+								info.AppliedPriceTier = priceTier
+								local displayString = `{if info.PriceInRobux == 0 then info.DisplayPrice else ` {info.PriceInRobux}`}{info.DisplaySubscriptionPeriod}`
+								info.DisplayString = displayString
+								if cheapestSubscription == nil or priceTier < cheapestSubscription.AppliedPriceTier then
+									cheapestSubscription = info
+									if subscriptionButton then
+										subscriptionButton.Text = displayString
+									end
+								end
+								subscriptionChecking -= 1
+							end)
+						else
+							hasOneTime = true
+							task.spawn(function()
+								local info = service.GetProductInfo(v.Id, v.Type)
+								info.Id = v.Id
+								info.Type = v.Type
+								if not info or not info.Created or not info.IsForSale then
+									oneTimeChecking -= 1
+									if oneTimeChecking <= 0 and not cheapestOneTime then
+										oneTimeRow:Destroy()
+									end
+									return
+								end
+								if cheapestOneTime == nil or info.PriceInRobux < cheapestOneTime.PriceInRobux then
+									cheapestOneTime = info
+									if oneTimeButton then
+										oneTimeButton.Text = ` {info.PriceInRobux}`
+									end
+								end
+								oneTimeChecking -= 1
+							end)
+						end
+					end
+					if hasOneTime then
+						oneTimeRow, oneTimeButton = renderRankPurchase(frame, `Unlock permanently`, if cheapestOneTime then ` {cheapestOneTime.PriceInRobux}` else `...`, -1)
+						oneTimeButton.Activated:Connect(function()
+							if not cheapestOneTime then return end
+							if table.find(CanBulkPurchaseTypes, cheapestOneTime.AssetTypeId) then
+								client.Remote.Send("PromptBulkPurchase", {cheapestOneTime.Id})
+							else
+								local func = if cheapestOneTime.Type == Enum.InfoType.Asset then service.MarketPlace.PromptPurchase else service.MarketPlace.PromptGamePassPurchase
+								func(service.MarketPlace, service.Player, cheapestOneTime.Id)
+							end
+						end)
+					end
+					if hasSubscription then
+						subscriptionRow, subscriptionButton = renderRankPurchase(frame, `Unlock with subscription`, if cheapestSubscription then cheapestSubscription.DisplayString else `...`, 0)
+						subscriptionButton.Activated:Connect(function()
+							if not cheapestSubscription then return end
+							service.MarketPlace:PromptSubscriptionPurchase(service.Player, cheapestSubscription.Id)
+						end)
+					end
+				end
+			end
 
 			for i, command in group do
 				local str = `{command.PrimaryAlias}`
@@ -251,6 +382,7 @@ return function(data, env)
 					Size = UDim2.new(1, 0, 0, 20),
 					TextXAlignment = Enum.TextXAlignment.Left,
 					TextTruncate = Enum.TextTruncate.AtEnd,
+					TextTransparency = if command.HasPermission then 0 else 0.4,
 					LayoutOrder = i * 2
 				})
 				commandLabel:Add("UIPadding", {
@@ -275,13 +407,20 @@ return function(data, env)
 	local box = window:Add("TextBox", {
 		Text = "",
 		PlaceholderText = "Search...",
-		Size = UDim2.new(1, -110, 0, 30),
-		Position = UDim2.fromOffset(10, 10),
+		Size = UDim2.new(1, -95, 0, 25),
+		Position = UDim2.fromOffset(5, 5),
 		TextXAlignment = Enum.TextXAlignment.Left,
 	})
 	box:Add("UIPadding", {
-		PaddingLeft = UDim.new(0, 5),
+		PaddingLeft = UDim.new(0, 25),
 		PaddingRight = UDim.new(0, 5)
+	})
+	box:Add("ImageLabel", {
+		Image = client.MatIcons.Search,
+		Size = UDim2.fromOffset(15, 15),
+		Position = UDim2.fromOffset(-5, 5),
+		AnchorPoint = Vector2.new(1, 0),
+		BackgroundTransparency = 1,
 	})
 
 	box:GetPropertyChangedSignal("Text"):Connect(function()
@@ -291,8 +430,8 @@ return function(data, env)
 
 	local dropdown = window:Add("Dropdown", {
 		Name = "GroupBy",
-		Position = UDim2.new(1, -90, 0, 10),
-		Size = UDim2.fromOffset(80, 30),
+		Position = UDim2.new(1, -85, 0, 5),
+		Size = UDim2.fromOffset(80, 25),
 		Options = { "Rank", "Category", "None" },
 		Selected = groupBy,
 		OnSelect = function(option)

--- a/MainModule/Client/UI/Default/CommandList.luau
+++ b/MainModule/Client/UI/Default/CommandList.luau
@@ -1,0 +1,307 @@
+return function(data, env)
+	if env then
+		setfenv(1, env)
+	end
+
+	local client = env.client
+	local service = env.service
+
+	local Remote = client.Remote
+	local UI = client.UI
+
+	local window = UI.Make("Window", {
+		Name = "Commands",
+		Title = "Commands",
+		Icon = client.MatIcons["Format list bulleted"],
+		Size = { 320, 340 },
+		AllowMultiple = false,
+	})
+	if not window then
+		return
+	end
+
+	local commands = Remote.Get("SearchCommands", "all") or {}
+	local purchasables = Remote.Get("RankPurchasables") or {}
+	local rankLevels = Remote.Get("RankLevels") or {}
+
+	local searchTerm = ""
+	local groupBy = "Rank"
+	
+	local scroll = window:Add("ScrollingFrame", {
+		Name = "CommandList",
+		Position = UDim2.fromOffset(10, 50),
+		Size = UDim2.new(1, -20, 1, -60),
+		BackgroundTransparency = 1,
+		AutomaticCanvasSize = Enum.AutomaticSize.Y,
+		VerticalScrollBarInset = Enum.ScrollBarInset.ScrollBar,
+	})
+	scroll:Add("UIListLayout", {
+		SortOrder = Enum.SortOrder.LayoutOrder
+	})
+
+	for _, command in commands do
+		command.Aliases = {}
+		for _, prefix in (typeof(command.Prefix) == "table" and command.Prefix or {command.Prefix}) do
+			for _, cmd in command.Commands do
+				table.insert(command.Aliases, prefix .. cmd)
+			end
+			if #command.Commands == 0 then
+				table.insert(command.Aliases, prefix)
+			end
+		end
+	end
+
+	local function renderCommandDetailsRow(parent, label, value)
+		local row = parent:Add("Frame", {
+			Size = UDim2.new(1, 0, 0, 16),
+			AutomaticSize = Enum.AutomaticSize.Y,
+			BackgroundTransparency = 1,
+			Name = label
+		})
+		row:Add("UIPadding", {
+			PaddingLeft = UDim.new(0, 5),
+			PaddingRight = UDim.new(0, 5)
+		})
+		row:Add("TextLabel", {
+			Text = label,
+			TextColor3 = Color3.fromRGB(150, 150, 150),
+			TextSize = 14,
+			BackgroundTransparency = 1,
+			TextXAlignment = Enum.TextXAlignment.Left,
+			Position = UDim2.fromOffset(0, 0),
+			Size = UDim2.new(0, 40, 1, 0)
+		})
+		row:Add("TextLabel", {
+			Text = value,
+			TextColor3 = Color3.fromRGB(200, 200, 200),
+			TextSize = 14,
+			TextWrapped = true,
+			AutomaticSize = Enum.AutomaticSize.Y,
+			BackgroundTransparency = 1,
+			TextXAlignment = Enum.TextXAlignment.Left,
+			Size = UDim2.new(1, -50, 0, 16),
+			Position = UDim2.fromOffset(50, 0)
+		})
+		return row
+	end
+
+	local function renderCommandDetails(parent, command, layoutOrder)
+		local container = parent:Add("Frame", {
+			Size = UDim2.fromScale(1, 0),
+			AutomaticSize = Enum.AutomaticSize.Y,
+			LayoutOrder = layoutOrder or 0
+		})
+		container:Add("UIPadding", {
+			PaddingTop = UDim.new(0, 3),
+			PaddingBottom = UDim.new(0, 3)
+		})
+		container:Add("UIListLayout", {
+			SortOrder = Enum.SortOrder.Name,
+			Padding = UDim.new(0, 3)
+		})
+		if #command.Aliases > 1 then
+			local str = ``
+			for _, alias in command.Aliases do
+				if alias == command.PrimaryAlias then continue end
+				str ..= `, {alias}`
+			end
+			renderCommandDetailsRow(container, "Aliases", string.sub(str, 3))
+		end
+		if command.Description then
+			renderCommandDetailsRow(container, "Desc", command.Description)
+		end
+
+		return container
+	end
+
+	local currentDetails, currentRow
+
+	local function renderCommands()
+		local groups = {}
+		local groupsInfo = {}
+
+		for _, command in commands do
+			if command.Hidden then continue end
+
+			if searchTerm and #searchTerm > 0 then
+				local found = false
+				for _, alias in command.Aliases do
+					if string.find(string.lower(alias), searchTerm, 1, true) then
+						command.PrimaryAlias = alias
+						found = true
+						break
+					end
+				end
+				if not found then continue end
+			else
+				command.PrimaryAlias = command.Aliases[1]
+			end
+
+			local groupKey
+			if groupBy == "Rank" then
+				groupKey = command.AdminLevel or 0
+			elseif groupBy == "Category" then
+				groupKey = command.Category or "Uncategorized"
+			else
+				groupKey = "All Commands"
+			end
+
+			if not groups[groupKey] then
+				local name = tostring(groupKey)
+				if groupBy == "Rank" then
+					if groupKey == 0 then
+						name = "Players"
+					else
+						for _, rank in rankLevels do
+							if rank.Level == command.AdminLevel then
+								name = rank.Rank
+								break
+							end
+						end
+					end
+				end
+				table.insert(groupsInfo, {
+					Key = groupKey,
+					Name = name
+				})
+
+				groups[groupKey] = {}
+			end
+			table.insert(groups[groupKey], command)
+		end
+
+		if groupBy == "Rank" then
+			table.sort(groupsInfo, function(a, b) 
+				if a.Key == "Donors" then
+					return true
+				elseif b.Key == "Donors" then
+					return false
+				else
+					return tostring(a.Key) < tostring(b.Key)
+				end
+			end)
+		else
+			table.sort(groupsInfo, function(a, b) return tostring(a.Key) < tostring(b.Key) end)
+		end
+
+		for _, commands in groups do
+			table.sort(commands, function(a, b) return a.Aliases[1] < b.Aliases[1] end)
+		end
+
+		for _,v in scroll:GetChildren() do
+			if v:IsA("UIListLayout") then continue end
+			v:Destroy()
+		end
+
+		for _, groupInfo in groupsInfo do
+			local group = groups[groupInfo.Key]
+			local frame = scroll:Add("Frame", {
+				AutomaticSize = Enum.AutomaticSize.Y,
+				Size = UDim2.fromScale(1, 0),
+				BackgroundTransparency = 1,
+			})
+			frame:Add("UIListLayout", {
+				SortOrder = Enum.SortOrder.LayoutOrder
+			})
+
+			local groupLabel = frame:Add("TextButton", {
+				Text = `<b>{groupInfo.Name}</b> ({#group})`,
+				RichText = true,
+				TextSize = 18,
+				BackgroundTransparency = 1,
+				Size = UDim2.new(1, 0, 0, 30),
+				TextXAlignment = Enum.TextXAlignment.Left,
+				LayoutOrder = -1
+			})
+
+			groupLabel:Add("UIPadding", {
+				PaddingLeft = UDim.new(0, 5),
+				PaddingRight = UDim.new(0, 5)
+			})
+
+			local expanded = true
+			local arrow = groupLabel:Add("TextLabel", {
+				Text = ">",
+				Size = UDim2.fromOffset(20, 20),
+				Position = UDim2.new(1, -20, 0.5, -10),
+				BackgroundTransparency = 1,
+				Rotation = 90
+			})
+			groupLabel.Activated:Connect(function()
+				expanded = not expanded
+				arrow.Rotation = (if expanded then 90 else 0)
+				for _, cmd in frame:GetChildren() do
+					if cmd == groupLabel or not cmd:IsA("GuiObject") then continue end
+					cmd.Visible = expanded
+				end
+			end)
+
+			for i, command in group do
+				local str = `{command.PrimaryAlias}`
+				local argStr = "";
+				for _,v in (command.Args or command.Arguments) do
+					argStr ..= `  &lt;{v}&gt;`
+				end
+				str ..= `<font color="rgb(150,150,150)">{argStr}</font>`
+				local commandLabel = frame:Add("TextButton", {
+					Text = str,
+					RichText = true,
+					TextWrapped = true,
+					BackgroundTransparency = 1,
+					Size = UDim2.new(1, 0, 0, 20),
+					TextXAlignment = Enum.TextXAlignment.Left,
+					TextTruncate = Enum.TextTruncate.AtEnd,
+					LayoutOrder = i * 2
+				})
+				commandLabel:Add("UIPadding", {
+					PaddingLeft = UDim.new(0, 5),
+					PaddingRight = UDim.new(0, 5)
+				})
+				commandLabel.Activated:Connect(function()
+					if currentRow then
+						currentRow:Destroy()
+					end
+					if currentDetails == commandLabel then
+						currentDetails = nil
+						return
+					end
+					currentDetails = commandLabel
+					currentRow = renderCommandDetails(frame, command, commandLabel.LayoutOrder + 1)
+				end)
+			end
+		end
+	end
+
+	local box = window:Add("TextBox", {
+		Text = "",
+		PlaceholderText = "Search...",
+		Size = UDim2.new(1, -110, 0, 30),
+		Position = UDim2.fromOffset(10, 10),
+		TextXAlignment = Enum.TextXAlignment.Left,
+	})
+	box:Add("UIPadding", {
+		PaddingLeft = UDim.new(0, 5),
+		PaddingRight = UDim.new(0, 5)
+	})
+
+	box:GetPropertyChangedSignal("Text"):Connect(function()
+		searchTerm = string.lower(box.Text)
+		renderCommands()
+	end)
+
+	local dropdown = window:Add("Dropdown", {
+		Name = "GroupBy",
+		Position = UDim2.new(1, -90, 0, 10),
+		Size = UDim2.fromOffset(80, 30),
+		Options = { "Rank", "Category", "None" },
+		Selected = groupBy,
+		OnSelect = function(option)
+			groupBy = option
+			renderCommands()
+		end
+	})
+
+	renderCommands()
+
+	window:Ready()
+end

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -430,7 +430,7 @@ return function(data, env)
 				BackgroundTransparency = 0.5;
 				Events = {
 					MouseButton1Down = function()
-						Remote.Send("ProcessCommand", `{commandPrefix}cmds`)
+						client.UI.Make("CommandList")
 					end
 				}
 			})

--- a/MainModule/Server/Commands/Donors.luau
+++ b/MainModule/Server/Commands/Donors.luau
@@ -58,7 +58,7 @@ return function(Vargs, env)
 		DonorNeon = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"neon", "donorneon"};
-			Args = {"color"};
+			Args = {"brickColor?"};
 			Description = "Changes your body material to neon and makes you the (optional) color of your choosing.";
 			Donors = true;
 			AdminLevel = "Donors";
@@ -79,7 +79,7 @@ return function(Vargs, env)
 		DonorFire = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"fire", "donorfire"};
-			Args = {"color (optional)"};
+			Args = {"brickColor?"};
 			Description = "Gives you fire with the specified color (if you specify one)";
 			Donors = true;
 			AdminLevel = "Donors";
@@ -120,7 +120,7 @@ return function(Vargs, env)
 		DonorSparkles = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"sparkles", "donorsparkles"};
-			Args = {"color (optional)"};
+			Args = {"brickColor?"};
 			Description = "Gives you sparkles with the specified color (if you specify one)";
 			Donors = true;
 			AdminLevel = "Donors";
@@ -159,7 +159,7 @@ return function(Vargs, env)
 		DonorLight = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"light", "donorlight"};
-			Args = {"color (optional)"};
+			Args = {"brickColor?"};
 			Description = "Gives you a PointLight with the specified color (if you specify one)";
 			Donors = true;
 			AdminLevel = "Donors";
@@ -192,7 +192,7 @@ return function(Vargs, env)
 		DonorParticle = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"particle", "donorparticle"};
-			Args = {"textureid", "startColor3", "endColor3"};
+			Args = {"textureId", "startColor3?", "endColor3?"};
 			Description = "Put a custom particle emitter on your character";
 			Donors = true;
 			AdminLevel = "Donors";
@@ -308,7 +308,7 @@ return function(Vargs, env)
 		DonorAvatarItem = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"avataritem", "accessory", "hat", "donorhat", "shirt", "donorshirt", "tshirt", "donortshirt", "givetshirt", "shirt", "donorshirt", "giveshirt", "pants", "donorpants", "givepants", "face", "donorface", "animation", "anim"};
-			Args = {"ID"};
+			Args = {"itemId"};
 			Description = "Gives yourself the avatar item that belongs to <ID>";
 			Donors = true;
 			AdminLevel = "Donors";

--- a/MainModule/Server/Commands/Fun.luau
+++ b/MainModule/Server/Commands/Fun.luau
@@ -548,7 +548,7 @@ return function(Vargs, env)
 
 		Davey = {
 			Prefix = Settings.Prefix;
-			Commands = {"Davey_Bones", "davey"};
+			Commands = {"davey_bones", "davey"};
 			Args = {"player"};
 			Description = "Turns you into me <3";
 			Fun = true;

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -5577,10 +5577,10 @@ return function(Vargs, env)
 
 		AvatarItem = {
 			Prefix = Settings.Prefix;
-			Commands = {"avataritem", "giveavtaritem", "catalogitem", "accessory", "hat", "tshirt", "givetshirt", "shirt", "giveshirt", "pants", "givepants", "face", "anim",
+			Commands = {"avataritem", "catalogitem", "accessory", "hat", "tshirt", "givetshirt", "shirt", "giveshirt", "pants", "givepants", "face", "anim",
 				"torso", "larm", "leftarm", "rarm", "rightarm", "lleg", "leftleg", "rleg", "rightleg", "head", "walkanimation", "walkanim", "runanimation", "runanim", "jumpanimation",
 				"jumpanim", "fallanimation", "fallanim"}; -- Legacy aliases from old commands
-			Args = {"player", "ID"};
+			Args = {"player", "itemId"};
 			Description = "Give the target player(s) the avatar/catalog item matching <ID> and adds it to their HumanoidDescription.";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {[number]:string})

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -18,57 +18,7 @@ return function(Vargs, env)
 			Description = "Lists all available commands";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
-				local tab = {}
-				local cmdCount = 0
-
-				for _, cmd in Admin.SearchCommands(plr, "all") do
-					local cmdAliases = table.create(#cmd.Commands)
-
-					if cmd.Hidden or cmd.Disabled then
-						continue
-					end
-
-					for _,alias in cmd.Commands do
-						if #cmdAliases >= 6 and (#cmd.Commands - #cmdAliases) ~= 0 then
-							table.insert(cmdAliases, `and {#cmd.Commands - #cmdAliases} more...`)
-							break
-						end
-
-						table.insert(cmdAliases, alias)
-					end
-
-					table.remove(cmdAliases, 1)
-
-					local permissionDesc = Admin.FormatCommandAdminLevel(cmd)
-					table.insert(tab, {
-						Text = Admin.FormatCommand(cmd),
-						Desc = `[{permissionDesc}] {if #cmdAliases >= 1 then `\nAliases: {table.concat(cmdAliases, ", ")}` else ""} \n\n{cmd.Description or "(No description provided)"}`,
-						Filter = permissionDesc
-					})
-					cmdCount += 1
-				end
-
-				for alias, command in Core.GetPlayer(plr).Aliases or {} do
-					table.insert(tab, {
-						Text = alias,
-						Desc = `[User Alias] {command}`,
-						Filter = command
-					})
-					cmdCount += 1
-				end
-
-				table.sort(tab, function(a, b) return a.Text < b.Text end)
-
-				Remote.MakeGui(plr, "List", {
-					Title = "Commands";
-					Table = tab;
-					TitleButtons = {
-						{
-							Text = "?";
-							OnClick = Core.Bytecode(`client.Remote.Send('ProcessCommand','{Settings.PlayerPrefix}usage')`)
-						}
-					};
-				})
+				Remote.MakeGui(plr, "CommandList")
 			end
 		};
 

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -75,7 +75,7 @@ return function(Vargs, env)
 		Notepad = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"notepad", "stickynote"};
-			Args = {"text (optional)"};
+			Args = {"text?"};
 			Description = "Opens a textbox window for you to type into";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
@@ -108,7 +108,7 @@ return function(Vargs, env)
 		NotifyMe = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"notifyme"};
-			Args = {"time (in seconds) or inf", "message"};
+			Args = {"seconds/inf", "text"};
 			Hidden = true;
 			Description = "Sends yourself a notification";
 			AdminLevel = "Players";
@@ -138,7 +138,7 @@ return function(Vargs, env)
 		RandomNum = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"rand", "random", "randnum", "dice"};
-			Args = {"num m", "num n"};
+			Args = {"min", "max"};
 			Description = "Generates a number using Lua's math.random";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {any})
@@ -282,7 +282,7 @@ return function(Vargs, env)
 		Donors = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"donors", "donorlist", "donatorlist", "donators"};
-			Args = {"autoupdate? (default: true)"};
+			Args = {"autoupdate?"};
 			Description = "Shows a list of Adonis donators who are currently in the server";
 			AdminLevel = "Players";
 			ListUpdater = function(plr: Player)
@@ -513,7 +513,7 @@ return function(Vargs, env)
 		Theme = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"theme", "usertheme"};
-			Args = {"theme name (leave blank to reset to default)"};
+			Args = {"name?"};
 			Hidden = true;
 			Description = "Changes the Adonis client UI theme";
 			AdminLevel = "Players";
@@ -671,7 +671,7 @@ return function(Vargs, env)
 		PersonalCountdown = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"countdown", "timer", "cd"};
-			Args = {"time (in seconds)"};
+			Args = {"seconds"};
 			Description = "Makes a countdown on your screen";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
@@ -858,7 +858,7 @@ return function(Vargs, env)
 		BuyItem = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"buyitem", "buyasset"};
-			Args = {"id"};
+			Args = {"itemId"};
 			Description = "Prompts yourself to buy the asset belonging to the ID supplied";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})
@@ -885,7 +885,7 @@ return function(Vargs, env)
 		Wait = {
 			Prefix = Settings.PlayerPrefix;
 			Commands = {"wait"};
-			Args = {"time"};
+			Args = {"seconds"};
 			Description = "Waits for the desired amount of time in seconds. Only works with batch commands";
 			AdminLevel = "Players";
 			Function = function(plr: Player, args: {string})

--- a/MainModule/Server/Core/Process.luau
+++ b/MainModule/Server/Core/Process.luau
@@ -1009,7 +1009,7 @@ return function(Vargs, GetEnv)
 				if level > 0 then
 					if Settings.Notification then
 						task.wait(1)
-						Functions.Notification("Welcome.", `Your rank is {rank} ({level}). Click here for commands.`, {p}, 15, "MatIcon://Verified user", Core.Bytecode(`client.Remote.Send("ProcessCommand","{Settings.Prefix}cmds")`))
+						Functions.Notification("Welcome.", `Your rank is {rank} ({level}). Click here for commands.`, {p}, 15, "MatIcon://Verified user", Core.Bytecode(`client.UI.Make("CommandList")`))
 
 						if #server.Messages > 0 then
 							for _, message in server.Messages do

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -550,6 +550,63 @@ return function(Vargs, GetEnv)
 					end
 				end
 			end;
+
+			RankLevels = function(p)
+				local levels = {}
+				for name, data in Settings.Ranks do
+					table.insert(levels, {
+						Rank = name;
+						Level = data.Level;
+					})
+				end
+				return levels
+			end;
+
+			RankPurchasables = function(p)
+				local purchasables = {}
+
+				if server.Settings.DonorCommands then
+					table.insert(purchasables, {
+						Rank = "Donor";
+						Type = Enum.InfoType.Asset;
+						Id = 6878510605;
+					})
+				end
+
+				for name, data in server.Settings.Ranks do
+					for _, user in data.Users do
+						if typeof(user) ~= "string" then continue end
+
+						local id, idType
+
+						if string.sub(user, 1, 5) == "Item:" then
+							id = tonumber(string.sub(user, 6))
+							idType = Enum.InfoType.Asset
+						elseif string.sub(user, 1, 9) == "GamePass:" then
+							id = tonumber(string.sub(user, 10))
+							idType = Enum.InfoType.GamePass
+						elseif string.sub(user, 1, 13) == "Subscription:" then
+							id = tonumber(string.sub(user, 14))
+							idType = Enum.InfoType.Subscription
+						else
+							continue
+						end
+
+						local info = if idType == Enum.InfoType.Subscription then service.GetSubscriptionInfo(id) else service.GetProductInfo(id, idType)
+						if not info or not info.Created then continue end
+						if not info.IsForSale then continue end
+						if idType == Enum.InfoType.GamePass and (not info.CanBeSoldInThisGame) then continue end
+
+						table.insert(purchasables, {
+							Rank = name;
+							Id = id;
+							Type = idType;
+						})
+					end
+				end
+
+				return purchasables
+			end;
 		};
 
 		Terminal = {

--- a/MainModule/Server/Core/Remote.luau
+++ b/MainModule/Server/Core/Remote.luau
@@ -551,29 +551,20 @@ return function(Vargs, GetEnv)
 				end
 			end;
 
-			RankLevels = function(p)
-				local levels = {}
+			CommandListData = function(p)
+				local ranks = {}
+				local commands = {}
+
+				local pDat = {
+					Player = p;
+					Level = Admin.GetLevel(p);
+					isDonor = Admin.CheckDonor(p);
+				}
+
+				local maxDisplayLevel = pDat.Level
+
 				for name, data in Settings.Ranks do
-					table.insert(levels, {
-						Rank = name;
-						Level = data.Level;
-					})
-				end
-				return levels
-			end;
-
-			RankPurchasables = function(p)
-				local purchasables = {}
-
-				if server.Settings.DonorCommands then
-					table.insert(purchasables, {
-						Rank = "Donor";
-						Type = Enum.InfoType.Asset;
-						Id = 6878510605;
-					})
-				end
-
-				for name, data in server.Settings.Ranks do
+					local purchasables = {}
 					for _, user in data.Users do
 						if typeof(user) ~= "string" then continue end
 
@@ -586,26 +577,76 @@ return function(Vargs, GetEnv)
 							id = tonumber(string.sub(user, 10))
 							idType = Enum.InfoType.GamePass
 						elseif string.sub(user, 1, 13) == "Subscription:" then
-							id = tonumber(string.sub(user, 14))
-							idType = Enum.InfoType.Subscription
+							id = string.sub(user, 14)
+							table.insert(purchasables, {
+								Id = id;
+								Type = Enum.InfoType.Subscription;
+							})
+							continue
 						else
 							continue
 						end
 
-						local info = if idType == Enum.InfoType.Subscription then service.GetSubscriptionInfo(id) else service.GetProductInfo(id, idType)
+						local info = service.GetProductInfo(id, idType)
 						if not info or not info.Created then continue end
 						if not info.IsForSale then continue end
-						if idType == Enum.InfoType.GamePass and (not info.CanBeSoldInThisGame) then continue end
+						--if idType == Enum.InfoType.GamePass and (not info.CanBeSoldInThisGame) then continue end
 
 						table.insert(purchasables, {
-							Rank = name;
 							Id = id;
 							Type = idType;
 						})
 					end
+
+					table.insert(ranks, {
+						Rank = name;
+						Level = data.Level;
+						Purchasables = purchasables;
+					})
+
+					if #purchasables > 0 then
+						maxDisplayLevel = math.max(data.Level, maxDisplayLevel)
+					end
 				end
 
-				return purchasables
+				for i = #ranks, 1, -1 do
+					if ranks[i].Level > maxDisplayLevel then
+						table.remove(ranks, i)
+					end
+				end
+
+				table.insert(ranks, {
+					Rank = "Players";
+					Level = 0;
+					Purchasables = {};
+				})
+
+				if Settings.DonorCommands then
+					table.insert(ranks, {
+						Rank = "Donors";
+						Level = "Donors";
+						Purchasables = {
+							{ Type = Enum.InfoType.Asset; Id = 6878510605; }
+						}
+					})
+				end
+
+				for key, command in Commands do
+					local hasPerm, err = Admin.CheckPermission(pDat, command, true)
+					if err then continue end
+
+					if hasPerm == true or (hasPerm == false and ((Settings.DonorCommands and command.Donors) or Admin.CheckComLevel(maxDisplayLevel, command.AdminLevel))) then
+						local newCommand = table.clone(command)
+						newCommand.HasPermission = hasPerm
+						commands[key] = newCommand
+					end
+				end
+
+				return {
+					PlayerData = pDat,
+					Ranks = ranks,
+					Commands = commands
+				}
 			end;
 		};
 

--- a/MainModule/Shared/Service.luau
+++ b/MainModule/Shared/Service.luau
@@ -1050,10 +1050,10 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 			return table.clone(cacheTab.results)
 		end;
 
-		GetSubscriptionInfo = function(subscriptionId: number)
-			subscriptionId = tonumber(subscriptionId) or 0
+		GetSubscriptionInfo = function(subscriptionId: string)
+			if server then error("Cannot get subscription info on server") end
 
-			if subscriptionId <= 0 then return end
+			if not subscriptionId then return end
 
 			local cacheIndex = `{subscriptionId}-{Enum.InfoType.Subscription.Value}`
 			local currentCache = assetInfoCache[cacheIndex]

--- a/MainModule/Shared/Service.luau
+++ b/MainModule/Shared/Service.luau
@@ -1019,38 +1019,65 @@ return function(errorHandler, eventChecker, fenceSpecific, env)
 			return `{num < 0 and "-" or ""}{table.concat(newInt):reverse()}{dec and `.{dec}` or ""}`
 		end;
 
-		GetProductInfo = function(assetId, infoType)
+		GetProductInfo = function(assetId: number, infoType: Enum.InfoType?)
 			assetId = tonumber(assetId) or 0
 			infoType = infoType or Enum.InfoType.Asset
 
-			if assetId > 0 then
-				local cache = assetInfoCache[`{assetId}-{infoType}`]
+			if assetId <= 0 then return end
 
-				if not cache then
-					cache = {
-						results = {
-							Created = false;
-						};
-						lastUpdated = -math.huge;
-					}
-					assetInfoCache[`{assetId}-{infoType}`] = cache
-				end
+			local cacheIndex = `{assetId}-{infoType.Value}`
+			local currentCache = assetInfoCache[cacheIndex]
 
-				local canUpdateCache = not cache.lastUpdated or os.clock()-cache.lastUpdated > 120
-
-				if canUpdateCache then
-					local suc,info = pcall(service.MarketplaceService.GetProductInfo, service.MarketplaceService, assetId, infoType)
-
-					if suc and type(info) == "table" then
-						info.Created = true
-						cache.results = info
-					else
-						cache.results.Created = false
-					end
-				end
-
-				return table.clone(cache.results)
+			if currentCache and os.clock() - currentCache.lastUpdated < 120 then 
+				return table.clone(assetInfoCache[cacheIndex].results)
 			end
+
+			local cacheTab = {
+				results = {
+					Created = false;
+				};
+				lastUpdated = os.clock();
+			}
+
+			local suc, info = pcall(service.MarketplaceService.GetProductInfo, service.MarketplaceService, assetId, infoType)
+
+			if suc and type(info) == "table" then
+				info.Created = true
+				cacheTab.results = info
+				assetInfoCache[cacheIndex] = cacheTab
+			end
+
+			return table.clone(cacheTab.results)
+		end;
+
+		GetSubscriptionInfo = function(subscriptionId: number)
+			subscriptionId = tonumber(subscriptionId) or 0
+
+			if subscriptionId <= 0 then return end
+
+			local cacheIndex = `{subscriptionId}-{Enum.InfoType.Subscription.Value}`
+			local currentCache = assetInfoCache[cacheIndex]
+
+			if currentCache and os.clock() - currentCache.lastUpdated < 120 then 
+				return table.clone(assetInfoCache[cacheIndex].results)
+			end
+
+			local cacheTab = {
+				results = {
+					Created = false;
+				};
+				lastUpdated = os.clock();
+			}
+
+			local suc, info = pcall(service.MarketplaceService.GetSubscriptionProductInfoAsync, service.MarketplaceService, subscriptionId)
+
+			if suc and type(info) == "table" then
+				info.Created = true
+				cacheTab.results = info
+				assetInfoCache[cacheIndex] = cacheTab
+			end
+
+			return table.clone(cacheTab.results)
 		end;
 
 		CheckPassOwnership = function(userId, gamepassId)


### PR DESCRIPTION
Brand new command list design with some additional features:

- Groups commands by permission level by default (changeable with a dropdown)
- Clicking on commands shows details rather than hovering for better mobile support and readability
- If a game sells admin ranks using GamePass, Item, or Subscriptions in the Ranks settings, it will display the commands for those ranks greyed-out with a purchase button to buy the cheapest item or subscription currently available (also applies for Donor commands if enabled)

Still todo:
- Setting to keep legacy command list
- Save group by dropdown in client settings
- Re-add user aliases

PoF:

https://github.com/user-attachments/assets/c42109a7-86fb-4dac-ab87-8306ddb0cb12


https://github.com/user-attachments/assets/50d9602a-d1c1-4c58-9927-beab25af7f94

