### PR TITLE
Revise MailVerified & IsVerified and add AdsAllowed to the player profile info

### DIFF
--- a/MainModule/Client/UI/Default/Profile.luau
+++ b/MainModule/Client/UI/Default/Profile.luau
@@ -112,8 +112,9 @@ return function(data, env)
 		for i, v in ipairs({
 			{"Membership", data.MembershipStatus or "None", "The player's Roblox membership type. (Plus/Premium)"},
 			{"Can Chat", data.CanChatGet[1] and boolToStr(data.CanChatGet[2]) or "[Error]", "Does the player's account settings allow them to chat?"},
+			{"Ads Allowed", data.AdsAllowed, "[Admins Only] Does the player have permission to view advertisements?"},
 			{"Mail Verified", data.MailVerified, "[Admins Only] Does the player have verified their mail?"},
-			{"Phone/ID Verified", data.IDVerified, "[Admins Only] Does the player have verified their non-VoIP phone / ID?"},
+			{"Verification Level", data.VerificationLevel, "[Admins Only] Does the player have a verification status?"},
 			}) do
 			generaltab:Add("TextLabel", {
 				Text = `  {v[1]}: `;

--- a/MainModule/Server/Commands/Players.luau
+++ b/MainModule/Server/Commands/Players.luau
@@ -787,23 +787,34 @@ return function(Vargs, env)
 								end
 							end
 						end
-						
-						local mailVerif = select(2, xpcall(service.MarketplaceService.PlayerOwnsAsset, function() return "[Error]" end, service.MarketplaceService, v, 102611803))
-						local hasVerifiedMail = if elevated then
-							type(mailVerif) == "string" and mailVerif or mailVerif and "Yes" or "No"
+
+						local policyInfo = elevated and select(2, xpcall(service.PolicyService.GetPolicyInfoForPlayerAsync, function() return "[Error]" end, service.PolicyService, v))
+						local hasAdsAllowed = if policyInfo then
+							type(policyInfo) == "string" and policyInfo or policyInfo.AreAdsAllowed and "Yes" or "No"
 							else "[Redacted]"
 
-						local idVerif = select(2, xpcall(v.IsVerified, function() return "[Error]" end, v))
-						local hasVerifiedId = if elevated then
-							type(idVerif) == "string" and idVerif or idVerif and "Yes" or "No"
+						local hasMailAccessory = select(2, xpcall(service.MarketplaceService.PlayerOwnsAsset, function() return "[Error]" end, service.MarketplaceService, v, 102611803))
+							or v.UserId < 50000000 and select(2, xpcall(service.MarketplaceService.PlayerOwnsAsset, function() return "[Error]" end, service.MarketplaceService, v, 1567446))
+
+						local hasVerifiedMail = if elevated then
+							type(hasMailAccessory) == "string" and hasMailAccessory or hasMailAccessory and "Yes" or "No"
+							else "[Redacted]"
+
+						local verifLevelLow = select(2, xpcall(v.IsVerified, function() return "[Error]" end, v, Enum.VerifiedLevel.Low))
+						local verifLevelHigh = select(2, xpcall(v.IsVerified, function() return "[Error]" end, v, Enum.VerifiedLevel.High))
+
+						local determinedVerifLevel = if elevated then
+							(type(verifLevelHigh) == "string" and verifLevelHigh or verifLevelHigh and "High")
+							or (type(verifLevelLow) == "string" and verifLevelLow or verifLevelLow and "Low") or "None"
 							else "[Redacted]"
 
 						Remote.RemoveGui(plr, `Profile_{v.UserId}`)
 						Remote.MakeGui(plr, "Profile", {
 							Target = v;
-							CanChatGet = table.pack(pcall(service.Chat.CanUserChatAsync, service.Chat, v.UserId));
+							AdsAllowed = hasAdsAllowed;
+							CanChatGet = table.pack(pcall(service.TextChatService.CanUserChatAsync, service.TextChatService, v.UserId));
 							MailVerified = hasVerifiedMail;
-							IDVerified = hasVerifiedId;
+							VerificationLevel = determinedVerifLevel;
 							IsDonor = Admin.CheckDonor(v);
 							GameData = gameData;
 							IsServerOwner = v.UserId == game.PrivateServerOwnerId;


### PR DESCRIPTION
This PR now changes the IsVerified logic since Roblox has just released an update to the Player:IsVerified() API, which allows fetching different verification levels between Low (the new default) and High: https://devforum.roblox.com/t/full-release-isverified-api-now-supports-verification-levels/4820514

The (legacy?) MailVerified info is revised to also check for the pre-2013 Verified sign if the User ID is below `50000000`, since the cutoff between the old sign and the new bonafide hat is somewhere between early to mid 2013.

In addition, the AreAdsAllowed policy information is now added in case the admin wants to confirm if the player's country, DoB, and other informations allow the player to view advertisements on the platform, which is useful in certain scenarios (e.g. a player complains that they can't view ads and the admin wants to check if the player is allowed to view ads in the first place).

# Proof-of-functionality

Sourced randomly from a tower obby game, cherry picked for replicating the possible situations related to the changes.

<img width="1207" height="408" alt="Screenshot_20260821_004410" src="https://github.com/user-attachments/assets/1ab97d75-ab2c-4094-b4d6-b6424db674b4" />