### PR TITLE
QoL Enhancement for !ping

### DIFF
--- a/MainModule/Client/Core/Remote.luau
+++ b/MainModule/Client/Core/Remote.luau
@@ -468,12 +468,11 @@ return function(Vargs, GetEnv)
 		end;
 
 		Ping = function()
-			local t = time()
+			local t = os.clock()
 			local ping = Remote.Get("Ping")
 			if not ping then return false end
-			local t2 = time()
-			local mult = 10^3
-			local ms = ((math.floor((t2-t)*mult+0.5)/mult)*1000)
+			local t2 = os.clock()
+			local ms = math.round( (t2 - t) * 1000 )
 			return ms
 		end;
 

--- a/MainModule/Client/UI/Default/PerfStats.luau
+++ b/MainModule/Client/UI/Default/PerfStats.luau
@@ -6,14 +6,30 @@ return function(data, env)
 	end
 
 	local gfps = true
+	local colorData = {
+		["Bad"] = "#ff3300",
+		["Mid"] = "#ffbf00",
+		["Ok"] = "#00ff5e"
+	}
+
+	function getColorForStat(statValue: number, isPing: boolean)
+		return isPing
+		and (statValue >= 350 and colorData.Bad
+			or statValue >= 125 and colorData.Mid
+			or colorData.Ok)
+		or (statValue <= 25 and colorData.Bad
+			or statValue <= 50 and colorData.Mid
+			or colorData.Ok)
+	end
+
 	local gTable
 
 	local window = client.UI.Make("Window", {
 		Name = "Performance stats",
 		Title = "Stats",
 		Icon = client.MatIcons.Leaderboard,
-		Size = { 150, 90 },
-		Position = UDim2.new(0, 10, 1, -100),
+		Size = { 150, 120 },
+		Position = UDim2.new(0, 10, 1, -130),
 		AllowMultiple = false,
 		NoHide = true,
 		Walls = true,
@@ -30,6 +46,7 @@ return function(data, env)
 			TextSize = 20,
 			Size = UDim2.new(1, 0, 1, 0),
 			Position = UDim2.new(0, 0, 0, 0),
+			RichText = true,
 			--TextScaled = true;
 			--TextWrapped = true;
 		})
@@ -37,12 +54,29 @@ return function(data, env)
 		gTable = window.gTable
 		window:Ready()
 
+		local prevPing = 50
 		repeat
+
+			local fps = 1 / service["RunService"].RenderStepped:Wait()
+			local physicsFps = workspace:GetRealPhysicsFPS()
+			local rawPing = service.Players.LocalPlayer:GetNetworkPing() * 1000
+			local realPing = client.Remote.Ping()
+			local correctPing = realPing
+
+			-- If we somehow get ratelimited, fall back to
+			-- old ping so we dont error out
+			if realPing == false then
+				correctPing = prevPing
+			else
+				prevPing = correctPing
+			end
+
 			label.Text = string.format(
-				"Render: %.1f fps\nPhysics: %.1f fps\nPing: %d ms",
-				1 / service["RunService"].RenderStepped:Wait(),
-				workspace:GetRealPhysicsFPS(),
-				service.Players.LocalPlayer:GetNetworkPing() * 1000
+				`<font color="{getColorForStat(fps)}">Render: %.1f fps</font> \n<font color="{getColorForStat(physicsFps)}">Physics: %.1f fps</font>\n<font color="{getColorForStat(rawPing, true)}">Raw Ping: %d ms</font>\n<font color="{getColorForStat(correctPing, true)}">Real Ping: %d ms</font>`,
+				fps,
+				physicsFps,
+				rawPing,
+				correctPing
 			)
 			task.wait(0.5)
 		until not gfps or not gTable.Active


### PR DESCRIPTION
Added QoL enhancements for !ping:
- Now shows `LocalPlayer:GetNetworkPing()` as "Raw Ping"
- Additionally shows `client.Remote.Ping()` as "Real Ping" *(because `GetNetworkPing()` is just raw, unserialized, unprocessed ping, and has a ~30ms difference between remote function based pinging - in some games up to ~70ms. "Real Ping" more accurately represents the ping felt ingame, and ping spikes aren't always shown by raw ping.)*
- Coloring depending on values
  - For FPS values: `<=25`: red `25-50`: orange `>=50`: green
  - For Ping values: `>=350`: red `125-350`: orange `<=125`: green
- Tweaked `Remote.Ping()` to be more precise, using `os.clock()` and simpler rounding

PoF: https://streamable.com/nwiq9o (Tested with serverside physics and by changing the clientside fps cap)