### PR TITLE
Fix typo (line 741)

### DIFF
--- a/MainModule/Server/Server.luau
+++ b/MainModule/Server/Server.luau
@@ -738,7 +738,7 @@ return service.NewProxy({
 			task.defer(xpcall, LoadModule, function(reason)
 				warn(`The plugin {type(module) == "string" and string.sub(module, 1, 15) or module} failed to load! Reason: {reason}`)
 				logError(`The plugin {type(module) == "string" and string.sub(module, 1, 15) or module} failed to load! Reason: {reason}`)
-				table.insert(server.messages, {
+				table.insert(server.Messages, {
 					Title = `The plugin {type(module) == "string" and string.sub(module, 1, 15) or module} failed to load!`,
 					Icon = "maticon://Dangerous",
 					Message = string.match(reason, "Requested module experienced an error while loading") and "The plugin has invalid code or the code fails before return!" or string.match(reason, "Module code did not return exactly one value") and "The plugin returns an invalid amount of values or returns nothing at all!" or `Reason {reason}`,


### PR DESCRIPTION
Fix typo that caused https://github.com/Epix-Incorporated/Adonis/issues/2146

there was a typo where the M in "server.Messages" in line 741 wasn't capitalized, which led to some errors related to plugins not being made visible.
