### PR TITLE
Fix flight changing once you end sentence with E on textchatservice

### DIFF
--- a/MainModule/Server/Dependencies/Assets/Fly.client.luau
+++ b/MainModule/Server/Dependencies/Assets/Fly.client.luau
@@ -180,7 +180,7 @@ function HandleInput(input, isGame, bool)
 				dir.Down = bool
 			elseif input.KeyCode == Enum.KeyCode.Space or input.KeyCode == Enum.KeyCode.DPadUp then
 				dir.Up = bool
-			elseif input.KeyCode == Enum.KeyCode.E or input.KeyCode == Enum.KeyCode.ButtonL3 then
+			elseif bool and input.KeyCode == Enum.KeyCode.E or input.KeyCode == Enum.KeyCode.ButtonL3 then
 				Toggle()
 			end
 		end


### PR DESCRIPTION
https://github.com/Epix-Incorporated/Adonis/issues/2168
> it being a keybind that activates when you end a sentence with "E" in the chat for some reason. This issue has been persistent for a while, 


I was able to reproduce this issue and its as simple as just not listening to InputEnded and only change the flight mode on InputBegan event

edit: so basically hold E while typing keep holding E even after sending your message and then once you sent the message on roblox chat stop holding E and boom bug reproduced