### PR TITLE
Fix UI errors while parsing invalid KeyCode settings

### DIFF
--- a/MainModule/Client/Core/Functions.luau
+++ b/MainModule/Client/Core/Functions.luau
@@ -1265,7 +1265,13 @@ return function(Vargs, GetEnv)
 		end;
 
 		KeyCodeToName = function(keyVal)
-			local keyCode = Enum.KeyCode:FromValue(tonumber(keyVal))
+			local keyCode: Enum.KeyCode? = nil
+
+			if typeof(keyVal) == "Enum" then
+				keyCode = Enum.KeyCode:FromName(keyVal.Name)
+			elseif tonumber(keyVal) then
+				keyCode = Enum.KeyCode:FromValue(tonumber(keyVal))
+			end
 
 			if keyCode then
 				local name = service.UserInputService:GetStringForKeyCode(keyCode)

--- a/MainModule/Client/UI/Default/Settings.luau
+++ b/MainModule/Client/UI/Default/Settings.luau
@@ -109,7 +109,7 @@ return function(data, env)
 			Text = "Console Key: ";
 			Desc = "Key used to open the console";
 			Entry = "Button";
-			Value = Functions.KeyCodeToName(Enum.KeyCode[Variables.CustomConsoleKey or Remote.Get("Setting","ConsoleKeyCode") or "Unknown"].Value);
+			Value = Functions.KeyCodeToName(Enum.KeyCode:FromName(Variables.CustomConsoleKey or Remote.Get("Setting","ConsoleKeyCode") or "None"));
 			Function = function(toggle)
 				local gotKey, visualName
 				toggle.Text = "Waiting..."

--- a/MainModule/Client/UI/Default/UserPanel.luau
+++ b/MainModule/Client/UI/Default/UserPanel.luau
@@ -394,7 +394,7 @@ return function(data, env)
 		})
 
 		-- Disable settings tab until permissions are checked
-		gameTab:Disable() 
+		gameTab:Disable()
 
 		if data.Tab then
 			local Tab = string.lower(data.Tab)
@@ -848,7 +848,7 @@ return function(data, env)
 				Position = UDim2.new(1, -140, 0, 105);
 				BackgroundTransparency = 1;
 			})
-			
+
 			dFrame:Add("TextLabel", {
 				Text = "Donate (Perks)";
 				TextXAlignment = "Center";
@@ -1567,7 +1567,7 @@ return function(data, env)
 					Text = "Console Key: ";
 					Desc = "- Key used to open the console";
 					Entry = "Keybind";
-					Value = Functions.KeyCodeToName(Enum.KeyCode[Variables.CustomConsoleKey or Remote.Get("Setting","ConsoleKeyCode") or "Unknown"].Value);
+					Value = Functions.KeyCodeToName(Enum.KeyCode:FromName(Variables.CustomConsoleKey or Remote.Get("Setting","ConsoleKeyCode") or "None"));
 					Function = function(toggle)
 						service.Debounce("CliSettingKeybinder", function()
 							local gotKey, visualName


### PR DESCRIPTION
The ConsoleKeyCode setting isn't correctly validated due to the flawed way of accessing the `Enum.KeyCode` by directly accessing the value in the Enum.KeyCode list instead of using proper ways like Enum.KeyCode:FromName().

If the ConsoleKeyCode is set to an empty or invalid value, trying to access the Client settings will cause an error in the fetching process, since unlike `Enum.KeyCode:FromName(value)` which returns nil for invalid values, passing an invalid value in `Enum.KeyCode[value]` will always throw an error.

With this PR, the keycode validation now properly handles invalid values and returns nil (aka. `UNKNOWN`) in case of an improperly set ConsoleKeyCode setting.

# Proof-of-functionality

Before this PR, UI errors while accessing the Client settings:

<img width="674" height="456" alt="Screenshot_20260816_131432" src="https://github.com/user-attachments/assets/2ad934b8-fab1-4707-a1d8-b93946d212ae" />

After this PR, the invalid KeyCode now properly falls back to `UNKNOWN` which can be properly set by players:

<img width="600" height="350" alt="Screenshot_20260816_131740" src="https://github.com/user-attachments/assets/cd85e303-d50d-4468-bf88-50ab8eab53d9" />

# FAQ
- Q: Why you don't warn high rank users if the ConsoleKeyCode is set invalid?
A: That's not the scope of this PR and should be done in separate PR.

- Q: Why you don't just change KeyCodeToName to accept direct enums instead of numeric enum values? It should've been called "KeyCodeValueToName" instead!
A: Compatibility reasons. Pre-existing plugins or changes could break, so I decided to tweak the function to accept both direct enums and numeric enum values.

- Q: Why you don't just assign the keyCode variable directly if the passed argument is a valid Enum?
A: To ensure that the passed enum is really a valid KeyCode enum. You never know if something passed an argument like `Enum.SomethingElse.Quote`, which does carry a value name listed in KeyCode, but it's still not an `Enum.KeyCode`.