### PR TITLE
feat: add a user based insert clear command and fix an index shifting bug that skipped items when deleting

### DIFF
--- a/MainModule/Server/Commands/Admins.luau
+++ b/MainModule/Server/Commands/Admins.luau
@@ -641,6 +641,7 @@ return function(Vargs, env)
 
 				local obj: Model? = service.Insert(tonumber(id), true)
 				if obj and plr.Character then
+					obj:SetAttribute("ADONIS_InsertedBy", plr.Name)
 					table.insert(Variables.InsertedObjects, obj)
 					pcall(obj.MakeJoints, obj)
 					obj:PivotTo(plr.Character:GetPivot())

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -2312,7 +2312,22 @@ return function(Vargs, env)
 			Prefix = Settings.Prefix;
 			Commands = {"insclear", "clearinserted", "clrins", "insclr"};
 			Args = {};
-			Description = "Removes inserted objects";
+			Description = "Removes your inserted objects";
+			AdminLevel = "Moderators";
+			Function = function(plr: Player, args: {string})
+				for i, v in Variables.InsertedObjects do
+					if not v:GetAttribute("ADONIS_InsertedBy") or v:GetAttribute("ADONIS_InsertedBy") ~= plr.Name then continue end
+					v:Destroy()
+					table.remove(Variables.InsertedObjects, i)
+				end
+			end
+		};
+
+		InsertClearAll = {
+			Prefix = Settings.Prefix;
+			Commands = {"insclearall", "clearallinserted", "clrallins", "insclrall"};
+			Args = {};
+			Description = "Removes all inserted objects";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
 				for i, v in Variables.InsertedObjects do

--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -2315,10 +2315,15 @@ return function(Vargs, env)
 			Description = "Removes your inserted objects";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in Variables.InsertedObjects do
-					if not v:GetAttribute("ADONIS_InsertedBy") or v:GetAttribute("ADONIS_InsertedBy") ~= plr.Name then continue end
-					v:Destroy()
-					table.remove(Variables.InsertedObjects, i)
+				for i = #Variables.InsertedObjects, 1, -1 do
+					local v = Variables.InsertedObjects[i]
+					
+					if v and v:GetAttribute("ADONIS_InsertedBy") == plr.Name then
+						if v.Parent then 
+							v:Destroy() 
+						end
+						table.remove(Variables.InsertedObjects, i)
+					end
 				end
 			end
 		};
@@ -2330,10 +2335,13 @@ return function(Vargs, env)
 			Description = "Removes all inserted objects";
 			AdminLevel = "Moderators";
 			Function = function(plr: Player, args: {string})
-				for i, v in Variables.InsertedObjects do
-					v:Destroy()
-					table.remove(Variables.InsertedObjects, i)
+				for i = #Variables.InsertedObjects, 1, -1 do
+					local v = Variables.InsertedObjects[i]
+					if v and v.Parent then
+						v:Destroy()
+					end
 				end
+				table.clear(Variables.InsertedObjects) 
 			end
 		};
 


### PR DESCRIPTION
## Description
Fixes a index shifting bug where the `InsertClear` command skipped items while looping and failed to delete everything correctly. Also added ownership tracking to inserted assets, a new command to only clear a user's specific inserts, and changed `insclear` to `insclearall` to clear all inserted entities.

## Changes

* feat: Added an `ADONIS_InsertedBy` attribute to track inserted instances to map ownership back to the inserting player.
* feat: Restricted the default `InsertClear` command to target only the executing player's inserts.
* feat: Added a `InsertClearAll` command to clear all inserts.
* Shifted from `table.remove` calls in `InsertClearAll` and `InsertClear` to a reverse loop style for deletion to avoid index shifting issues during in-place removals, followed by a `table.clear()` for the table's reference.

## Proof of functionality

https://github.com/user-attachments/assets/85edb38e-37bb-43c9-84d9-7db2ab556c13

