### PR TITLE
Fix GetFakePlayer UserId comparisson bug by converting UserId to number

### DIFF
--- a/MainModule/Server/Core/Functions.luau
+++ b/MainModule/Server/Core/Functions.luau
@@ -422,6 +422,8 @@ return function(Vargs, GetEnv)
 				data[k] = v
 			end
 
+			data.UserId = tonumber(data.UserId) or 0
+
 			if data.UserId > 0 then
 				local success, actualName = pcall(service.Players.GetNameFromUserIdAsync, service.Players, data.UserId)
 				if success then


### PR DESCRIPTION
Convert UserId to a number to fix "attempt to compare number > string" when creating a fake player from a userid

post change: 
<img width="917" height="650" alt="image" src="https://github.com/user-attachments/assets/5ffcdebb-fa1e-421a-8342-ab8edeebccde" />

pre change: 
<img width="531" height="464" alt="image" src="https://github.com/user-attachments/assets/f5c87480-9737-4059-81cb-b4cb72f3db39" />
