### PR TITLE
Fix memory leak from lingering containers

### DIFF
--- a/MainModule/Server/Core/Core.luau
+++ b/MainModule/Server/Core/Core.luau
@@ -480,18 +480,17 @@ return function(Vargs, GetEnv)
 
 						--container:Destroy(); -- Destroy update causes an issue with this pretty sure
 						container.Parent = nil
-						local leaveEvent; leaveEvent = p.AncestryChanged:Connect(function() -- after/on remove, not on removing...
-							task.wait()
-							if p.Parent == nil then
+						local leaveEvent; leaveEvent = p.AncestryChanged:Connect(function(child, parent)
+							if child == p and parent == nil then
 								-- Prevent potential memory leak and ensure this gets properly murdered when they leave and it's no longer needed
-								pcall(function()
-									container:Destroy()
-								end)
+								pcall(container.Destroy, container)
+								container = nil
+
+								leaveEvent:Disconnect()
+								leaveEvent = nil
 							end
 						end)
 
-						leaveEvent:Disconnect()
-						leaveEvent = nil
 						event:Disconnect()
 						event = nil
 					end


### PR DESCRIPTION
Fixes an issue where the change to just parent the ScreenGui to nil then clean-up once the player leaves was not handled properly and instantly disconnected the event.

PoF (leaving with prints to make sure the event actually works...):
<img width="687" height="64" alt="image" src="https://github.com/user-attachments/assets/588ab3f9-1e8a-4754-90e2-c3bf66e8eaf8" />
<img width="388" height="27" alt="image" src="https://github.com/user-attachments/assets/4c6cf98c-1375-42f8-aaac-7d9a509fc31a" />
