### PR TITLE
Allow admins command to show table entries (Group)

### DIFF
--- a/MainModule/Server/Commands/Moderators.luau
+++ b/MainModule/Server/Commands/Moderators.luau
@@ -1966,7 +1966,7 @@ return function(Vargs, env)
 				table.insert(temptable, "<b><font color='rgb(180, 60, 0)'>All Admins:</font></b>")
 
 				for rank, data in Settings.Ranks do
-					if not data.Hidden then
+					if type(rank) == "string" and type(data) == "table" and tonumber(data.Level) and not data.Hidden then
 						table.insert(unsorted, {
 							Text = string.format(RANK_RICHTEXT, rank, data.Level);
 							Desc = "";
@@ -1993,6 +1993,11 @@ return function(Vargs, env)
 					table.insert(temptable, v)
 
 					for _, user in Users do
+						--// { Group: number, Rank: number }
+						if type(user) == "table" then
+							user = `Group:{user.Group}:{user.Rank} [table]`
+						end
+
 						table.insert(temptable, {
 							Text = `  {user}`;
 							Desc = string.format(RANK_DESCRIPTION_FORMAT, Rank, Level);


### PR DESCRIPTION
Allow Group entries that are tables instead of the string equivalent (Group:1234:-43) to be shown instead of just the table reference.

Also fix command breaking if someone accidentally adds an array or invalid level to the rank definition.

PoF:
<img width="679" height="189" alt="image" src="https://github.com/user-attachments/assets/b1874e44-7e51-470d-83cc-a2c96360990e" />
<img width="304" height="61" alt="image" src="https://github.com/user-attachments/assets/67d767f1-6dda-4e8c-beae-2e8bf8d26793" />

